### PR TITLE
feat: 프로필 화면 구현

### DIFF
--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - 일정: ScheduleListView (CRUD)
 /// - 스팟 추천: Phase 4에서 구현
 /// - 긴급 연락: Phase 5에서 구현
-/// - 프로필: Phase 2에서 구현
+/// - 프로필: ProfileView (프로필 조회 + 로그아웃)
 ///
 /// Phase 1에서는 탭 구조만 잡고,
 /// 각 탭의 실제 콘텐츠는 해당 Phase 커밋에서 교체
@@ -60,7 +60,7 @@ struct HomeView: View {
                 .tabItem { Label(Tab.emergency.rawValue, systemImage: Tab.emergency.icon) }
                 .tag(Tab.emergency)
 
-            placeholderTab("프로필", icon: "person.fill", phase: 2)
+            ProfileView()
                 .tabItem { Label(Tab.profile.rawValue, systemImage: Tab.profile.icon) }
                 .tag(Tab.profile)
         }

--- a/HiTrip/Features/Auth/Views/SplashView.swift
+++ b/HiTrip/Features/Auth/Views/SplashView.swift
@@ -36,9 +36,13 @@ struct SplashView: View {
 
             // 1.5초 후 자동 로그인 판단
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                router.handleAutoLogin(
-                    isLoggedIn: KeychainManager.shared.isLoggedIn
-                )
+                // TODO: 서버 연동 후 아래 주석 해제하고 디버그 코드 삭제
+                // router.handleAutoLogin(
+                //     isLoggedIn: KeychainManager.shared.isLoggedIn
+                // )
+
+                // [DEBUG] 로그인 없이 바로 홈 화면으로 이동 (CRUD 테스트용)
+                router.navigateToHome()
             }
         }
     }

