### PR TITLE
feat: SignUp 4단계 회원가입 플로우 구현

### DIFF
--- a/HiTrip/App/HiTrip-Bridging-Header.h
+++ b/HiTrip/App/HiTrip-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  HiTrip-Bridging-Header.h
+//  HiTrip
+//
+//  Objective-C Bridging Header
+//  Swift에서 Objective-C 코드를 사용하기 위한 브릿지 파일
+//  현재는 비어있지만, Xcode 빌드 설정에서 참조하고 있어 필요합니다.
+//
+

--- a/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
+++ b/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
@@ -1,1 +1,261 @@
 import Foundation
+import RxSwift
+import RxCocoa
+
+// MARK: - SignUpViewModel
+/// 회원가입 4단계 플로우 관리 ViewModel
+///
+/// 회원가입 단계:
+/// ```
+/// Step 1: 닉네임 설정 → 중복 확인 API
+/// Step 2: 약관 동의 → 필수 약관 체크
+/// Step 3: 아이디 설정 → 길이 검증
+/// Step 4: 비밀번호 설정 → 일치 검증 → 회원가입 API
+///       → 완료 화면
+/// ```
+///
+/// 설계 포인트:
+/// - 각 단계의 입력값을 @Published로 관리
+/// - currentStep으로 단계 전환 (SwiftUI 애니메이션 연동)
+/// - 뒤로가기 시 이전 단계로 복귀 (입력값 유지)
+///
+/// 면접 포인트:
+/// "멀티스텝 폼을 어떻게 관리하셨나요?"
+/// → "하나의 ViewModel에서 모든 단계의 상태를 관리합니다.
+///    각 단계는 enum Step으로 구분하고, @Published currentStep을
+///    변경하면 SwiftUI가 자동으로 해당 단계 View를 렌더링합니다.
+///    뒤로가기 시 입력값이 사라지지 않도록 ViewModel이 데이터를 보존합니다."
+
+final class SignUpViewModel: ObservableObject {
+
+    // MARK: - Step 정의
+
+    /// 회원가입 단계 enum
+    /// - CaseIterable: 전체 단계 수 계산용 (프로그레스 바)
+    /// - Equatable: SwiftUI .animation에서 값 변화 감지용
+    enum Step: Int, CaseIterable, Equatable {
+        case nickname = 0   // 닉네임 설정
+        case terms = 1      // 약관 동의
+        case userId = 2     // 아이디 설정
+        case password = 3   // 비밀번호 설정
+        case complete = 4   // 가입 완료
+
+        /// 프로그레스 바 진행률 (0.0 ~ 1.0)
+        /// complete 단계는 1.0 (100%)
+        var progress: Double {
+            if self == .complete { return 1.0 }
+            return Double(rawValue) / Double(Step.allCases.count - 1)
+        }
+
+        /// 각 단계의 타이틀 (네비게이션 바에 표시)
+        var title: String {
+            switch self {
+            case .nickname: return "닉네임 설정"
+            case .terms:    return "약관 동의"
+            case .userId:   return "아이디 설정"
+            case .password: return "비밀번호 설정"
+            case .complete: return "가입 완료"
+            }
+        }
+    }
+
+    // MARK: - Flow State (단계 관리)
+
+    /// 현재 단계 — View에서 이 값을 관찰하여 화면 전환
+    @Published var currentStep: Step = .nickname
+
+    // MARK: - Step 1: 닉네임
+
+    @Published var nickname: String = ""
+    /// 닉네임 중복 확인 완료 여부
+    /// - true: 서버에서 사용 가능 확인됨 → "다음" 버튼 활성화
+    /// - false: 아직 확인 안 됨 또는 중복
+    @Published var isNicknameChecked: Bool = false
+    /// 닉네임 상태 메시지 ("사용 가능한 닉네임입니다" 등)
+    @Published var nicknameMessage: String?
+    /// 닉네임이 사용 가능한지 여부 (메시지 색상 결정용)
+    @Published var isNicknameAvailable: Bool = false
+
+    // MARK: - Step 2: 약관 동의
+
+    /// 전체 동의 토글
+    @Published var agreeAll: Bool = false
+    /// [필수] 서비스 이용약관
+    @Published var agreeService: Bool = false
+    /// [필수] 개인정보 수집 및 이용
+    @Published var agreePrivacy: Bool = false
+    /// [선택] 마케팅 정보 수신
+    @Published var agreeMarketing: Bool = false
+
+    // MARK: - Step 3: 아이디
+
+    @Published var userId: String = ""
+
+    // MARK: - Step 4: 비밀번호
+
+    @Published var password: String = ""
+    @Published var passwordConfirm: String = ""
+
+    // MARK: - Common State (공통 UI 상태)
+
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var signUpCompleted: Bool = false
+
+    // MARK: - Dependencies
+
+    private let signUpUseCase: SignUpUseCase
+    private let disposeBag = DisposeBag()
+
+    init(signUpUseCase: SignUpUseCase) {
+        self.signUpUseCase = signUpUseCase
+    }
+
+    // MARK: - Step Navigation (단계 이동)
+
+    /// 다음 단계로 이동
+    /// - complete 단계에서는 더 이상 진행하지 않음
+    func goToNextStep() {
+        guard let nextRaw = Step(rawValue: currentStep.rawValue + 1) else { return }
+        errorMessage = nil
+        currentStep = nextRaw
+    }
+
+    /// 이전 단계로 이동
+    /// - nickname(첫 단계)에서는 더 이상 뒤로가지 않음
+    /// - 에러 메시지 초기화
+    func goToPreviousStep() {
+        guard let prevRaw = Step(rawValue: currentStep.rawValue - 1) else { return }
+        errorMessage = nil
+        currentStep = prevRaw
+    }
+
+    // MARK: - Step 1: 닉네임 중복 확인
+
+    /// 닉네임 변경 시 확인 상태 초기화
+    /// - 사용자가 닉네임을 수정하면 이전 확인 결과 무효화
+    /// - View의 .onChange(of: nickname)에서 호출
+    func resetNicknameCheck() {
+        isNicknameChecked = false
+        isNicknameAvailable = false
+        nicknameMessage = nil
+    }
+
+    /// 닉네임 중복 확인 API 호출
+    ///
+    /// 동작 흐름:
+    /// 1. UseCase.checkNickname() → 입력 검증 + API 호출
+    /// 2. 성공 → isAvailable 확인 → 메시지 표시
+    /// 3. 실패 → 에러 메시지 표시
+    func checkNickname() {
+        isLoading = true
+        errorMessage = nil
+
+        signUpUseCase.checkNickname(nickname)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] response in
+                    self?.isLoading = false
+                    self?.isNicknameChecked = true
+                    self?.isNicknameAvailable = response.isAvailable
+
+                    if response.isAvailable {
+                        self?.nicknameMessage = "사용 가능한 닉네임입니다."
+                    } else {
+                        self?.nicknameMessage = "이미 사용 중인 닉네임입니다."
+                    }
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.isNicknameChecked = false
+                    self?.isNicknameAvailable = false
+                    self?.nicknameMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Step 2: 약관 동의 로직
+
+    /// "전체 동의" 토글 시 호출
+    /// - true: 모든 약관 체크
+    /// - false: 모든 약관 해제
+    func toggleAgreeAll() {
+        agreeAll.toggle()
+        agreeService = agreeAll
+        agreePrivacy = agreeAll
+        agreeMarketing = agreeAll
+    }
+
+    /// 개별 약관 토글 시 호출
+    /// - 모든 개별 약관이 체크되면 agreeAll도 자동으로 true
+    /// - 하나라도 해제되면 agreeAll은 false
+    func updateAgreeAll() {
+        agreeAll = agreeService && agreePrivacy && agreeMarketing
+    }
+
+    /// 필수 약관이 모두 동의되었는지 확인
+    /// - 서비스 이용약관 + 개인정보 수집 = 필수
+    /// - 마케팅은 선택이므로 체크하지 않아도 통과
+    var isRequiredTermsAgreed: Bool {
+        agreeService && agreePrivacy
+    }
+
+    // MARK: - Step 3: 아이디 유효성
+
+    /// 아이디 유효성 검사
+    /// - 비어있지 않고, 4자 이상이면 유효
+    var isUserIdValid: Bool {
+        !userId.trimmed.isEmpty && userId.trimmed.count >= 4
+    }
+
+    // MARK: - Step 4: 비밀번호 유효성
+
+    /// 비밀번호 유효성 (6자 이상)
+    var isPasswordValid: Bool {
+        password.count >= 6
+    }
+
+    /// 비밀번호 확인 일치 여부
+    var isPasswordMatch: Bool {
+        !passwordConfirm.isEmpty && password == passwordConfirm
+    }
+
+    /// 비밀번호 단계 전체 유효성
+    var isPasswordStepValid: Bool {
+        isPasswordValid && isPasswordMatch
+    }
+
+    // MARK: - 회원가입 실행
+
+    /// 최종 회원가입 API 호출
+    ///
+    /// 동작 흐름:
+    /// 1. SignUpUseCase.execute() → 전체 입력값 검증 + API 호출
+    /// 2. 성공 → signUpCompleted = true → complete 단계로 이동
+    /// 3. 실패 → errorMessage 표시 (현재 단계 유지)
+    func signUp() {
+        isLoading = true
+        errorMessage = nil
+
+        signUpUseCase.execute(
+            nickname: nickname,
+            userId: userId,
+            password: password,
+            passwordConfirm: passwordConfirm
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] _ in
+                self?.isLoading = false
+                self?.signUpCompleted = true
+                self?.currentStep = .complete
+            },
+            onFailure: { [weak self] error in
+                self?.isLoading = false
+                self?.errorMessage = error.localizedDescription
+            }
+        )
+        .disposed(by: disposeBag)
+    }
+}

