### PR TITLE
test: Auth UseCase 단위 테스트 (Login + SignUp)

### DIFF
--- a/HiTrip/Domain/UseCases/LoginUseCase.swift
+++ b/HiTrip/Domain/UseCases/LoginUseCase.swift
@@ -73,7 +73,7 @@ final class LoginUseCase {
 // MARK: - LoginError
 /// 로그인 관련 에러 정의
 /// LocalizedError 채택 → .localizedDescription으로 한글 메시지 바로 사용 가능
-enum LoginError: LocalizedError {
+enum LoginError: LocalizedError, Equatable {
     /// ID(성함) 미입력
     case emptyId
     /// 비밀번호(생년월일) 미입력

--- a/HiTrip/Domain/UseCases/SignUpUseCase.swift
+++ b/HiTrip/Domain/UseCases/SignUpUseCase.swift
@@ -95,7 +95,7 @@ final class SignUpUseCase {
 
 // MARK: - SignUpError
 /// 회원가입 관련 에러 정의
-enum SignUpError: LocalizedError {
+enum SignUpError: LocalizedError, Equatable {
     case emptyNickname
     case nicknameTooShort      // 2자 미만
     case nicknameDuplicate     // 서버에서 중복 판정

--- a/HiTripTests/HiTripTests.swift
+++ b/HiTripTests/HiTripTests.swift
@@ -1,0 +1,15 @@
+//
+//  HiTripTests.swift
+//  HiTripTests
+//
+//  Created by ETiOn on 3/16/26.
+//
+
+// 이 파일은 Xcode가 자동 생성한 기본 테스트 파일입니다.
+// 실제 테스트는 아래 파일들에서 작성합니다:
+//
+// - MockAuthRepository.swift: 테스트용 가짜 Repository + 더미 데이터
+// - LoginUseCaseTests.swift: 로그인 비즈니스 로직 테스트
+// - SignUpUseCaseTests.swift: 회원가입 비즈니스 로직 테스트
+
+import XCTest

--- a/HiTripTests/LoginUseCaseTests.swift
+++ b/HiTripTests/LoginUseCaseTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+import RxSwift
+@testable import HiTrip
+
+// MARK: - LoginUseCaseTests
+/// LoginUseCase의 비즈니스 로직 검증
+///
+/// 테스트 대상:
+/// 1. 빈 ID 입력 시 emptyId 에러
+/// 2. 공백만 있는 ID 입력 시 emptyId 에러
+/// 3. 빈 비밀번호 입력 시 emptyPassword 에러
+/// 4. 유효한 입력 시 로그인 성공
+/// 5. 서버 에러 시 에러 전달
+/// 6. 자동 로그인 확인 (토큰 유/무)
+///
+/// 면접 포인트:
+/// "테스트 코드를 왜 작성하셨나요?"
+/// → "UseCase의 입력 검증 로직이 올바르게 동작하는지 자동으로 검증합니다.
+///    기능 추가나 리팩토링 후에도 기존 로직이 깨지지 않았음을 보장할 수 있습니다."
+
+final class LoginUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    /// 테스트 대상 (System Under Test)
+    private var sut: LoginUseCase!
+    /// 가짜 Repository
+    private var mockRepository: MockAuthRepository!
+    /// RxSwift 구독 해제용
+    private var disposeBag: DisposeBag!
+
+    // MARK: - Setup / Teardown
+
+    /// 각 테스트 메서드 실행 전에 호출
+    /// - 매번 새로운 Mock + UseCase를 생성 → 테스트 간 상태 격리
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockAuthRepository()
+        sut = LoginUseCase(repository: mockRepository)
+        disposeBag = DisposeBag()
+    }
+
+    /// 각 테스트 메서드 실행 후에 호출
+    /// - 메모리 해제로 테스트 간 간섭 방지
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    // MARK: - 입력 검증 테스트
+
+    /// 빈 ID → emptyId 에러
+    func test_빈_아이디_입력시_emptyId_에러() {
+        // given: Mock 설정 불필요 (검증 단계에서 걸러짐)
+        let expectation = expectation(description: "emptyId 에러 발생")
+
+        // when: 빈 ID로 로그인 시도
+        sut.execute(id: "", password: "990101")
+            .subscribe(
+                onSuccess: { _ in
+                    XCTFail("성공하면 안 됨")
+                },
+                onFailure: { error in
+                    // then: emptyId 에러인지 확인
+                    XCTAssertTrue(error is LoginError)
+                    XCTAssertEqual(error as? LoginError, .emptyId)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        // Repository가 호출되지 않았는지 확인 (검증 단계에서 이미 차단)
+        XCTAssertEqual(mockRepository.loginCallCount, 0)
+    }
+
+    /// 공백만 있는 ID → emptyId 에러 (.trimmed 동작 확인)
+    func test_공백만_있는_아이디_입력시_emptyId_에러() {
+        let expectation = expectation(description: "공백 ID 에러")
+
+        sut.execute(id: "   ", password: "990101")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? LoginError, .emptyId)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.loginCallCount, 0)
+    }
+
+    /// 빈 비밀번호 → emptyPassword 에러
+    func test_빈_비밀번호_입력시_emptyPassword_에러() {
+        let expectation = expectation(description: "emptyPassword 에러")
+
+        sut.execute(id: "홍길동", password: "")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? LoginError, .emptyPassword)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.loginCallCount, 0)
+    }
+
+    // MARK: - 로그인 성공 테스트
+
+    /// 유효한 입력 → 로그인 성공 → UserInfo 반환
+    func test_유효한_입력시_로그인_성공() {
+        // given: Mock에 성공 응답 설정
+        mockRepository.loginResult = .success(TestFixtures.loginSuccess)
+
+        let expectation = expectation(description: "로그인 성공")
+
+        // when
+        sut.execute(id: "홍길동", password: "990101")
+            .subscribe(
+                onSuccess: { userInfo in
+                    // then: UserInfo가 올바르게 반환되는지 확인
+                    XCTAssertEqual(userInfo.id, "user123")
+                    XCTAssertEqual(userInfo.name, "테스트유저")
+                    XCTAssertEqual(userInfo.userType, .tourist)
+                    expectation.fulfill()
+                },
+                onFailure: { error in
+                    XCTFail("실패하면 안 됨: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        // Repository가 정확히 1번 호출되었는지 확인
+        XCTAssertEqual(mockRepository.loginCallCount, 1)
+    }
+
+    // MARK: - 서버 에러 테스트
+
+    /// 서버 에러 시 에러가 그대로 전달되는지 확인
+    func test_서버_에러시_에러_전달() {
+        // given: Mock에 실패 응답 설정
+        mockRepository.loginResult = .failure(LoginError.invalidCredentials)
+
+        let expectation = expectation(description: "서버 에러")
+
+        // when
+        sut.execute(id: "홍길동", password: "000000")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    // then
+                    XCTAssertEqual(error as? LoginError, .invalidCredentials)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.loginCallCount, 1)
+    }
+
+    // MARK: - 자동 로그인 테스트
+
+    /// 토큰이 있으면 자동 로그인 가능
+    func test_토큰_있으면_자동로그인_true() {
+        mockRepository.savedToken = "some-token"
+        XCTAssertTrue(sut.checkAutoLogin())
+    }
+
+    /// 토큰이 없으면 자동 로그인 불가
+    func test_토큰_없으면_자동로그인_false() {
+        mockRepository.savedToken = nil
+        XCTAssertFalse(sut.checkAutoLogin())
+    }
+}

--- a/HiTripTests/MockAuthRepository.swift
+++ b/HiTripTests/MockAuthRepository.swift
@@ -1,0 +1,141 @@
+import Foundation
+import RxSwift
+@testable import HiTrip
+
+// MARK: - MockAuthRepository
+/// 테스트용 가짜 Repository
+///
+/// 역할:
+/// - 네트워크 요청 없이 UseCase의 비즈니스 로직만 독립 테스트
+/// - 테스트 케이스마다 성공/실패 응답을 자유롭게 설정 가능
+///
+/// 사용 예시:
+/// ```
+/// let mock = MockAuthRepository()
+/// mock.loginResult = .success(fakeResponse)  // 성공 케이스
+/// mock.loginResult = .failure(someError)     // 실패 케이스
+/// let useCase = LoginUseCase(repository: mock)
+/// ```
+///
+/// 면접 포인트:
+/// "테스트에서 Mock 객체를 왜 사용하셨나요?"
+/// → "UseCase는 비즈니스 로직만 담당하므로, 네트워크나 DB 같은
+///    외부 의존성을 Mock으로 교체하면 로직만 순수하게 검증할 수 있습니다.
+///    Protocol 기반 설계(DIP) 덕분에 프로덕션 코드 수정 없이
+///    Mock을 주입할 수 있었습니다."
+
+final class MockAuthRepository: AuthRepositoryProtocol {
+
+    // MARK: - 테스트 제어용 프로퍼티
+
+    /// login() 호출 시 반환할 결과 (테스트마다 설정)
+    var loginResult: Result<LoginResponse, Error> = .failure(MockError.notConfigured)
+
+    /// checkNickname() 호출 시 반환할 결과
+    var nicknameResult: Result<NicknameCheckResponse, Error> = .failure(MockError.notConfigured)
+
+    /// signUp() 호출 시 반환할 결과
+    var signUpResult: Result<SignUpResponse, Error> = .failure(MockError.notConfigured)
+
+    /// getSavedToken() 호출 시 반환할 토큰 값 (nil이면 로그인 안 된 상태)
+    var savedToken: String? = nil
+
+    /// 각 메서드가 몇 번 호출되었는지 추적
+    /// - 테스트에서 "이 메서드가 실제로 호출되었는가?" 검증용
+    var loginCallCount = 0
+    var checkNicknameCallCount = 0
+    var signUpCallCount = 0
+    var logoutCallCount = 0
+
+    // MARK: - AuthRepositoryProtocol 구현
+
+    func login(request: LoginRequest) -> Single<LoginResponse> {
+        loginCallCount += 1
+        switch loginResult {
+        case .success(let response):
+            return .just(response)
+        case .failure(let error):
+            return .error(error)
+        }
+    }
+
+    func refreshToken() -> Single<LoginResponse> {
+        // 이번 Phase에서는 테스트하지 않음
+        return .error(MockError.notConfigured)
+    }
+
+    func getSavedToken() -> String? {
+        return savedToken
+    }
+
+    func logout() {
+        logoutCallCount += 1
+        savedToken = nil
+    }
+
+    func checkNickname(_ nickname: String) -> Single<NicknameCheckResponse> {
+        checkNicknameCallCount += 1
+        switch nicknameResult {
+        case .success(let response):
+            return .just(response)
+        case .failure(let error):
+            return .error(error)
+        }
+    }
+
+    func signUp(request: SignUpRequest) -> Single<SignUpResponse> {
+        signUpCallCount += 1
+        switch signUpResult {
+        case .success(let response):
+            return .just(response)
+        case .failure(let error):
+            return .error(error)
+        }
+    }
+}
+
+// MARK: - MockError
+/// Mock 전용 에러
+enum MockError: Error {
+    /// 테스트 설정을 안 한 상태에서 호출됨
+    case notConfigured
+}
+
+// MARK: - Test Fixtures (테스트용 더미 데이터)
+/// 테스트에서 반복 사용하는 가짜 데이터를 한 곳에 모아 관리
+enum TestFixtures {
+
+    /// 더미 UserInfo
+    static let sampleUser = UserInfo(
+        id: "user123",
+        name: "테스트유저",
+        userType: .tourist,
+        phone: "010-1234-5678",
+        country: "KR"
+    )
+
+    /// 더미 LoginResponse (login 성공)
+    static let loginSuccess = LoginResponse(
+        accessToken: "fake-access-token",
+        refreshToken: "fake-refresh-token",
+        user: sampleUser
+    )
+
+    /// 더미 NicknameCheckResponse (닉네임 사용 가능)
+    static let nicknameAvailable = NicknameCheckResponse(
+        isAvailable: true,
+        message: "사용 가능한 닉네임입니다."
+    )
+
+    /// 더미 NicknameCheckResponse (닉네임 중복)
+    static let nicknameDuplicate = NicknameCheckResponse(
+        isAvailable: false,
+        message: "이미 사용 중인 닉네임입니다."
+    )
+
+    /// 더미 SignUpResponse (가입 성공)
+    static let signUpSuccess = SignUpResponse(
+        message: "가입이 완료되었습니다.",
+        user: sampleUser
+    )
+}

--- a/HiTripTests/SignUpUseCaseTests.swift
+++ b/HiTripTests/SignUpUseCaseTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+import RxSwift
+@testable import HiTrip
+
+// MARK: - SignUpUseCaseTests
+/// SignUpUseCase의 비즈니스 로직 검증
+///
+/// 테스트 대상:
+/// 1. 닉네임 중복 확인 — 빈 값, 2자 미만, 사용 가능, 중복
+/// 2. 회원가입 실행 — 각 필드별 검증 에러, 비밀번호 불일치, 성공
+
+final class SignUpUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var sut: SignUpUseCase!
+    private var mockRepository: MockAuthRepository!
+    private var disposeBag: DisposeBag!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockAuthRepository()
+        sut = SignUpUseCase(repository: mockRepository)
+        disposeBag = DisposeBag()
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    // MARK: - 닉네임 중복 확인 테스트
+
+    /// 빈 닉네임 → emptyNickname 에러
+    func test_빈_닉네임_checkNickname_에러() {
+        let expectation = expectation(description: "빈 닉네임 에러")
+
+        sut.checkNickname("")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .emptyNickname)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        // 검증 단계에서 걸러졌으므로 Repository 호출 없음
+        XCTAssertEqual(mockRepository.checkNicknameCallCount, 0)
+    }
+
+    /// 1자 닉네임 → nicknameTooShort 에러
+    func test_1자_닉네임_checkNickname_에러() {
+        let expectation = expectation(description: "닉네임 너무 짧음")
+
+        sut.checkNickname("가")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .nicknameTooShort)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.checkNicknameCallCount, 0)
+    }
+
+    /// 유효한 닉네임 + 사용 가능 → isAvailable true
+    func test_유효한_닉네임_사용가능() {
+        mockRepository.nicknameResult = .success(TestFixtures.nicknameAvailable)
+
+        let expectation = expectation(description: "닉네임 사용 가능")
+
+        sut.checkNickname("여행자")
+            .subscribe(
+                onSuccess: { response in
+                    XCTAssertTrue(response.isAvailable)
+                    expectation.fulfill()
+                },
+                onFailure: { error in
+                    XCTFail("실패하면 안 됨: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.checkNicknameCallCount, 1)
+    }
+
+    /// 유효한 닉네임 + 중복 → isAvailable false
+    func test_유효한_닉네임_중복() {
+        mockRepository.nicknameResult = .success(TestFixtures.nicknameDuplicate)
+
+        let expectation = expectation(description: "닉네임 중복")
+
+        sut.checkNickname("여행자")
+            .subscribe(
+                onSuccess: { response in
+                    XCTAssertFalse(response.isAvailable)
+                    expectation.fulfill()
+                },
+                onFailure: { _ in XCTFail("실패하면 안 됨") }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - 회원가입 실행 테스트
+
+    /// 빈 닉네임으로 가입 시도 → emptyNickname 에러
+    func test_빈_닉네임으로_가입시_에러() {
+        let expectation = expectation(description: "빈 닉네임 가입 에러")
+
+        sut.execute(nickname: "", userId: "user1", password: "123456", passwordConfirm: "123456")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .emptyNickname)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 빈 아이디로 가입 시도 → emptyUserId 에러
+    func test_빈_아이디로_가입시_에러() {
+        let expectation = expectation(description: "빈 아이디 가입 에러")
+
+        sut.execute(nickname: "여행자", userId: "", password: "123456", passwordConfirm: "123456")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .emptyUserId)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 3자 아이디 → userIdTooShort 에러
+    func test_짧은_아이디로_가입시_에러() {
+        let expectation = expectation(description: "짧은 아이디 에러")
+
+        sut.execute(nickname: "여행자", userId: "abc", password: "123456", passwordConfirm: "123456")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .userIdTooShort)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 빈 비밀번호 → emptyPassword 에러
+    func test_빈_비밀번호로_가입시_에러() {
+        let expectation = expectation(description: "빈 비밀번호 에러")
+
+        sut.execute(nickname: "여행자", userId: "user1", password: "", passwordConfirm: "")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .emptyPassword)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 5자 비밀번호 → passwordTooShort 에러
+    func test_짧은_비밀번호로_가입시_에러() {
+        let expectation = expectation(description: "짧은 비밀번호 에러")
+
+        sut.execute(nickname: "여행자", userId: "user1", password: "12345", passwordConfirm: "12345")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .passwordTooShort)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 비밀번호 불일치 → passwordMismatch 에러
+    func test_비밀번호_불일치시_에러() {
+        let expectation = expectation(description: "비밀번호 불일치")
+
+        sut.execute(nickname: "여행자", userId: "user1", password: "123456", passwordConfirm: "654321")
+            .subscribe(
+                onSuccess: { _ in XCTFail("성공하면 안 됨") },
+                onFailure: { error in
+                    XCTAssertEqual(error as? SignUpError, .passwordMismatch)
+                    expectation.fulfill()
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockRepository.signUpCallCount, 0)
+    }
+
+    /// 모든 입력 유효 → 회원가입 성공
+    func test_유효한_입력시_가입_성공() {
+        mockRepository.signUpResult = .success(TestFixtures.signUpSuccess)
+
+        let expectation = expectation(description: "가입 성공")
+
+        sut.execute(nickname: "여행자", userId: "user1", password: "123456", passwordConfirm: "123456")
+            .subscribe(
+                onSuccess: { response in
+                    XCTAssertEqual(response.message, "가입이 완료되었습니다.")
+                    XCTAssertEqual(response.user.name, "테스트유저")
+                    expectation.fulfill()
+                },
+                onFailure: { error in
+                    XCTFail("실패하면 안 됨: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+
+        wait(for: [expectation], timeout: 1.0)
+        // 모든 검증 통과 후 Repository가 1번 호출됨
+        XCTAssertEqual(mockRepository.signUpCallCount, 1)
+    }
+}


### PR DESCRIPTION
## 개요
Login/SignUp UseCase의 비즈니스 로직을 검증하는 단위 테스트를 작성합니다.
MockAuthRepository를 활용하여 네트워크 없이 입력 검증, 성공/실패 흐름을 독립적으로 테스트합니다.

<br>

## 변경 사항

### 신규 파일 (HiTripTests/)
- **MockAuthRepository.swift**: AuthRepositoryProtocol 구현 Mock + 호출 횟수 추적 + TestFixtures 더미 데이터
- **LoginUseCaseTests.swift**: 7개 테스트 (빈 ID, 공백 ID, 빈 PW, 로그인 성공, 서버 에러, 자동 로그인 토큰 유/무)
- **SignUpUseCaseTests.swift**: 10개 테스트 (닉네임 빈값/1자/사용가능/중복, 가입 시 각 필드 검증, 비밀번호 불일치, 가입 성공)

### 수정 파일 (HiTrip/)
- **LoginError**: `Equatable` 프로토콜 채택 추가
- **SignUpError**: `Equatable` 프로토콜 채택 추가

<br>

## 테스트 구조
```
LoginUseCaseTests / SignUpUseCaseTests
  └─ UseCase (테스트 대상)
       └─ MockAuthRepository (가짜 주입)
            └─ TestFixtures (더미 데이터)
```

### 테스트 목록

**LoginUseCaseTests (7개)**
| 테스트 | 검증 내용 |
|--------|-----------|
| test_빈_아이디_입력시_emptyId_에러 | 빈 ID → Repository 호출 없이 에러 |
| test_공백만_있는_아이디_입력시_emptyId_에러 | .trimmed 동작 확인 |
| test_빈_비밀번호_입력시_emptyPassword_에러 | 빈 PW → Repository 호출 없이 에러 |
| test_유효한_입력시_로그인_성공 | Mock 성공 응답 → UserInfo 반환 |
| test_서버_에러시_에러_전달 | Mock 실패 응답 → 에러 그대로 전달 |
| test_토큰_있으면_자동로그인_true | savedToken 존재 → true |
| test_토큰_없으면_자동로그인_false | savedToken nil → false |

**SignUpUseCaseTests (10개)**
| 테스트 | 검증 내용 |
|--------|-----------|
| test_빈_닉네임_checkNickname_에러 | 빈 닉네임 → emptyNickname |
| test_1자_닉네임_checkNickname_에러 | 1자 → nicknameTooShort |
| test_유효한_닉네임_사용가능 | 2자 이상 + Mock 사용가능 → isAvailable true |
| test_유효한_닉네임_중복 | 2자 이상 + Mock 중복 → isAvailable false |
| test_빈_닉네임으로_가입시_에러 | emptyNickname, signUpCallCount 0 |
| test_빈_아이디로_가입시_에러 | emptyUserId, signUpCallCount 0 |
| test_짧은_아이디로_가입시_에러 | 3자 → userIdTooShort |
| test_빈_비밀번호로_가입시_에러 | emptyPassword |
| test_짧은_비밀번호로_가입시_에러 | 5자 → passwordTooShort |
| test_비밀번호_불일치시_에러 | passwordMismatch |
| test_유효한_입력시_가입_성공 | 모든 검증 통과 → signUpCallCount 1 |

<br>

## 테스트 방법론

### 단위 테스트 (Unit Test)
UI 테스트나 통합 테스트가 아닌, 가장 작은 코드 단위(UseCase의 메서드)를 독립적으로 검증하는 단위 테스트를 작성했습니다. 네트워크나 DB 없이 순수 비즈니스 로직만 테스트합니다.

### Given-When-Then 패턴
모든 테스트를 3단계로 구성했습니다:
```swift
func test_유효한_입력시_로그인_성공() {
    // Given (준비) — 어떤 상황에서
    mockRepository.loginResult = .success(TestFixtures.loginSuccess)

    // When (실행) — 이걸 했을 때
    sut.execute(id: "홍길동", password: "990101")

    // Then (검증) — 이런 결과가 나와야 한다
    XCTAssertEqual(userInfo.name, "테스트유저")
}
```

### Mock 객체 + DIP (의존성 역전)
UseCase는 `AuthRepositoryProtocol`에만 의존하므로, 프로덕션에서는 진짜 `AuthRepository`를, 테스트에서는 `MockAuthRepository`를 주입할 수 있습니다. Protocol 기반 설계(DIP)가 실제로 효과를 발휘하는 부분입니다.
```
프로덕션: UseCase → AuthRepository (진짜 서버 호출)
테스트:   UseCase → MockAuthRepository (가짜 응답 반환)
```

### 테스트 격리 (setUp / tearDown)
매 테스트마다 `setUp`에서 새로운 Mock + UseCase를 생성하고, `tearDown`에서 해제합니다. 이전 테스트의 상태가 다음 테스트에 영향을 주지 않도록 완전히 격리합니다.

### Spy 패턴 (호출 횟수 검증)
Mock에 `loginCallCount`, `signUpCallCount` 등을 두어 Repository 호출 여부를 추적합니다. 예를 들어 빈 ID 입력 시 UseCase가 검증 단계에서 에러를 반환하고, 불필요한 네트워크 호출을 하지 않았는지 `XCTAssertEqual(mockRepository.loginCallCount, 0)`으로 확인합니다.

### SUT (System Under Test) 네이밍
테스트 대상 객체를 `sut`으로 명명하는 업계 관례를 따랐습니다. 어떤 테스트 파일을 열든 `sut`만 보면 테스트 대상을 바로 식별할 수 있습니다.


<br>

## 트러블슈팅

### XCTAssertEqual Equatable 미채택 에러
- **증상**: `Global function 'XCTAssertEqual' requires that 'LoginError' conform to 'Equatable'`
- **원인**: `XCTAssertEqual(error as? LoginError, .emptyId)`에서 `==` 비교를 하려면 `Equatable` 프로토콜 채택이 필요한데, `LoginError`와 `SignUpError`에 누락되어 있었음
- **해결**: 두 enum에 `Equatable` 프로토콜 채택 추가
- **배운 점**: Swift의 enum은 `Equatable`을 채택하면 컴파일러가 자동으로 `==` 구현을 생성해줌 (associated value가 있는 case도 해당 타입이 Equatable이면 자동 합성). 테스트 코드 작성 시 비교 대상 타입의 프로토콜 채택 여부를 미리 확인해야 함
