### PR TITLE
feat: Schedule CRUD

### DIFF
--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -48,6 +48,11 @@ final class AppDIContainer {
         AuthRepository(networkService: networkService)
     }()
 
+    /// 일정 Repository — 현재 메모리 저장, 나중에 서버 연동으로 교체
+    private lazy var scheduleRepository: ScheduleRepositoryProtocol = {
+        ScheduleRepository()
+    }()
+
     // MARK: - Init
 
     /// 프로덕션용 — 싱글턴으로만 사용
@@ -86,6 +91,10 @@ final class AppDIContainer {
         SignUpUseCase(repository: authRepository)
     }
 
+    func makeScheduleUseCase() -> ScheduleUseCase {
+        ScheduleUseCase(repository: scheduleRepository)
+    }
+
     // MARK: - ViewModel Factory
 
     /// RootView에서 호출하여 LoginView에 주입
@@ -96,5 +105,10 @@ final class AppDIContainer {
     /// RootView에서 호출하여 SignUpFlowView에 주입
     func makeSignUpViewModel() -> SignUpViewModel {
         SignUpViewModel(signUpUseCase: makeSignUpUseCase())
+    }
+
+    /// HomeView의 일정 탭에서 사용
+    func makeScheduleViewModel() -> ScheduleViewModel {
+        ScheduleViewModel(scheduleUseCase: makeScheduleUseCase())
     }
 }