--- a/HiTrip/Features/Auth/Views/LoginView.swift
+++ b/HiTrip/Features/Auth/Views/LoginView.swift
@@ -53,7 +53,7 @@ struct LoginView: View {
             }
         }
         // 로그인 성공 시 홈 화면으로 전환
-        .onChange(of: viewModel.loginSuccess) { _, success in
+        .onChange(of: viewModel.loginSuccess) { success in
             if success { router.navigateToHome() }
         }
     }

--- a/HiTrip/Features/Auth/Views/SignUpCompleteView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpCompleteView.swift
@@ -1,1 +1,100 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpCompleteView
+/// 회원가입 완료 화면
+///
+/// UI 구성:
+/// - 체크마크 아이콘 (스케일 애니메이션)
+/// - "가입이 완료되었습니다!" 메시지
+/// - 닉네임 표시 ("OOO님, 환영합니다!")
+/// - "로그인하러 가기" 버튼 → 로그인 화면으로 이동
+///
+/// 이 화면에서는 네비게이션 바와 프로그레스 바가 숨겨짐
+/// (SignUpFlowView에서 .complete 단계일 때 숨김 처리)
+
+struct SignUpCompleteView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+    @EnvironmentObject var router: AppRouter
+
+    /// 체크마크 등장 애니메이션 상태
+    @State private var showCheckmark = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // 체크마크 아이콘
+            checkmarkIcon
+                .padding(.bottom, 24)
+
+            // 완료 메시지
+            completionMessage
+                .padding(.bottom, 8)
+
+            // 환영 메시지
+            welcomeMessage
+
+            Spacer()
+
+            // 로그인하러 가기 버튼
+            loginButton
+                .padding(.bottom, 40)
+        }
+        .padding(.horizontal, 24)
+        .onAppear {
+            // 화면 등장 시 체크마크 애니메이션 실행
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.6).delay(0.2)) {
+                showCheckmark = true
+            }
+        }
+    }
+
+    // MARK: - Checkmark Icon
+
+    /// 파란 원 안에 체크마크
+    /// - onAppear 시 스케일 0 → 1 스프링 애니메이션
+    private var checkmarkIcon: some View {
+        Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 80))
+            .foregroundColor(HiTripColor.primary800)
+            .scaleEffect(showCheckmark ? 1.0 : 0.0)
+    }
+
+    // MARK: - Completion Message
+
+    private var completionMessage: some View {
+        Text("가입이 완료되었습니다!")
+            .font(.system(size: 24, weight: .bold))
+            .foregroundColor(HiTripColor.textBlack)
+    }
+
+    // MARK: - Welcome Message
+
+    /// 닉네임을 포함한 환영 메시지
+    private var welcomeMessage: some View {
+        Text("\(viewModel.nickname)님, 환영합니다!")
+            .font(.system(size: 16))
+            .foregroundColor(HiTripColor.gray500)
+    }
+
+    // MARK: - Login Button
+
+    /// "로그인하러 가기" 버튼
+    /// - 탭 시 AppRouter를 통해 로그인 화면으로 이동
+    /// - 회원가입 완료 후 자동 로그인이 아닌, 수동 로그인 유도
+    ///   (보안 관점: 사용자가 직접 입력하여 로그인 확인)
+    private var loginButton: some View {
+        Button {
+            router.navigateToLogin()
+        } label: {
+            Text("로그인하러 가기")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(HiTripColor.buttonPrimary)
+                .cornerRadius(10)
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/SignUpFlowView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpFlowView.swift
@@ -1,1 +1,148 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpFlowView
+/// 회원가입 전체 플로우 컨테이너 View
+///
+/// 역할:
+/// - 상단 네비게이션 바 (뒤로가기 + 단계 타이틀)
+/// - 프로그레스 바 (현재 진행률 시각화)
+/// - ViewModel.currentStep에 따라 해당 단계 View 렌더링
+///
+/// 구조:
+/// ```
+/// SignUpFlowView (컨테이너)
+///   ├─ 뒤로가기 버튼 + 타이틀
+///   ├─ 프로그레스 바
+///   └─ switch currentStep
+///       ├─ .nickname → SignUpNicknameView
+///       ├─ .terms    → SignUpTermsView
+///       ├─ .userId   → SignUpUserIdView
+///       ├─ .password → SignUpPasswordView
+///       └─ .complete → SignUpCompleteView
+/// ```
+///
+/// 면접 포인트:
+/// "컨테이너 패턴을 왜 사용했나요?"
+/// → "각 단계 View가 독립적으로 UI만 담당하고,
+///    네비게이션/프로그레스 같은 공통 요소는 컨테이너에서 한 번만 구현합니다.
+///    이렇게 하면 단계를 추가/제거할 때 개별 View를 수정할 필요가 없습니다."
+
+struct SignUpFlowView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+    @EnvironmentObject var router: AppRouter
+
+    var body: some View {
+        ZStack {
+            // 배경색
+            HiTripColor.screenBackground
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // 네비게이션 바 (완료 화면에서는 숨김)
+                if viewModel.currentStep != .complete {
+                    navigationBar
+                    progressBar
+                }
+
+                // 단계별 View 렌더링
+                stepContent
+                    .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+            }
+
+            // 로딩 오버레이
+            if viewModel.isLoading {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .overlay(ProgressView().tint(.white))
+            }
+        }
+    }
+
+    // MARK: - Navigation Bar
+
+    /// 커스텀 네비게이션 바
+    /// - 첫 단계(닉네임): 뒤로가기 → 로그인 화면으로 돌아감
+    /// - 이후 단계: 뒤로가기 → 이전 단계로 이동
+    private var navigationBar: some View {
+        HStack {
+            Button {
+                if viewModel.currentStep == .nickname {
+                    // 첫 단계에서 뒤로가기 = 회원가입 취소 → 로그인으로
+                    router.navigateToLogin()
+                } else {
+                    viewModel.goToPreviousStep()
+                }
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(HiTripColor.textBlack)
+            }
+
+            Spacer()
+
+            Text(viewModel.currentStep.title)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Spacer()
+
+            // 오른쪽 여백 맞추기용 투명 요소
+            Image(systemName: "chevron.left")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(.clear)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Progress Bar
+
+    /// 진행률 표시 바
+    /// - 전체 너비 대비 현재 단계 비율만큼 채움
+    /// - 애니메이션으로 부드럽게 진행
+    private var progressBar: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                // 배경 바
+                Rectangle()
+                    .fill(HiTripColor.gray200)
+                    .frame(height: 4)
+
+                // 진행 바
+                Rectangle()
+                    .fill(HiTripColor.primary800)
+                    .frame(
+                        width: geometry.size.width * viewModel.currentStep.progress,
+                        height: 4
+                    )
+                    .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+            }
+        }
+        .frame(height: 4)
+    }
+
+    // MARK: - Step Content
+
+    /// ViewModel.currentStep에 따라 해당 단계 View 렌더링
+    /// - @ViewBuilder: 여러 View 중 하나를 조건부로 반환
+    @ViewBuilder
+    private var stepContent: some View {
+        switch viewModel.currentStep {
+        case .nickname:
+            SignUpNicknameView(viewModel: viewModel)
+
+        case .terms:
+            SignUpTermsView(viewModel: viewModel)
+
+        case .userId:
+            SignUpUserIdView(viewModel: viewModel)
+
+        case .password:
+            SignUpPasswordView(viewModel: viewModel)
+
+        case .complete:
+            SignUpCompleteView(viewModel: viewModel)
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
@@ -1,1 +1,161 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpNicknameView
+/// 회원가입 Step 1: 닉네임 설정
+///
+/// UI 구성:
+/// - 안내 텍스트 ("Hi Trip에서 사용할 닉네임을 입력해 주세요")
+/// - 닉네임 입력 필드 + 중복확인 버튼
+/// - 중복 확인 결과 메시지 (사용 가능/불가)
+/// - "다음" 버튼 (중복 확인 완료 시 활성화)
+///
+/// 동작:
+/// 1. 닉네임 2자 이상 입력 → "중복확인" 버튼 활성화
+/// 2. 중복확인 탭 → API 호출 → 결과 메시지 표시
+/// 3. 닉네임 수정 → 확인 상태 초기화 (다시 확인 필요)
+/// 4. 사용 가능 확인 완료 → "다음" 버튼 활성화 → Step 2로
+
+struct SignUpNicknameView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 안내 텍스트
+            guideSection
+                .padding(.top, 32)
+
+            // 닉네임 입력 + 중복확인 버튼
+            nicknameInputSection
+                .padding(.top, 28)
+
+            // 확인 결과 메시지
+            messageSection
+                .padding(.top, 8)
+
+            Spacer()
+
+            // 다음 버튼
+            nextButton
+                .padding(.bottom, 40)
+        }
+        .padding(.horizontal, 24)
+        // 닉네임 변경 시 확인 상태 초기화
+        .onChange(of: viewModel.nickname) { _, _ in
+            viewModel.resetNicknameCheck()
+        }
+    }
+
+    // MARK: - Guide Section
+
+    private var guideSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("닉네임 설정")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("Hi Trip에서 사용할 닉네임을 입력해 주세요.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - Nickname Input
+
+    /// 닉네임 입력 필드 + 중복확인 버튼을 나란히 배치
+    /// - HStack으로 입력필드(유연 너비) + 버튼(고정 너비)
+    private var nicknameInputSection: some View {
+        HStack(spacing: 10) {
+            TextField("닉네임 입력 (2자 이상)", text: $viewModel.nickname)
+                .padding(14)
+                .background(HiTripColor.inputBackground)
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(nicknameBorderColor, lineWidth: 1)
+                )
+                .focused($isFocused)
+                .submitLabel(.done)
+                .onSubmit { isFocused = false }
+
+            // 중복확인 버튼
+            Button {
+                isFocused = false
+                viewModel.checkNickname()
+            } label: {
+                Text("중복확인")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .background(
+                        isCheckButtonEnabled
+                            ? HiTripColor.primary800
+                            : HiTripColor.buttonDisabled
+                    )
+                    .cornerRadius(10)
+            }
+            .disabled(!isCheckButtonEnabled)
+        }
+    }
+
+    // MARK: - Message Section
+
+    /// 닉네임 확인 결과 메시지
+    /// - 사용 가능: 초록색
+    /// - 사용 불가/에러: 빨간색
+    private var messageSection: some View {
+        Group {
+            if let message = viewModel.nicknameMessage {
+                Text(message)
+                    .font(.system(size: 13))
+                    .foregroundColor(
+                        viewModel.isNicknameAvailable
+                            ? HiTripColor.readCheck
+                            : HiTripColor.error
+                    )
+            }
+        }
+        .frame(height: 20, alignment: .leading)
+    }
+
+    // MARK: - Next Button
+
+    /// "다음" 버튼 — 닉네임 중복 확인 완료 시에만 활성화
+    private var nextButton: some View {
+        Button {
+            viewModel.goToNextStep()
+        } label: {
+            Text("다음")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    viewModel.isNicknameChecked && viewModel.isNicknameAvailable
+                        ? HiTripColor.buttonPrimary
+                        : HiTripColor.buttonDisabled
+                )
+                .cornerRadius(10)
+        }
+        .disabled(!(viewModel.isNicknameChecked && viewModel.isNicknameAvailable))
+    }
+
+    // MARK: - Computed Helpers
+
+    /// 중복확인 버튼 활성화 조건
+    /// - 닉네임 2자 이상 + 아직 확인 안 된 상태
+    private var isCheckButtonEnabled: Bool {
+        viewModel.nickname.trimmed.count >= 2 && !viewModel.isNicknameChecked
+    }
+
+    /// 입력 필드 테두리 색상
+    /// - 기본: 회색 테두리
+    /// - 확인 완료 + 사용 가능: 초록색
+    /// - 확인 완료 + 사용 불가: 빨간색
+    private var nicknameBorderColor: Color {
+        guard viewModel.isNicknameChecked else { return HiTripColor.gray300 }
+        return viewModel.isNicknameAvailable ? HiTripColor.readCheck : HiTripColor.error
+    }
+}