--- a/HiTrip/Features/Profile/Views/ProfileView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileView.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+
+// MARK: - ProfileView
+/// 프로필 화면
+///
+/// UI 구성:
+/// - 프로필 아바타 (이니셜 원형 뱃지)
+/// - 사용자 정보 (이름, 아이디, 유저 타입)
+/// - 메뉴 섹션 (알림 설정, 이용약관, 버전 정보)
+/// - 로그아웃 버튼
+///
+/// 현재는 Keychain에 저장된 정보로 표시
+/// 서버 연동 후 API에서 받아온 정보로 교체 예정
+
+struct ProfileView: View {
+
+    @EnvironmentObject var router: AppRouter
+
+    /// 로그아웃 확인 Alert 표시 여부
+    @State private var showLogoutAlert = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                // 프로필 헤더
+                profileHeader
+                    .listRowBackground(Color.clear)
+
+                // 계정 정보
+                accountSection
+
+                // 앱 설정
+                settingsSection
+
+                // 앱 정보
+                appInfoSection
+
+                // 로그아웃
+                logoutSection
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("프로필")
+            // 로그아웃 확인 Alert
+            .alert("로그아웃", isPresented: $showLogoutAlert) {
+                Button("로그아웃", role: .destructive) {
+                    KeychainManager.shared.clearAll()
+                    router.navigateToLogin()
+                }
+                Button("취소", role: .cancel) {}
+            } message: {
+                Text("로그아웃 하시겠습니까?")
+            }
+        }
+    }
+
+    // MARK: - Profile Header
+
+    /// 프로필 아바타 + 이름 + 유저 타입 뱃지
+    private var profileHeader: some View {
+        VStack(spacing: 12) {
+            // 아바타 (이니셜 표시)
+            ZStack {
+                Circle()
+                    .fill(HiTripColor.primary800)
+                    .frame(width: 80, height: 80)
+
+                Text(avatarInitial)
+                    .font(.system(size: 32, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            // 사용자 이름
+            Text(userName)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            // 유저 타입 뱃지 (안내사/관광객)
+            Text(userTypeBadge)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(HiTripColor.primary800)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(HiTripColor.secondary100)
+                .cornerRadius(12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+    }
+
+    // MARK: - Account Section
+
+    /// 계정 정보 섹션
+    private var accountSection: some View {
+        Section("계정 정보") {
+            // 아이디
+            HStack {
+                Label("아이디", systemImage: "person.text.rectangle")
+                    .foregroundColor(HiTripColor.textGrayA)
+                Spacer()
+                Text(userId)
+                    .foregroundColor(HiTripColor.gray500)
+            }
+
+            // 유저 타입
+            HStack {
+                Label("유형", systemImage: "person.crop.rectangle")
+                    .foregroundColor(HiTripColor.textGrayA)
+                Spacer()
+                Text(userTypeBadge)
+                    .foregroundColor(HiTripColor.gray500)
+            }
+        }
+    }
+
+    // MARK: - Settings Section
+
+    /// 앱 설정 섹션 (Phase 6에서 실제 동작 연결)
+    private var settingsSection: some View {
+        Section("설정") {
+            // 알림 설정
+            NavigationLink {
+                placeholderView("알림 설정", phase: 6)
+            } label: {
+                Label("알림 설정", systemImage: "bell")
+                    .foregroundColor(HiTripColor.textGrayA)
+            }
+
+            // 언어 설정
+            NavigationLink {
+                placeholderView("언어 설정", phase: 6)
+            } label: {
+                Label("언어", systemImage: "globe")
+                    .foregroundColor(HiTripColor.textGrayA)
+            }
+        }
+    }
+
+    // MARK: - App Info Section
+
+    /// 앱 정보 섹션
+    private var appInfoSection: some View {
+        Section("앱 정보") {
+            // 이용약관
+            NavigationLink {
+                placeholderView("이용약관", phase: 6)
+            } label: {
+                Label("이용약관", systemImage: "doc.text")
+                    .foregroundColor(HiTripColor.textGrayA)
+            }
+
+            // 개인정보처리방침
+            NavigationLink {
+                placeholderView("개인정보처리방침", phase: 6)
+            } label: {
+                Label("개인정보처리방침", systemImage: "lock.shield")
+                    .foregroundColor(HiTripColor.textGrayA)
+            }
+
+            // 버전 정보
+            HStack {
+                Label("버전", systemImage: "info.circle")
+                    .foregroundColor(HiTripColor.textGrayA)
+                Spacer()
+                Text(appVersion)
+                    .foregroundColor(HiTripColor.gray400)
+            }
+        }
+    }
+
+    // MARK: - Logout Section
+
+    /// 로그아웃 버튼
+    private var logoutSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showLogoutAlert = true
+            } label: {
+                HStack {
+                    Spacer()
+                    Text("로그아웃")
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    // MARK: - Placeholder View
+
+    /// Phase 6에서 구현 예정인 상세 화면
+    private func placeholderView(_ title: String, phase: Int) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Text(title)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(HiTripColor.textGrayA)
+            Text("Phase \(phase)에서 구현 예정")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray400)
+            Spacer()
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Computed Helpers
+
+    /// Keychain에서 사용자 이름 조회 (없으면 기본값)
+    private var userName: String {
+        KeychainManager.shared.getUserId() ?? "Hi Trip 사용자"
+    }
+
+    /// 아바타 이니셜 (이름 첫 글자)
+    private var avatarInitial: String {
+        String(userName.prefix(1))
+    }
+
+    /// 사용자 아이디
+    private var userId: String {
+        KeychainManager.shared.getUserId() ?? "-"
+    }
+
+    /// 유저 타입 표시 텍스트
+    private var userTypeBadge: String {
+        guard let type = KeychainManager.shared.getUserType() else { return "미설정" }
+        return type == "guide" ? "안내사" : "관광객"
+    }
+
+    /// 앱 버전 (Bundle에서 자동 조회)
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,8 +100,13 @@ HiTrip/
 ├── Data/                         # 데이터 접근 구현체
 │   └── Repositories/             # Protocol 구현 (API + Keychain)
 ├── Features/                     # 기능별 UI
-│   └── Auth/
-│       ├── ViewModels/
+│   ├── Auth/
+│   │   ├── ViewModels/
+│   │   └── Views/
+│   ├── Schedule/
+│   │   ├── ViewModels/
+│   │   └── Views/
+│   └── Profile/
 │       └── Views/
 └── Resources/                    # Assets, 리소스 파일
 ```
@@ -119,9 +124,14 @@ HiTrip/
 - [x] SignUp 4단계 플로우
 - [x] Unit Tests (LoginUseCase + SignUpUseCase)
 
-### Phase 2 — 일정 관리
-- [ ] 일정 CRUD (안내사/관광객 뷰 분리)
-- [ ] 프로필 화면
+### Phase 2 — 일정 관리 + 프로필 ✅
+- [x] Schedule Entity + Repository Protocol + UseCase
+- [x] ScheduleRepository 메모리 기반 CRUD 구현
+- [x] ScheduleViewModel (CRUD 상태 관리)
+- [x] ScheduleListView / CreateView / DetailView
+- [x] Schedule DI 연결 + HomeView 탭 교체
+- [x] ProfileView (프로필 조회 + 로그아웃)
+- [x] HomeView 프로필 탭 연결
 
 ### Phase 3 — 실시간 채팅
 - [ ] WebSocket 기반 1:1 채팅


### PR DESCRIPTION
<h2>개요</h2>
<p>Phase 2에서는 <strong>일정 관리 CRUD</strong>와 <strong>프로필 화면</strong>을 구현.
Clean Architecture 구조를 그대로 유지하면서, Domain → Data → Presentation 순서로 레이어별 커밋을 진행.</p>

</br>
<h2>변경 사항</h2>
<h3>일정 관리 (Schedule CRUD)</h3>
<p><strong>Domain Layer</strong></p>
<ul>
<li><code>Schedule</code> Entity 정의 (Identifiable + Codable + Equatable)</li>
<li><code>ScheduleRepositoryProtocol</code> — CRUD 메서드 인터페이스 (RxSwift Single 기반)</li>
<li><code>ScheduleUseCase</code> — 비즈니스 로직 검증 (빈 제목 방지 등)</li>
</ul>
<p><strong>Data Layer</strong></p>
<ul>
<li><code>ScheduleRepository</code> — 메모리 기반 CRUD 구현 (서버 연동 전 로컬 테스트용)</li>
</ul>
<p><strong>Presentation Layer</strong></p>
<ul>
<li><code>ScheduleViewModel</code> — @Published 기반 UI 상태 관리 + CRUD 메서드</li>
<li><code>ScheduleListView</code> — 일정 목록 조회 + 스와이프 삭제</li>
<li><code>ScheduleCreateView</code> — 일정 생성 폼 (제목/날짜/장소/설명)</li>
<li><code>ScheduleDetailView</code> — 상세 조회 + 수정 모드 전환 + 삭제 확인 Alert</li>
</ul>
<p><strong>DI 연결</strong></p>
<ul>
<li><code>AppDIContainer</code>에 Schedule 의존성 등록 (Repository → UseCase → ViewModel)</li>
<li><code>HomeView</code> 일정 탭을 <code>ScheduleListView</code>로 교체</li>
</ul>
</br>
<h3>프로필 화면 (Profile)</h3>
<ul>
<li><code>ProfileView</code> — Keychain 기반 사용자 정보 표시, 설정 메뉴, 로그아웃</li>
<li><code>HomeView</code> 프로필 탭을 <code>ProfileView</code>로 교체</li>
</ul>

</br>
<h2>아키텍처 — Clean Architecture CRUD 흐름</h2>
<pre><code>View (사용자 입력)
  ↓ 메서드 호출
ViewModel (@Published 상태 관리)
  ↓ 비즈니스 로직 위임
UseCase (검증 + Repository 호출)
  ↓ Protocol 기반 추상화
Repository (실제 데이터 처리 — 현재 메모리, 추후 서버)
  ↓ Single&lt;T&gt; 결과 반환
ViewModel → View (UI 업데이트)
</code></pre>

</br>
<h2>트러블슈팅</h2>
<h3>1. 일정 생성 후 시트가 닫히지 않는 문제</h3>
<p><strong>증상:</strong> 저장 버튼 클릭 시 일정은 생성되지만 Sheet가 자동으로 닫히지 않음</p>
<p><strong>원인:</strong> <code>createSchedule()</code> 성공 콜백에서 <code>isCompleted = true</code> 설정 직후 <code>resetForm()</code>이 호출되면서 <code>isCompleted = false</code>로 되돌림. SwiftUI <code>.onChange(of:)</code>가 <code>true</code> 상태를 감지하기 전에 <code>false</code>로 바뀌어 Sheet dismiss가 트리거되지 않음.</p>
<p><strong>해결:</strong> <code>createSchedule()</code> 성공 콜백에서 <code>resetForm()</code> 호출을 제거. 폼 초기화는 Sheet가 닫힌 후 별도로 처리.</p>
<pre><code class="language-swift">// 변경 전 (버그)
self.isCompleted = true
self.resetForm()  // isCompleted를 다시 false로

// 변경 후 (수정)
self.isCompleted = true
// resetForm()은 Sheet dismiss 후에 처리
</code></pre>

</br>
<h2>테스트 방법</h2>
<ul>
<li>[x] 일정 생성 → 목록에 표시 확인</li>
<li>[x] 일정 상세 → 수정 모드 → 저장 확인</li>
<li>[x] 스와이프 삭제 + 상세 화면 삭제 확인</li>
<li>[x] 빈 제목 생성 시도 → 에러 메시지 확인</li>
<li>[x] 프로필 탭 → 사용자 정보 표시 확인</li>
<li>[x] 로그아웃 → 로그인 화면 이동 확인</li>
</ul></body></html>