--- a/HiTrip/Data/Repositories/ScheduleRepository.swift
+++ b/HiTrip/Data/Repositories/ScheduleRepository.swift
@@ -1,0 +1,104 @@
+import Foundation
+import RxSwift
+
+// MARK: - ScheduleRepository
+/// 일정 저장소 구현체 (메모리 저장)
+///
+/// 현재: 앱 메모리(배열)에 저장 — 앱 종료 시 데이터 사라짐
+/// 나중에: NetworkService를 사용하여 서버 API로 교체
+///
+/// ScheduleRepositoryProtocol을 구현하므로,
+/// UseCase는 이 클래스의 존재를 모름 (DIP)
+///
+/// 메모리 저장 → 서버 저장으로 변경할 때:
+/// - 이 파일의 내부 구현만 수정
+/// - UseCase, ViewModel, View는 수정 불필요
+
+final class ScheduleRepository: ScheduleRepositoryProtocol {
+
+    // MARK: - 저장소
+
+    /// 메모리 기반 일정 저장소
+    /// - 배열에 Schedule을 저장하고, CRUD 메서드에서 이 배열을 조작
+    /// - private: 외부에서 직접 접근 불가 (반드시 메서드를 통해서만 접근)
+    private var schedules: [Schedule] = []
+
+    // MARK: - [C] Create
+
+    /// 일정을 배열에 추가하고, 추가된 일정을 반환
+    func create(schedule: Schedule) -> Single<Schedule> {
+        return Single.create { [weak self] single in
+            self?.schedules.append(schedule)
+            single(.success(schedule))
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - [R] Read
+
+    /// 전체 일정을 날짜순(최신순)으로 정렬하여 반환
+    func fetchAll() -> Single<[Schedule]> {
+        return Single.create { [weak self] single in
+            let sorted = self?.schedules.sorted { $0.date > $1.date } ?? []
+            single(.success(sorted))
+            return Disposables.create()
+        }
+    }
+
+    /// ID로 특정 일정 조회
+    /// - 찾으면 해당 일정 반환, 못 찾으면 notFound 에러
+    func fetchById(id: UUID) -> Single<Schedule> {
+        return Single.create { [weak self] single in
+            if let schedule = self?.schedules.first(where: { $0.id == id }) {
+                single(.success(schedule))
+            } else {
+                single(.failure(ScheduleError.notFound))
+            }
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - [U] Update
+
+    /// 배열에서 같은 ID를 가진 일정을 찾아 교체
+    /// - 못 찾으면 notFound 에러
+    func update(schedule: Schedule) -> Single<Schedule> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(ScheduleError.notFound))
+                return Disposables.create()
+            }
+
+            // 같은 ID의 일정 위치(index) 찾기
+            if let index = self.schedules.firstIndex(where: { $0.id == schedule.id }) {
+                // 해당 위치의 일정을 새 데이터로 교체
+                self.schedules[index] = schedule
+                single(.success(schedule))
+            } else {
+                single(.failure(ScheduleError.notFound))
+            }
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - [D] Delete
+
+    /// 배열에서 같은 ID를 가진 일정을 제거
+    /// - 못 찾으면 notFound 에러
+    func delete(id: UUID) -> Single<Void> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(ScheduleError.notFound))
+                return Disposables.create()
+            }
+
+            if let index = self.schedules.firstIndex(where: { $0.id == id }) {
+                self.schedules.remove(at: index)
+                single(.success(()))
+            } else {
+                single(.failure(ScheduleError.notFound))
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/HiTrip/Domain/Entities/Schedule.swift
+++ b/HiTrip/Domain/Entities/Schedule.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// MARK: - Schedule
+/// 일정 데이터 모델
+///
+/// CRUD의 기본 단위 — 하나의 "일정"이 가지는 모든 정보
+///
+/// 필드 설계 기준:
+/// - id: 각 일정을 고유하게 식별 (UUID 자동 생성)
+/// - title: 일정 제목 (필수)
+/// - description: 상세 내용 (선택)
+/// - date: 일정 날짜 (필수)
+/// - location: 장소 (선택, Phase 4에서 KakaoMap 연동)
+/// - createdAt: 생성 시간 (자동, 정렬용)
+///
+/// Identifiable 채택 이유:
+/// - SwiftUI의 List, ForEach에서 각 항목을 구분하기 위해 필요
+/// - id 프로퍼티가 있으면 SwiftUI가 자동으로 항목 추적
+///
+/// Codable 채택 이유:
+/// - 나중에 서버 JSON ↔ Swift 변환용 (현재는 메모리 저장이지만 미리 준비)
+
+struct Schedule: Identifiable, Codable, Equatable {
+
+    /// 고유 식별자 — UUID로 자동 생성
+    let id: UUID
+
+    /// 일정 제목 (필수)
+    /// 예: "제주도 한라산 등반", "서울 궁궐 투어"
+    var title: String
+
+    /// 일정 상세 설명 (선택)
+    /// 예: "오전 9시 출발, 등산 장비 준비"
+    var description: String
+
+    /// 일정 날짜 (필수)
+    var date: Date
+
+    /// 장소 (선택)
+    /// Phase 4에서 KakaoMap 좌표와 연동 예정
+    var location: String
+
+    /// 생성 시간 — 목록 정렬에 사용
+    let createdAt: Date
+
+    /// 기본 생성자
+    /// - id와 createdAt은 자동 생성 (직접 지정할 필요 없음)
+    init(
+        id: UUID = UUID(),
+        title: String,
+        description: String = "",
+        date: Date,
+        location: String = "",
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.date = date
+        self.location = location
+        self.createdAt = createdAt
+    }
+}

--- a/HiTrip/Domain/Repositories/ScheduleRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/ScheduleRepositoryProtocol.swift
@@ -1,0 +1,31 @@
+import Foundation
+import RxSwift
+
+// MARK: - ScheduleRepositoryProtocol
+/// 일정 데이터 접근 인터페이스 (Domain 레이어)
+///
+/// CRUD 4가지 동작을 Protocol로 정의
+/// - 실제 구현은 Data 레이어의 ScheduleRepository에서 담당
+/// - 테스트 시 MockScheduleRepository로 교체 가능
+///
+/// AuthRepositoryProtocol과 동일한 설계 패턴:
+/// - Domain은 Protocol만 알고, 구현체는 모름 (DIP)
+/// - UseCase가 이 Protocol에 의존
+
+protocol ScheduleRepositoryProtocol {
+
+    /// [C] 일정 생성 — 새 일정을 저장소에 추가
+    func create(schedule: Schedule) -> Single<Schedule>
+
+    /// [R] 전체 일정 조회 — 저장된 모든 일정을 반환
+    func fetchAll() -> Single<[Schedule]>
+
+    /// [R] 단일 일정 조회 — ID로 특정 일정 조회
+    func fetchById(id: UUID) -> Single<Schedule>
+
+    /// [U] 일정 수정 — 기존 일정의 내용을 업데이트
+    func update(schedule: Schedule) -> Single<Schedule>
+
+    /// [D] 일정 삭제 — ID로 특정 일정 삭제
+    func delete(id: UUID) -> Single<Void>
+}

--- a/HiTrip/Domain/UseCases/ScheduleUseCase.swift
+++ b/HiTrip/Domain/UseCases/ScheduleUseCase.swift
@@ -1,0 +1,93 @@
+import Foundation
+import RxSwift
+
+// MARK: - ScheduleUseCase
+/// 일정 CRUD 비즈니스 로직
+///
+/// 역할:
+/// - 입력값 검증 (제목 빈 값 등)
+/// - 검증 통과 시 Repository에 실제 동작 위임
+///
+/// LoginUseCase와 동일한 패턴:
+/// - Protocol에만 의존 (DIP)
+/// - 검증 실패 시 Repository 호출하지 않음 (불필요한 저장/네트워크 방지)
+
+final class ScheduleUseCase {
+
+    private let repository: ScheduleRepositoryProtocol
+
+    init(repository: ScheduleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - [C] Create (생성)
+
+    /// 일정 생성
+    ///
+    /// 검증: 제목이 비어있으면 에러 반환
+    /// 통과: Repository.create() 호출
+    func create(schedule: Schedule) -> Single<Schedule> {
+        guard !schedule.title.trimmed.isEmpty else {
+            return .error(ScheduleError.emptyTitle)
+        }
+
+        return repository.create(schedule: schedule)
+    }
+
+    // MARK: - [R] Read (조회)
+
+    /// 전체 일정 목록 조회
+    /// - 검증 불필요 → 바로 Repository 호출
+    func fetchAll() -> Single<[Schedule]> {
+        return repository.fetchAll()
+    }
+
+    /// 특정 일정 조회
+    func fetchById(id: UUID) -> Single<Schedule> {
+        return repository.fetchById(id: id)
+    }
+
+    // MARK: - [U] Update (수정)
+
+    /// 일정 수정
+    ///
+    /// 검증: 제목이 비어있으면 에러 반환
+    /// 통과: Repository.update() 호출
+    func update(schedule: Schedule) -> Single<Schedule> {
+        guard !schedule.title.trimmed.isEmpty else {
+            return .error(ScheduleError.emptyTitle)
+        }
+
+        return repository.update(schedule: schedule)
+    }
+
+    // MARK: - [D] Delete (삭제)
+
+    /// 일정 삭제
+    /// - 검증 불필요 → 바로 Repository 호출
+    func delete(id: UUID) -> Single<Void> {
+        return repository.delete(id: id)
+    }
+}
+
+// MARK: - ScheduleError
+/// 일정 관련 에러 정의
+enum ScheduleError: LocalizedError, Equatable {
+    /// 제목 미입력
+    case emptyTitle
+    /// 해당 ID의 일정을 찾을 수 없음
+    case notFound
+    /// 서버 에러
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTitle:
+            return "일정 제목을 입력해주세요."
+        case .notFound:
+            return "일정을 찾을 수 없습니다."
+        case .serverError(let msg):
+            return msg
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 ///
 /// 탭 구성:
 /// - 홈: 로그인 성공 확인 + 로그아웃
-/// - 일정: Phase 2에서 구현
+/// - 일정: ScheduleListView (CRUD)
 /// - 스팟 추천: Phase 4에서 구현
 /// - 긴급 연락: Phase 5에서 구현
 /// - 프로필: Phase 2에서 구현
@@ -46,7 +46,9 @@ struct HomeView: View {
                 .tabItem { Label(Tab.home.rawValue, systemImage: Tab.home.icon) }
                 .tag(Tab.home)
 
-            placeholderTab("일정", icon: "calendar", phase: 2)
+            ScheduleListView(
+                    viewModel: AppDIContainer.shared.makeScheduleViewModel()
+                )
                 .tabItem { Label(Tab.schedule.rawValue, systemImage: Tab.schedule.icon) }
                 .tag(Tab.schedule)
 

--- a/HiTrip/Features/Schedule/ViewModels/ScheduleViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/ScheduleViewModel.swift
@@ -1,0 +1,190 @@
+import Foundation
+import RxSwift
+
+// MARK: - ScheduleViewModel
+/// 일정 CRUD 화면의 ViewModel
+///
+/// LoginViewModel과 동일한 패턴:
+/// - @Published로 View와 양방향 바인딩
+/// - UseCase를 통해 비즈니스 로직 실행
+/// - View는 ViewModel의 @Published만 관찰
+///
+/// CRUD 대응:
+/// - [C] createSchedule() → 새 일정 생성
+/// - [R] fetchSchedules() → 목록 조회 (화면 진입 시 자동 호출)
+/// - [U] updateSchedule() → 기존 일정 수정
+/// - [D] deleteSchedule() → 일정 삭제
+
+final class ScheduleViewModel: ObservableObject {
+
+    // MARK: - 목록 상태 (Read)
+
+    /// 일정 목록 — ScheduleListView에서 ForEach로 표시
+    @Published var schedules: [Schedule] = []
+
+    // MARK: - 입력 폼 상태 (Create / Update)
+
+    /// 제목 입력 — TextField와 바인딩
+    @Published var title: String = ""
+
+    /// 설명 입력 — TextEditor와 바인딩
+    @Published var description: String = ""
+
+    /// 날짜 선택 — DatePicker와 바인딩
+    @Published var date: Date = Date()
+
+    /// 장소 입력 — TextField와 바인딩
+    @Published var location: String = ""
+
+    // MARK: - UI 상태
+
+    /// 로딩 중 여부
+    @Published var isLoading: Bool = false
+
+    /// 에러 메시지 (nil이면 에러 없음)
+    @Published var errorMessage: String?
+
+    /// 작업 완료 여부 (생성/수정/삭제 성공 시 true → View가 화면 닫기)
+    @Published var isCompleted: Bool = false
+
+    // MARK: - Dependencies
+
+    private let scheduleUseCase: ScheduleUseCase
+    private let disposeBag = DisposeBag()
+
+    init(scheduleUseCase: ScheduleUseCase) {
+        self.scheduleUseCase = scheduleUseCase
+    }
+
+    // MARK: - [R] Read — 목록 조회
+
+    /// 전체 일정 목록 불러오기
+    /// - 화면 진입 시 (.onAppear) 호출
+    func fetchSchedules() {
+        isLoading = true
+
+        scheduleUseCase.fetchAll()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] schedules in
+                    self?.isLoading = false
+                    self?.schedules = schedules
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - [C] Create — 일정 생성
+
+    /// 입력 폼의 데이터로 새 일정 생성
+    func createSchedule() {
+        let newSchedule = Schedule(
+            title: title.trimmed,
+            description: description.trimmed,
+            date: date,
+            location: location.trimmed
+        )
+
+        isLoading = true
+        errorMessage = nil
+
+        scheduleUseCase.create(schedule: newSchedule)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoading = false
+                    self?.isCompleted = true
+                    self?.resetForm()
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - [U] Update — 일정 수정
+
+    /// 기존 일정의 데이터를 수정
+    /// - Parameter schedule: 수정할 일정 (id가 동일한 기존 일정을 찾아 교체)
+    func updateSchedule(_ schedule: Schedule) {
+        let updatedSchedule = Schedule(
+            id: schedule.id,
+            title: title.trimmed,
+            description: description.trimmed,
+            date: date,
+            location: location.trimmed,
+            createdAt: schedule.createdAt
+        )
+
+        isLoading = true
+        errorMessage = nil
+
+        scheduleUseCase.update(schedule: updatedSchedule)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoading = false
+                    self?.isCompleted = true
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - [D] Delete — 일정 삭제
+
+    /// ID로 일정 삭제
+    func deleteSchedule(id: UUID) {
+        isLoading = true
+        errorMessage = nil
+
+        scheduleUseCase.delete(id: id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoading = false
+                    // 목록에서도 즉시 제거 (서버 재조회 없이 로컬 반영)
+                    self?.schedules.removeAll { $0.id == id }
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 폼 관련 헬퍼
+
+    /// 입력 폼 초기화 (생성 완료 후 호출)
+    func resetForm() {
+        title = ""
+        description = ""
+        date = Date()
+        location = ""
+        isCompleted = false
+        errorMessage = nil
+    }
+
+    /// 수정 화면 진입 시, 기존 일정 데이터를 폼에 채워넣기
+    func loadScheduleForEdit(_ schedule: Schedule) {
+        title = schedule.title
+        description = schedule.description
+        date = schedule.date
+        location = schedule.location
+    }
+
+    /// 제목이 입력되었는지 확인 (버튼 활성화용)
+    var isTitleValid: Bool {
+        !title.trimmed.isEmpty
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/ScheduleViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/ScheduleViewModel.swift
@@ -98,7 +98,6 @@ final class ScheduleViewModel: ObservableObject {
                 onSuccess: { [weak self] _ in
                     self?.isLoading = false
                     self?.isCompleted = true
-                    self?.resetForm()
                 },
                 onFailure: { [weak self] error in
                     self?.isLoading = false

--- a/HiTrip/Features/Schedule/Views/ScheduleCreateView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleCreateView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+// MARK: - ScheduleCreateView
+/// 일정 생성 화면 — CRUD의 [C] Create 담당
+///
+/// UI 구성:
+/// - 네비게이션 바 (취소 + 저장 버튼)
+/// - 제목 입력 (필수)
+/// - 날짜 선택 (DatePicker)
+/// - 장소 입력 (선택)
+/// - 설명 입력 (선택, TextEditor)
+///
+/// 동작:
+/// 1. 사용자가 폼 입력
+/// 2. "저장" 탭 → viewModel.createSchedule()
+/// 3. 성공 → isCompleted = true → 시트 닫기
+
+struct ScheduleCreateView: View {
+
+    @ObservedObject var viewModel: ScheduleViewModel
+
+    /// 시트를 닫기 위한 환경 변수
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                // 제목 (필수)
+                Section("제목") {
+                    TextField("일정 제목을 입력하세요", text: $viewModel.title)
+                }
+
+                // 날짜
+                Section("날짜") {
+                    DatePicker(
+                        "일정 날짜",
+                        selection: $viewModel.date,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                    .labelsHidden()
+                }
+
+                // 장소 (선택)
+                Section("장소") {
+                    TextField("장소를 입력하세요 (선택)", text: $viewModel.location)
+                }
+
+                // 설명 (선택)
+                Section("설명") {
+                    TextEditor(text: $viewModel.description)
+                        .frame(minHeight: 100)
+                }
+
+                // 에러 메시지
+                if let error = viewModel.errorMessage {
+                    Section {
+                        Text(error)
+                            .foregroundColor(HiTripColor.error)
+                            .font(.system(size: 14))
+                    }
+                }
+            }
+            .navigationTitle("일정 추가")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                // 왼쪽: 취소
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("취소") {
+                        dismiss()
+                    }
+                }
+                // 오른쪽: 저장
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("저장") {
+                        viewModel.createSchedule()
+                    }
+                    .disabled(!viewModel.isTitleValid)
+                    .fontWeight(.semibold)
+                }
+            }
+            // 생성 완료 시 시트 닫기
+            .onChange(of: viewModel.isCompleted) { completed in
+                if completed { dismiss() }
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/ScheduleDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleDetailView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+// MARK: - ScheduleDetailView
+/// 일정 상세/수정 화면 — CRUD의 [R] 상세 조회 + [U] Update + [D] Delete
+///
+/// 두 가지 모드:
+/// - 보기 모드: 일정 상세 정보 표시 + 수정/삭제 버튼
+/// - 수정 모드: ScheduleCreateView와 동일한 폼 (기존 데이터 채워짐)
+///
+/// 동작:
+/// - "수정" 탭 → 수정 모드 전환 → 폼에 기존 데이터 로드
+/// - "저장" 탭 → viewModel.updateSchedule() → 성공 시 시트 닫기
+/// - "삭제" 탭 → 확인 Alert → viewModel.deleteSchedule() → 시트 닫기
+
+struct ScheduleDetailView: View {
+
+    @ObservedObject var viewModel: ScheduleViewModel
+
+    /// 상세 보기 대상 일정
+    let schedule: Schedule
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// 보기 모드 / 수정 모드 전환
+    @State private var isEditing = false
+
+    /// 삭제 확인 Alert 표시 여부
+    @State private var showDeleteAlert = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isEditing {
+                    editForm
+                } else {
+                    detailContent
+                }
+            }
+            .navigationTitle(isEditing ? "일정 수정" : "일정 상세")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                // 왼쪽 버튼
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if isEditing {
+                        Button("취소") {
+                            isEditing = false
+                        }
+                    } else {
+                        Button("닫기") {
+                            dismiss()
+                        }
+                    }
+                }
+
+                // 오른쪽 버튼
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if isEditing {
+                        Button("저장") {
+                            viewModel.updateSchedule(schedule)
+                        }
+                        .disabled(!viewModel.isTitleValid)
+                        .fontWeight(.semibold)
+                    } else {
+                        Button("수정") {
+                            viewModel.loadScheduleForEdit(schedule)
+                            isEditing = true
+                        }
+                    }
+                }
+            }
+            // 수정 완료 시 시트 닫기
+            .onChange(of: viewModel.isCompleted) { completed in
+                if completed {
+                    viewModel.isCompleted = false
+                    dismiss()
+                }
+            }
+            // 삭제 확인 Alert
+            .alert("일정 삭제", isPresented: $showDeleteAlert) {
+                Button("삭제", role: .destructive) {
+                    viewModel.deleteSchedule(id: schedule.id)
+                    dismiss()
+                }
+                Button("취소", role: .cancel) {}
+            } message: {
+                Text("'\(schedule.title)' 일정을 삭제하시겠습니까?")
+            }
+        }
+    }
+
+    // MARK: - Detail Content (보기 모드)
+
+    /// 일정 상세 정보 표시
+    private var detailContent: some View {
+        List {
+            // 제목
+            Section("제목") {
+                Text(schedule.title)
+                    .font(.system(size: 16, weight: .medium))
+            }
+
+            // 날짜
+            Section("날짜") {
+                HStack(spacing: 8) {
+                    Image(systemName: "calendar")
+                        .foregroundColor(HiTripColor.primary800)
+                    Text(schedule.date.formatted(date: .long, time: .shortened))
+                }
+            }
+
+            // 장소 (있을 때만)
+            if !schedule.location.isEmpty {
+                Section("장소") {
+                    HStack(spacing: 8) {
+                        Image(systemName: "mappin.and.ellipse")
+                            .foregroundColor(HiTripColor.primary800)
+                        Text(schedule.location)
+                    }
+                }
+            }
+
+            // 설명 (있을 때만)
+            if !schedule.description.isEmpty {
+                Section("설명") {
+                    Text(schedule.description)
+                        .font(.system(size: 15))
+                        .foregroundColor(HiTripColor.textGrayA)
+                }
+            }
+
+            // 삭제 버튼
+            Section {
+                Button(role: .destructive) {
+                    showDeleteAlert = true
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("일정 삭제")
+                        Spacer()
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Edit Form (수정 모드)
+
+    /// 수정 폼 — ScheduleCreateView와 동일한 구조
+    private var editForm: some View {
+        Form {
+            Section("제목") {
+                TextField("일정 제목을 입력하세요", text: $viewModel.title)
+            }
+
+            Section("날짜") {
+                DatePicker(
+                    "일정 날짜",
+                    selection: $viewModel.date,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                .labelsHidden()
+            }
+
+            Section("장소") {
+                TextField("장소를 입력하세요 (선택)", text: $viewModel.location)
+            }
+
+            Section("설명") {
+                TextEditor(text: $viewModel.description)
+                    .frame(minHeight: 100)
+            }
+
+            if let error = viewModel.errorMessage {
+                Section {
+                    Text(error)
+                        .foregroundColor(HiTripColor.error)
+                        .font(.system(size: 14))
+                }
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/ScheduleListView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleListView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+// MARK: - ScheduleListView
+/// 일정 목록 화면 — CRUD의 [R] Read 담당
+///
+/// UI 구성:
+/// - 네비게이션 바 (타이틀 + "+" 추가 버튼)
+/// - 일정이 없으면 빈 상태 안내
+/// - 일정이 있으면 리스트로 표시 (날짜순 정렬)
+/// - 각 항목 탭 → 상세 화면으로 이동
+/// - 스와이프 → 삭제
+
+struct ScheduleListView: View {
+
+    @ObservedObject var viewModel: ScheduleViewModel
+
+    /// 일정 생성 화면 표시 여부
+    @State private var showCreateView = false
+
+    /// 상세 화면으로 이동할 일정
+    @State private var selectedSchedule: Schedule?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.schedules.isEmpty && !viewModel.isLoading {
+                    // 빈 상태
+                    emptyStateView
+                } else {
+                    // 일정 목록
+                    scheduleListContent
+                }
+            }
+            .navigationTitle("일정")
+            .toolbar {
+                // 오른쪽 상단 "+" 버튼
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        viewModel.resetForm()
+                        showCreateView = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .foregroundColor(HiTripColor.primary800)
+                    }
+                }
+            }
+            // 생성 화면 (시트로 표시)
+            .sheet(isPresented: $showCreateView) {
+                ScheduleCreateView(viewModel: viewModel)
+            }
+            // 상세 화면 (시트로 표시)
+            .sheet(item: $selectedSchedule) { schedule in
+                ScheduleDetailView(viewModel: viewModel, schedule: schedule)
+            }
+            // 생성/수정 화면 닫힌 후 목록 새로고침
+            .onChange(of: showCreateView) { isShowing in
+                if !isShowing { viewModel.fetchSchedules() }
+            }
+            .onChange(of: selectedSchedule) { selected in
+                if selected == nil { viewModel.fetchSchedules() }
+            }
+            // 화면 진입 시 목록 로드
+            .onAppear {
+                viewModel.fetchSchedules()
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    /// 일정이 없을 때 표시하는 안내 화면
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "calendar.badge.plus")
+                .font(.system(size: 50))
+                .foregroundColor(HiTripColor.gray300)
+
+            Text("등록된 일정이 없습니다")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundColor(HiTripColor.gray500)
+
+            Text("오른쪽 상단 +를 눌러 일정을 추가해보세요")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray400)
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Schedule List
+
+    /// 일정 목록 리스트
+    private var scheduleListContent: some View {
+        List {
+            ForEach(viewModel.schedules) { schedule in
+                scheduleRow(schedule)
+                    .contentShape(Rectangle()) // 전체 영역 탭 가능
+                    .onTapGesture {
+                        selectedSchedule = schedule
+                    }
+            }
+            // 스와이프 삭제
+            .onDelete { indexSet in
+                for index in indexSet {
+                    let schedule = viewModel.schedules[index]
+                    viewModel.deleteSchedule(id: schedule.id)
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - Schedule Row
+
+    /// 목록에서 하나의 일정을 표시하는 행
+    private func scheduleRow(_ schedule: Schedule) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // 제목
+            Text(schedule.title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            // 날짜
+            HStack(spacing: 4) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 12))
+                Text(schedule.date.formatted(date: .abbreviated, time: .shortened))
+                    .font(.system(size: 13))
+            }
+            .foregroundColor(HiTripColor.gray500)
+
+            // 장소 (있을 때만)
+            if !schedule.location.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "mappin")
+                        .font(.system(size: 12))
+                    Text(schedule.location)
+                        .font(.system(size: 13))
+                }
+                .foregroundColor(HiTripColor.gray400)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 관광 안내사와 관광객을 연결하는 여행 SaaS 플랫폼
 
-**2025 한국관광공사 × 카카오 관광데이터 활용 공모전** 출품작
+**2026 한국관광공사 × 카카오 관광데이터 활용 공모전** 출품예정
 
 <br>
 
@@ -60,20 +60,20 @@ Hi Trip은 관광 안내사(Guide)와 관광객(Tourist)을 매칭하여
 │  └──────────┘       └───────┬────────┘   │
 ├─────────────────────────────┼────────────┤
 │              Domain Layer   │            │
-│  ┌──────────┐       ┌──────┴─────────┐   │
+│  ┌──────────┐       ┌───────┴────────┐   │
 │  │  Entity  │       │    UseCase     │   │
-│  │  (Model) │       │ (비즈니스 로직)  │   │
+│  │  (Model) │       │  (비즈니스 로직)   │   │
 │  └──────────┘       └───────┬────────┘   │
 │                             │ Protocol   │
 ├─────────────────────────────┼────────────┤
 │               Data Layer    │            │
-│  ┌──────────────┐   ┌──────┴─────────┐   │
-│  │ NetworkService│   │  Repository   │   │
-│  │ (URLSession)  │   │  (구현체)      │   │
-│  └──────────────┘   └───────┬────────┘   │
-│                      ┌──────┴─────────┐   │
-│                      │KeychainManager │   │
-│                      └────────────────┘   │
+│  ┌───────────────┐   ┌──────┴─────────┐  │
+│  │ NetworkService│   │   Repository   │  │
+│  │ (URLSession)  │   │    (구현체)      │  │
+│  └───────────────┘   └───────┬────────┘  │
+│                      ┌───────┴────────┐  │
+│                      │KeychainManager │  │
+│                      └────────────────┘  │
 └──────────────────────────────────────────┘
 ```
 
@@ -110,14 +110,14 @@ HiTrip/
 
 ## 구현 로드맵
 
-### Phase 1 — 인증 플로우
+### Phase 1 — 인증 플로우 ✅
 - [x] Xcode 프로젝트 초기 설정
 - [x] Core Network layer (URLSession + RxSwift)
 - [x] Domain layer (Entity, Protocol, UseCase)
 - [x] Data layer (Repository, Keychain)
-- [ ] Login UI + ViewModel + Design System
-- [ ] SignUp 4단계 플로우
-- [ ] Unit Tests
+- [x] Login UI + ViewModel + Design System
+- [x] SignUp 4단계 플로우
+- [x] Unit Tests (LoginUseCase + SignUpUseCase)
 
 ### Phase 2 — 일정 관리
 - [ ] 일정 CRUD (안내사/관광객 뷰 분리)


### PR DESCRIPTION
## 개요
일정 관리 CRUD 기능을 Clean Architecture 패턴으로 구현합니다.
현재 메모리 기반 저장으로 동작하며, 서버 연동 시 Repository 구현체만 교체하면 됩니다.

## 변경 사항

### Domain Layer
- **Schedule.swift**: 일정 Entity (Identifiable + Codable + Equatable)
- **ScheduleRepositoryProtocol.swift**: CRUD 5개 메서드 인터페이스
- **ScheduleUseCase.swift**: 입력 검증 (제목 빈값) + Repository 위임

### Data Layer
- **ScheduleRepository.swift**: 메모리 배열 기반 CRUD 구현 (서버 연동 전 임시)

### Presentation Layer
- **ScheduleViewModel.swift**: CRUD UI 상태 관리 (@Published)
- **ScheduleListView.swift**: 일정 목록 + 빈 상태 안내 + 스와이프 삭제
- **ScheduleCreateView.swift**: 일정 생성 폼 (제목/날짜/장소/설명)
- **ScheduleDetailView.swift**: 상세 조회 + 보기↔수정 모드 전환 + 삭제 확인 Alert

### DI 연결
- **AppDIContainer.swift**: scheduleRepository → ScheduleUseCase → ScheduleViewModel 체인 추가
- **HomeView.swift**: 일정 탭 placeholder → ScheduleListView 교체

## 아키텍처

### CRUD ↔ 코드 매핑
```
[C] Create → ScheduleCreateView → ViewModel.createSchedule() → UseCase → Repository.create()
[R] Read   → ScheduleListView   → ViewModel.fetchSchedules() → UseCase → Repository.fetchAll()
[U] Update → ScheduleDetailView → ViewModel.updateSchedule() → UseCase → Repository.update()
[D] Delete → 스와이프 / 삭제버튼 → ViewModel.deleteSchedule() → UseCase → Repository.delete()
```

### 데이터 흐름
```
View (사용자 입력)
  → @Published 바인딩 (ScheduleViewModel)
    → ScheduleUseCase (입력 검증)
      → ScheduleRepository (메모리 배열 조작)
        → 결과 → ViewModel @Published 업데이트 → View 자동 렌더링
```

### 의존성 주입
```
AppDIContainer.makeScheduleViewModel()
  └─ ScheduleViewModel(scheduleUseCase:)
       └─ ScheduleUseCase(repository:)
            └─ ScheduleRepository() ← 나중에 서버 연동 시 이것만 교체
```

## 트러블슈팅

### 일정 생성 후 시트가 자동으로 닫히지 않음 부분 수정
- **증상**: "저장" 버튼 클릭 시 일정은 생성되지만 시트가 닫히지 않고, 폼만 초기화됨 (UX 관점에서 bad)
- **원인**: `createSchedule()` 성공 콜백에서 `isCompleted = true` 직후 `resetForm()`을 호출하는데, `resetForm()` 내부에서 `isCompleted = false`로 되돌림. SwiftUI의 `.onChange`가 `true`를 감지하기 전에 `false`로 바뀌어 `dismiss()`가 호출되지 않음
- **해결**: 성공 콜백에서 `resetForm()` 호출 제거. 시트가 닫힌 후 다시 열릴 때 `resetForm()`이 호출되도록 변경
- **배운 점**: SwiftUI의 `@Published` 값 변경과 `.onChange` 감지 사이에는 렌더링 사이클이 필요함. 같은 콜백 내에서 `true → false`로 즉시 되돌리면 View가 변화를 감지하지 못할 수 있음