--- a/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
@@ -42,7 +42,7 @@ struct SignUpNicknameView: View {
         }
         .padding(.horizontal, 24)
         // 닉네임 변경 시 확인 상태 초기화
-        .onChange(of: viewModel.nickname) { _, _ in
+        .onChange(of: viewModel.nickname) { _ in
             viewModel.resetNicknameCheck()
         }
     }

--- a/HiTrip/Features/Auth/Views/SignUpPasswordView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpPasswordView.swift
@@ -1,1 +1,176 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpPasswordView
+/// 회원가입 Step 4: 비밀번호 설정
+///
+/// UI 구성:
+/// - 안내 텍스트
+/// - 비밀번호 입력 (SecureField, 6자 이상)
+/// - 비밀번호 확인 입력 (SecureField, 일치 여부)
+/// - 실시간 유효성 피드백
+/// - "가입하기" 버튼 (둘 다 유효 시 활성화 → 회원가입 API 호출)
+///
+/// 검증 규칙:
+/// - 비밀번호: 6자 이상
+/// - 비밀번호 확인: 비밀번호와 일치
+/// - 두 조건 모두 만족 시 "가입하기" 버튼 활성화
+
+struct SignUpPasswordView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+    @FocusState private var focusedField: Field?
+
+    enum Field { case password, confirm }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 안내 텍스트
+            guideSection
+                .padding(.top, 32)
+
+            // 비밀번호 입력
+            passwordInputSection
+                .padding(.top, 28)
+
+            // 에러 메시지 (API 호출 실패 시)
+            errorSection
+                .padding(.top, 8)
+
+            Spacer()
+
+            // 가입하기 버튼
+            signUpButton
+                .padding(.bottom, 40)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Guide Section
+
+    private var guideSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("비밀번호 설정")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("안전한 비밀번호를 설정해 주세요.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - Password Input
+
+    private var passwordInputSection: some View {
+        VStack(spacing: 12) {
+            // 비밀번호 입력
+            VStack(alignment: .leading, spacing: 6) {
+                SecureField("비밀번호 (6자 이상)", text: $viewModel.password)
+                    .padding(14)
+                    .background(HiTripColor.inputBackground)
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(passwordBorderColor, lineWidth: 1)
+                    )
+                    .focused($focusedField, equals: .password)
+                    .submitLabel(.next)
+                    .onSubmit { focusedField = .confirm }
+
+                // 비밀번호 길이 피드백
+                if !viewModel.password.isEmpty {
+                    Text(viewModel.isPasswordValid
+                         ? "사용 가능한 비밀번호입니다."
+                         : "비밀번호는 6자 이상이어야 합니다.")
+                        .font(.system(size: 13))
+                        .foregroundColor(
+                            viewModel.isPasswordValid
+                                ? HiTripColor.readCheck
+                                : HiTripColor.error
+                        )
+                }
+            }
+
+            // 비밀번호 확인
+            VStack(alignment: .leading, spacing: 6) {
+                SecureField("비밀번호 확인", text: $viewModel.passwordConfirm)
+                    .padding(14)
+                    .background(HiTripColor.inputBackground)
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(confirmBorderColor, lineWidth: 1)
+                    )
+                    .focused($focusedField, equals: .confirm)
+                    .submitLabel(.done)
+                    .onSubmit { focusedField = nil }
+
+                // 비밀번호 일치 피드백
+                if !viewModel.passwordConfirm.isEmpty {
+                    Text(viewModel.isPasswordMatch
+                         ? "비밀번호가 일치합니다."
+                         : "비밀번호가 일치하지 않습니다.")
+                        .font(.system(size: 13))
+                        .foregroundColor(
+                            viewModel.isPasswordMatch
+                                ? HiTripColor.readCheck
+                                : HiTripColor.error
+                        )
+                }
+            }
+        }
+    }
+
+    // MARK: - Error Section
+
+    /// API 호출 실패 시 에러 메시지 표시
+    private var errorSection: some View {
+        Group {
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.error)
+            }
+        }
+        .frame(height: 20, alignment: .leading)
+    }
+
+    // MARK: - Sign Up Button
+
+    /// "가입하기" 버튼
+    /// - 비밀번호 유효 + 확인 일치 시 활성화
+    /// - 탭 시 ViewModel.signUp() 호출 → API 요청
+    private var signUpButton: some View {
+        Button {
+            focusedField = nil
+            viewModel.signUp()
+        } label: {
+            Text("가입하기")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    viewModel.isPasswordStepValid
+                        ? HiTripColor.buttonPrimary
+                        : HiTripColor.buttonDisabled
+                )
+                .cornerRadius(10)
+        }
+        .disabled(!viewModel.isPasswordStepValid)
+    }
+
+    // MARK: - Border Colors
+
+    /// 비밀번호 필드 테두리
+    private var passwordBorderColor: Color {
+        guard !viewModel.password.isEmpty else { return HiTripColor.gray300 }
+        return viewModel.isPasswordValid ? HiTripColor.readCheck : HiTripColor.error
+    }
+
+    /// 비밀번호 확인 필드 테두리
+    private var confirmBorderColor: Color {
+        guard !viewModel.passwordConfirm.isEmpty else { return HiTripColor.gray300 }
+        return viewModel.isPasswordMatch ? HiTripColor.readCheck : HiTripColor.error
+    }
+}

--- a/HiTrip/Features/Auth/Views/SignUpTermsView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpTermsView.swift
@@ -1,1 +1,194 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpTermsView
+/// 회원가입 Step 2: 약관 동의
+///
+/// UI 구성:
+/// - 안내 텍스트
+/// - "전체 동의" 체크박스 (구분선으로 분리)
+/// - [필수] 서비스 이용약관 + 보기 버튼
+/// - [필수] 개인정보 수집 및 이용 + 보기 버튼
+/// - [선택] 마케팅 정보 수신
+/// - "다음" 버튼 (필수 약관 모두 동의 시 활성화)
+///
+/// 동작:
+/// - "전체 동의" 토글 → 모든 약관 일괄 체크/해제
+/// - 개별 약관 토글 → 3개 모두 체크 시 전체 동의 자동 활성화
+/// - 필수 2개 동의 시 "다음" 버튼 활성화 (마케팅은 선택)
+
+struct SignUpTermsView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 안내 텍스트
+            guideSection
+                .padding(.top, 32)
+
+            // 약관 체크박스 영역
+            termsSection
+                .padding(.top, 28)
+
+            Spacer()
+
+            // 다음 버튼
+            nextButton
+                .padding(.bottom, 40)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Guide Section
+
+    private var guideSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("약관 동의")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("서비스 이용을 위해 약관에 동의해 주세요.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - Terms Checkboxes
+
+    private var termsSection: some View {
+        VStack(spacing: 0) {
+            // 전체 동의
+            agreeAllRow
+                .padding(.bottom, 16)
+
+            // 구분선
+            Divider()
+                .padding(.bottom, 16)
+
+            // [필수] 서비스 이용약관
+            termRow(
+                title: "[필수] 서비스 이용약관",
+                isChecked: $viewModel.agreeService,
+                showDetail: true
+            )
+            .padding(.bottom, 12)
+
+            // [필수] 개인정보 수집 및 이용
+            termRow(
+                title: "[필수] 개인정보 수집 및 이용",
+                isChecked: $viewModel.agreePrivacy,
+                showDetail: true
+            )
+            .padding(.bottom, 12)
+
+            // [선택] 마케팅 정보 수신
+            termRow(
+                title: "[선택] 마케팅 정보 수신",
+                isChecked: $viewModel.agreeMarketing,
+                showDetail: false
+            )
+        }
+        .padding(20)
+        .background(Color.white)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Agree All Row
+
+    /// "전체 동의" 체크박스
+    /// - 나머지 개별 약관을 한꺼번에 토글
+    private var agreeAllRow: some View {
+        Button {
+            viewModel.toggleAgreeAll()
+        } label: {
+            HStack(spacing: 12) {
+                checkboxIcon(isChecked: viewModel.agreeAll)
+
+                Text("전체 동의")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Individual Term Row
+
+    /// 개별 약관 행
+    /// - isChecked: 바인딩 (토글 가능)
+    /// - showDetail: true면 "보기" 버튼 표시 (약관 상세 페이지 이동용)
+    private func termRow(
+        title: String,
+        isChecked: Binding<Bool>,
+        showDetail: Bool
+    ) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                isChecked.wrappedValue.toggle()
+                viewModel.updateAgreeAll()
+            } label: {
+                HStack(spacing: 12) {
+                    checkboxIcon(isChecked: isChecked.wrappedValue)
+
+                    Text(title)
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.textGrayA)
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            // "보기" 버튼 (약관 상세 내용 — Phase 2에서 WebView 연동)
+            if showDetail {
+                Button {
+                    // TODO: Phase 2 — 약관 상세 WebView 표시
+                } label: {
+                    Text("보기")
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.gray400)
+                        .underline()
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Checkbox Icon
+
+    /// 체크박스 아이콘
+    /// - 체크됨: 파란 원 + 체크마크
+    /// - 미체크: 회색 빈 원
+    private func checkboxIcon(isChecked: Bool) -> some View {
+        Image(systemName: isChecked
+              ? "checkmark.circle.fill"
+              : "circle")
+            .font(.system(size: 22))
+            .foregroundColor(isChecked
+                             ? HiTripColor.primary800
+                             : HiTripColor.gray300)
+    }
+
+    // MARK: - Next Button
+
+    private var nextButton: some View {
+        Button {
+            viewModel.goToNextStep()
+        } label: {
+            Text("다음")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    viewModel.isRequiredTermsAgreed
+                        ? HiTripColor.buttonPrimary
+                        : HiTripColor.buttonDisabled
+                )
+                .cornerRadius(10)
+        }
+        .disabled(!viewModel.isRequiredTermsAgreed)
+    }
+}

--- a/HiTrip/Features/Auth/Views/SignUpUserIdView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpUserIdView.swift
@@ -1,1 +1,130 @@
-import Foundation
+import SwiftUI
+
+// MARK: - SignUpUserIdView
+/// 회원가입 Step 3: 아이디 설정
+///
+/// UI 구성:
+/// - 안내 텍스트 ("로그인에 사용할 아이디를 입력해 주세요")
+/// - 아이디 입력 필드
+/// - 유효성 안내 메시지 (4자 이상)
+/// - "다음" 버튼 (4자 이상 입력 시 활성화)
+///
+/// 검증 규칙:
+/// - 공백 제거 후 4자 이상 필요 (SignUpUseCase.execute()에서도 이중 검증)
+/// - 클라이언트 사이드 검증 → 빠른 피드백
+/// - 서버 사이드 검증 → 최종 회원가입 시 재검증
+
+struct SignUpUserIdView: View {
+
+    @ObservedObject var viewModel: SignUpViewModel
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 안내 텍스트
+            guideSection
+                .padding(.top, 32)
+
+            // 아이디 입력 필드
+            userIdInputSection
+                .padding(.top, 28)
+
+            // 유효성 메시지
+            validationMessage
+                .padding(.top, 8)
+
+            Spacer()
+
+            // 다음 버튼
+            nextButton
+                .padding(.bottom, 40)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Guide Section
+
+    private var guideSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("아이디 설정")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("로그인에 사용할 아이디를 입력해 주세요.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - User ID Input
+
+    private var userIdInputSection: some View {
+        TextField("아이디 입력 (4자 이상)", text: $viewModel.userId)
+            .padding(14)
+            .background(HiTripColor.inputBackground)
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(borderColor, lineWidth: 1)
+            )
+            .focused($isFocused)
+            .autocapitalization(.none)    // 대문자 자동 변환 비활성화
+            .disableAutocorrection(true)  // 자동 수정 비활성화
+            .submitLabel(.done)
+            .onSubmit { isFocused = false }
+    }
+
+    // MARK: - Validation Message
+
+    /// 아이디 길이 안내 메시지
+    /// - 빈 상태: 메시지 없음
+    /// - 4자 미만: 빨간색 경고
+    /// - 4자 이상: 초록색 확인
+    private var validationMessage: some View {
+        Group {
+            if !viewModel.userId.isEmpty {
+                if viewModel.isUserIdValid {
+                    Text("사용 가능한 아이디 형식입니다.")
+                        .foregroundColor(HiTripColor.readCheck)
+                } else {
+                    Text("아이디는 4자 이상이어야 합니다.")
+                        .foregroundColor(HiTripColor.error)
+                }
+            }
+        }
+        .font(.system(size: 13))
+        .frame(height: 20, alignment: .leading)
+    }
+
+    // MARK: - Next Button
+
+    private var nextButton: some View {
+        Button {
+            viewModel.goToNextStep()
+        } label: {
+            Text("다음")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    viewModel.isUserIdValid
+                        ? HiTripColor.buttonPrimary
+                        : HiTripColor.buttonDisabled
+                )
+                .cornerRadius(10)
+        }
+        .disabled(!viewModel.isUserIdValid)
+    }
+
+    // MARK: - Border Color
+
+    /// 입력 필드 테두리 색상
+    /// - 빈 상태: 기본 회색
+    /// - 유효: 초록색
+    /// - 무효: 빨간색
+    private var borderColor: Color {
+        guard !viewModel.userId.isEmpty else { return HiTripColor.gray300 }
+        return viewModel.isUserIdValid ? HiTripColor.readCheck : HiTripColor.error
+    }
+}


### PR DESCRIPTION
## 개요
회원가입 4단계 플로우(닉네임 → 약관동의 → 아이디 → 비밀번호 → 완료)를 구현합니다.
LoginView의 "회원가입" 버튼 → SignUpFlowView → 각 단계 View → 완료 후 로그인 화면 복귀까지의 전체 흐름이 연결됩니다.

<br>

## 변경 사항

### ViewModel
- **SignUpViewModel.swift**: 4단계 플로우 상태 관리
  - `Step` enum (nickname → terms → userId → password → complete)으로 단계 정의
  - 각 단계별 입력값 @Published로 관리 (뒤로가기 시 데이터 보존)
  - 닉네임 중복확인 API 호출 (`checkNickname()`)
  - 약관 동의 전체/개별 동기화 (`toggleAgreeAll()`, `updateAgreeAll()`)
  - 비밀번호 유효성 검사 (6자 이상 + 확인 일치)
  - 최종 회원가입 API 호출 (`signUp()`)

### Views
- **SignUpFlowView.swift**: 컨테이너 View (커스텀 네비게이션 바 + 프로그레스 바 + 단계별 View 라우팅)
- **SignUpNicknameView.swift**: Step 1 — 닉네임 입력 + 중복확인 버튼, 확인 완료 시 "다음" 활성화
- **SignUpTermsView.swift**: Step 2 — 전체동의/[필수]서비스이용약관/[필수]개인정보수집/[선택]마케팅 체크박스
- **SignUpUserIdView.swift**: Step 3 — 아이디 입력 (4자 이상 실시간 유효성 피드백)
- **SignUpPasswordView.swift**: Step 4 — 비밀번호 + 확인 입력 (6자 이상 + 일치 검증) → "가입하기" 버튼으로 API 호출
- **SignUpCompleteView.swift**: 완료 화면 — 체크마크 스프링 애니메이션 + "로그인하러 가기" 버튼

### Bug Fix
- **HiTrip-Bridging-Header.h**: Xcode 빌드 설정에서 참조하는 Bridging Header 파일 누락 수정
- **LoginView.swift / SignUpNicknameView.swift**: `.onChange(of:)` iOS 16 호환 문법으로 수정 (`{ _, newValue in }` → `{ newValue in }`)


<br>

## 아키텍처

### 화면 전환 흐름
```
LoginView "회원가입" 탭
  → AppRouter.navigateToSignUp()
    → RootView switch .signUp
      → SignUpFlowView (컨테이너)
        → SignUpViewModel.currentStep에 따라 View 전환
          ├─ .nickname → SignUpNicknameView
          ├─ .terms   → SignUpTermsView
          ├─ .userId  → SignUpUserIdView
          ├─ .password → SignUpPasswordView (→ signUp() API 호출)
          └─ .complete → SignUpCompleteView
                          → "로그인하러 가기" → AppRouter.navigateToLogin()
```

### 데이터 흐름
```
View (사용자 입력)
  → @Published 바인딩 (SignUpViewModel)
    → 유효성 검사 (computed property)
      → UseCase 호출 (SignUpUseCase)
        → Repository (AuthRepository)
          → NetworkService (API 요청)
            → 응답 → ViewModel @Published 업데이트 → View 자동 렌더링
```

### 의존성 주입
```
AppDIContainer.makeSignUpViewModel()
  └─ SignUpViewModel(signUpUseCase:)
       └─ SignUpUseCase(repository:)
            └─ AuthRepository(networkService:)
                 └─ NetworkService.shared
```


<br>

## 트러블슈팅

### 1. Bridging Header 파일 누락 빌드 에러
- **증상**: `Build input file cannot be found: 'HiTrip/App/HiTrip-Bridging-Header.h'`
- **원인**: Xcode Build Settings의 `Objective-C Bridging Header` 경로가 해당 파일을 참조하고 있었으나, 실제 파일이 프로젝트에 존재하지 않았음
- **해결**: 빈 `HiTrip-Bridging-Header.h` 파일 생성
- **배운 점**: Bridging Header는 Swift에서 Objective-C 코드를 import할 때 사용하는 파일로, 빌드 설정에 경로가 지정되어 있으면 내용이 비어있더라도 파일 자체는 반드시 존재해야 함

### 2. onChange iOS 버전 호환성 에러
- **증상**: `'onChange(of:initial:_:)' is only available in iOS 17.0 or newer`
- **원인**: 프로젝트 최소 배포 타겟이 iOS 16.6인데, iOS 17+ 전용 문법 `.onChange(of:) { oldValue, newValue in }` 사용
- **해결**: iOS 16 호환 문법 `.onChange(of:) { newValue in }`으로 변경
- **배운 점**: `.onChange` 수정자는 iOS 버전에 따라 클로저 시그니처가 다름
  - iOS 17+: `{ oldValue, newValue in }` (이전 값 + 새 값)
  - iOS 14~16: `{ newValue in }` (새 값만)
  - 최소 배포 타겟에 맞는 API를 사용해야 하며, Xcode가 제안하는 자동완성이 항상 호환되는 것은 아님