### PR TITLE
feat: 긴급 연락처 기능 추가

### DIFF
--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -58,6 +58,11 @@ final class AppDIContainer {
         ChatRepository()
     }()
 
+    /// 긴급 연락처 Repository — 프리셋 번호 + 개인 연락처
+    private lazy var emergencyRepository: EmergencyRepositoryProtocol = {
+        EmergencyRepository()
+    }()
+
     // MARK: - Init
 
     /// 프로덕션용 — 싱글턴으로만 사용
@@ -104,6 +109,10 @@ final class AppDIContainer {
         ChatUseCase(repository: chatRepository)
     }
 
+    func makeEmergencyUseCase() -> EmergencyUseCase {
+        EmergencyUseCase(repository: emergencyRepository)
+    }
+
     // MARK: - ViewModel Factory
 
     /// RootView에서 호출하여 LoginView에 주입
@@ -124,5 +133,10 @@ final class AppDIContainer {
     /// HomeView의 채팅 탭에서 사용
     func makeChatViewModel() -> ChatViewModel {
         ChatViewModel(chatUseCase: makeChatUseCase())
+    }
+
+    /// HomeView의 긴급 연락 탭에서 사용
+    func makeEmergencyViewModel() -> EmergencyViewModel {
+        EmergencyViewModel(emergencyUseCase: makeEmergencyUseCase())
     }
 }

--- a/HiTrip/Data/Repositories/EmergencyRepository.swift
+++ b/HiTrip/Data/Repositories/EmergencyRepository.swift
@@ -1,0 +1,148 @@
+import Foundation
+import RxSwift
+
+// MARK: - EmergencyRepository
+/// 긴급 연락처 저장소 구현체 (메모리 저장)
+///
+/// 이전 Repository들과 다른 점:
+/// - 초기화 시 **프리셋 긴급번호**가 미리 등록되어 있음
+/// - 프리셋(isPreset: true)은 삭제 불가
+///
+/// 프리셋 연락처:
+/// - 경찰 (112), 소방/구급 (119)
+/// - 응급의료정보센터 (1339)
+/// - 관광불편신고 (1330), 외국인종합안내 (1345)
+
+final class EmergencyRepository: EmergencyRepositoryProtocol {
+
+    // MARK: - 저장소
+
+    /// 긴급 연락처 배열 — 프리셋 + 개인 연락처
+    private var contacts: [EmergencyContact]
+
+    // MARK: - Init
+
+    init() {
+        // 프리셋 긴급번호 초기 등록
+        self.contacts = Self.presetContacts
+    }
+
+    // MARK: - 프리셋 긴급번호
+
+    /// 기본 제공 긴급 연락처 목록
+    /// 여행 중 필요한 핵심 번호들
+    private static let presetContacts: [EmergencyContact] = [
+        // 긴급 기관
+        EmergencyContact(
+            name: "경찰",
+            phoneNumber: "112",
+            category: .emergency,
+            isPreset: true,
+            iconName: "shield.fill"
+        ),
+        EmergencyContact(
+            name: "소방/구급",
+            phoneNumber: "119",
+            category: .emergency,
+            isPreset: true,
+            iconName: "flame.fill"
+        ),
+
+        // 의료
+        EmergencyContact(
+            name: "응급의료정보센터",
+            phoneNumber: "1339",
+            category: .medical,
+            isPreset: true,
+            iconName: "cross.fill"
+        ),
+
+        // 관광
+        EmergencyContact(
+            name: "관광불편신고",
+            phoneNumber: "1330",
+            category: .tourism,
+            isPreset: true,
+            iconName: "exclamationmark.bubble.fill"
+        ),
+        EmergencyContact(
+            name: "외국인종합안내",
+            phoneNumber: "1345",
+            category: .tourism,
+            isPreset: true,
+            iconName: "globe"
+        ),
+    ]
+
+    // MARK: - Read
+
+    /// 전체 연락처 조회 — 카테고리 순서대로 반환
+    func fetchAll() -> Single<[EmergencyContact]> {
+        return Single.create { [weak self] single in
+            let sorted = self?.contacts ?? []
+            single(.success(sorted))
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - Create
+
+    /// 개인 연락처 추가
+    func addContact(contact: EmergencyContact) -> Single<EmergencyContact> {
+        return Single.create { [weak self] single in
+            self?.contacts.append(contact)
+            single(.success(contact))
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - Update
+
+    /// 개인 연락처 수정 — 프리셋은 수정 불가
+    func updateContact(contact: EmergencyContact) -> Single<EmergencyContact> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(EmergencyError.notFound))
+                return Disposables.create()
+            }
+
+            if let index = self.contacts.firstIndex(where: { $0.id == contact.id }) {
+                // 프리셋은 수정 불가
+                if self.contacts[index].isPreset {
+                    single(.failure(EmergencyError.cannotDeletePreset))
+                } else {
+                    self.contacts[index] = contact
+                    single(.success(contact))
+                }
+            } else {
+                single(.failure(EmergencyError.notFound))
+            }
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - Delete
+
+    /// 개인 연락처 삭제 — 프리셋은 삭제 불가
+    func deleteContact(id: UUID) -> Single<Void> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(EmergencyError.notFound))
+                return Disposables.create()
+            }
+
+            if let index = self.contacts.firstIndex(where: { $0.id == id }) {
+                // 프리셋 삭제 방지
+                if self.contacts[index].isPreset {
+                    single(.failure(EmergencyError.cannotDeletePreset))
+                } else {
+                    self.contacts.remove(at: index)
+                    single(.success(()))
+                }
+            } else {
+                single(.failure(EmergencyError.notFound))
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/HiTrip/Domain/Entities/EmergencyContact.swift
+++ b/HiTrip/Domain/Entities/EmergencyContact.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+// MARK: - EmergencyContact
+/// 긴급 연락처 데이터 모델
+///
+/// 두 가지 종류의 연락처를 하나의 모델로 관리:
+/// 1. 프리셋 (preset): 112, 119, 관광불편신고 등 기본 제공 번호
+/// 2. 개인 (personal): 사용자가 직접 추가한 보호자/동행자 연락처
+///
+/// 필드 설계 기준:
+/// - id: 고유 식별자 (UUID)
+/// - name: 연락처 이름 (예: "경찰", "엄마")
+/// - phoneNumber: 전화번호 (예: "112", "010-1234-5678")
+/// - category: 분류 (긴급기관/의료/관광/개인)
+/// - isPreset: 기본 제공 여부 (true면 삭제 불가)
+/// - iconName: SF Symbol 아이콘 이름
+
+struct EmergencyContact: Identifiable, Codable, Equatable {
+
+    /// 고유 식별자
+    let id: UUID
+
+    /// 연락처 이름
+    /// 예: "경찰 (112)", "엄마", "관광불편신고"
+    var name: String
+
+    /// 전화번호
+    /// 예: "112", "010-1234-5678", "1330"
+    var phoneNumber: String
+
+    /// 분류 카테고리
+    var category: ContactCategory
+
+    /// 기본 제공 연락처 여부
+    /// true: 삭제 불가 (112, 119 등)
+    /// false: 사용자가 추가한 연락처 (삭제 가능)
+    let isPreset: Bool
+
+    /// SF Symbol 아이콘 이름
+    /// 예: "shield.fill", "cross.fill", "phone.fill"
+    var iconName: String
+
+    /// 기본 생성자
+    init(
+        id: UUID = UUID(),
+        name: String,
+        phoneNumber: String,
+        category: ContactCategory,
+        isPreset: Bool = false,
+        iconName: String = "phone.fill"
+    ) {
+        self.id = id
+        self.name = name
+        self.phoneNumber = phoneNumber
+        self.category = category
+        self.isPreset = isPreset
+        self.iconName = iconName
+    }
+}
+
+// MARK: - ContactCategory
+/// 긴급 연락처 분류
+///
+/// 화면에서 섹션별로 그룹핑하기 위한 카테고리
+enum ContactCategory: String, Codable, CaseIterable, Equatable {
+    /// 긴급 기관 (경찰, 소방)
+    case emergency = "긴급"
+    /// 의료 기관 (응급의료정보센터)
+    case medical = "의료"
+    /// 관광 관련 (관광불편신고, 외국인종합안내)
+    case tourism = "관광"
+    /// 개인 연락처 (보호자, 동행자)
+    case personal = "개인"
+}

--- a/HiTrip/Domain/Repositories/EmergencyRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/EmergencyRepositoryProtocol.swift
@@ -1,0 +1,24 @@
+import Foundation
+import RxSwift
+
+// MARK: - EmergencyRepositoryProtocol
+/// 긴급 연락처 데이터 접근 인터페이스 (Domain 레이어)
+///
+/// Schedule, Chat과 동일한 DIP 패턴
+/// - 프리셋 연락처(112, 119 등) + 개인 연락처를 함께 관리
+/// - 추후 서버 연동 시 구현체만 교체
+
+protocol EmergencyRepositoryProtocol {
+
+    /// 전체 연락처 조회 — 프리셋 + 개인 연락처 모두 포함
+    func fetchAll() -> Single<[EmergencyContact]>
+
+    /// 개인 연락처 추가
+    func addContact(contact: EmergencyContact) -> Single<EmergencyContact>
+
+    /// 개인 연락처 수정
+    func updateContact(contact: EmergencyContact) -> Single<EmergencyContact>
+
+    /// 개인 연락처 삭제 — 프리셋은 삭제 불가
+    func deleteContact(id: UUID) -> Single<Void>
+}

--- a/HiTrip/Domain/UseCases/EmergencyUseCase.swift
+++ b/HiTrip/Domain/UseCases/EmergencyUseCase.swift
@@ -1,0 +1,91 @@
+import Foundation
+import RxSwift
+
+// MARK: - EmergencyUseCase
+/// 긴급 연락처 비즈니스 로직
+///
+/// 검증 규칙:
+/// - 이름, 전화번호가 비어있으면 에러
+/// - 프리셋 연락처는 삭제 불가 (Repository에서도 체크하지만 UseCase에서 먼저 차단)
+///
+/// 이전 UseCase들과 동일한 패턴:
+/// - Protocol에만 의존 (DIP)
+/// - 검증 실패 시 Repository 호출 안 함
+
+final class EmergencyUseCase {
+
+    private let repository: EmergencyRepositoryProtocol
+
+    init(repository: EmergencyRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Read
+
+    /// 전체 연락처 조회
+    func fetchAll() -> Single<[EmergencyContact]> {
+        return repository.fetchAll()
+    }
+
+    // MARK: - Create
+
+    /// 개인 연락처 추가
+    ///
+    /// 검증: 이름과 전화번호가 비어있으면 에러
+    func addContact(contact: EmergencyContact) -> Single<EmergencyContact> {
+        guard !contact.name.trimmed.isEmpty else {
+            return .error(EmergencyError.emptyName)
+        }
+        guard !contact.phoneNumber.trimmed.isEmpty else {
+            return .error(EmergencyError.emptyPhoneNumber)
+        }
+
+        return repository.addContact(contact: contact)
+    }
+
+    // MARK: - Update
+
+    /// 개인 연락처 수정
+    func updateContact(contact: EmergencyContact) -> Single<EmergencyContact> {
+        guard !contact.name.trimmed.isEmpty else {
+            return .error(EmergencyError.emptyName)
+        }
+        guard !contact.phoneNumber.trimmed.isEmpty else {
+            return .error(EmergencyError.emptyPhoneNumber)
+        }
+
+        return repository.updateContact(contact: contact)
+    }
+
+    // MARK: - Delete
+
+    /// 연락처 삭제
+    func deleteContact(id: UUID) -> Single<Void> {
+        return repository.deleteContact(id: id)
+    }
+}
+
+// MARK: - EmergencyError
+/// 긴급 연락처 관련 에러
+enum EmergencyError: LocalizedError, Equatable {
+    case emptyName
+    case emptyPhoneNumber
+    case cannotDeletePreset
+    case notFound
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "이름을 입력해주세요."
+        case .emptyPhoneNumber:
+            return "전화번호를 입력해주세요."
+        case .cannotDeletePreset:
+            return "기본 긴급 연락처는 삭제할 수 없습니다."
+        case .notFound:
+            return "연락처를 찾을 수 없습니다."
+        case .serverError(let msg):
+            return msg
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - 일정: ScheduleListView (CRUD)
 /// - 채팅: ChatListView (1:1 메시지)
 /// - 스팟 추천: Phase 4에서 구현
-/// - 긴급 연락: Phase 5에서 구현
+/// - 긴급 연락: EmergencyView (긴급 전화 + 연락처 관리)
 /// - 프로필: ProfileView (프로필 조회 + 로그아웃)
 ///
 /// Phase 1에서는 탭 구조만 잡고,
@@ -65,7 +65,9 @@ struct HomeView: View {
                 .tabItem { Label(Tab.spots.rawValue, systemImage: Tab.spots.icon) }
                 .tag(Tab.spots)
 
-            placeholderTab("긴급 연락", icon: "exclamationmark.triangle.fill", phase: 5)
+            EmergencyView(
+                    viewModel: AppDIContainer.shared.makeEmergencyViewModel()
+                )
                 .tabItem { Label(Tab.emergency.rawValue, systemImage: Tab.emergency.icon) }
                 .tag(Tab.emergency)
 

--- a/HiTrip/Features/Emergency/ViewModels/EmergencyViewModel.swift
+++ b/HiTrip/Features/Emergency/ViewModels/EmergencyViewModel.swift
@@ -1,0 +1,152 @@
+import Foundation
+import RxSwift
+
+// MARK: - EmergencyViewModel
+/// 긴급 연락처 화면의 ViewModel
+///
+/// 이전 ViewModel들과 동일한 @Published 패턴
+/// 추가 기능: 카테고리별 그룹핑, 전화 걸기 URL 생성
+
+final class EmergencyViewModel: ObservableObject {
+
+    // MARK: - 목록 상태
+
+    /// 전체 연락처 목록
+    @Published var contacts: [EmergencyContact] = []
+
+    // MARK: - 입력 폼 상태 (개인 연락처 추가용)
+
+    /// 이름 입력
+    @Published var name: String = ""
+
+    /// 전화번호 입력
+    @Published var phoneNumber: String = ""
+
+    /// 카테고리 — 개인 연락처는 항상 .personal
+    @Published var category: ContactCategory = .personal
+
+    // MARK: - UI 상태
+
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var isCompleted: Bool = false
+
+    // MARK: - Dependencies
+
+    private let emergencyUseCase: EmergencyUseCase
+    private let disposeBag = DisposeBag()
+
+    init(emergencyUseCase: EmergencyUseCase) {
+        self.emergencyUseCase = emergencyUseCase
+    }
+
+    // MARK: - Read
+
+    /// 전체 연락처 불러오기
+    func fetchContacts() {
+        isLoading = true
+
+        emergencyUseCase.fetchAll()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] contacts in
+                    self?.isLoading = false
+                    self?.contacts = contacts
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Create
+
+    /// 개인 연락처 추가
+    func addContact() {
+        let newContact = EmergencyContact(
+            name: name.trimmed,
+            phoneNumber: phoneNumber.trimmed,
+            category: .personal,
+            isPreset: false,
+            iconName: "person.fill"
+        )
+
+        isLoading = true
+        errorMessage = nil
+
+        emergencyUseCase.addContact(contact: newContact)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoading = false
+                    self?.isCompleted = true
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Delete
+
+    /// 개인 연락처 삭제
+    func deleteContact(id: UUID) {
+        isLoading = true
+        errorMessage = nil
+
+        emergencyUseCase.deleteContact(id: id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isLoading = false
+                    self?.contacts.removeAll { $0.id == id }
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 카테고리별 그룹핑
+
+    /// 카테고리 순서대로 연락처를 그룹핑하여 반환
+    /// Section 표시에 사용: "긴급", "의료", "관광", "개인"
+    func contactsByCategory(_ category: ContactCategory) -> [EmergencyContact] {
+        contacts.filter { $0.category == category }
+    }
+
+    /// 개인 연락처가 있는지 (섹션 표시 여부 판단용)
+    var hasPersonalContacts: Bool {
+        contacts.contains { $0.category == .personal }
+    }
+
+    // MARK: - 전화 걸기
+
+    /// 전화번호로 tel:// URL 생성
+    /// iOS에서 이 URL을 열면 전화 앱이 실행됨
+    func makeCallURL(phoneNumber: String) -> URL? {
+        let cleaned = phoneNumber.replacingOccurrences(of: "-", with: "")
+        return URL(string: "tel://\(cleaned)")
+    }
+
+    // MARK: - 폼 헬퍼
+
+    /// 폼 초기화
+    func resetForm() {
+        name = ""
+        phoneNumber = ""
+        isCompleted = false
+        errorMessage = nil
+    }
+
+    /// 폼 유효성 (추가 버튼 활성화용)
+    var isFormValid: Bool {
+        !name.trimmed.isEmpty && !phoneNumber.trimmed.isEmpty
+    }
+}

--- a/HiTrip/Features/Emergency/Views/EmergencyAddView.swift
+++ b/HiTrip/Features/Emergency/Views/EmergencyAddView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+// MARK: - EmergencyAddView
+/// 개인 긴급 연락처 추가 화면 (Sheet)
+///
+/// ChatCreateView, ScheduleCreateView와 동일한 패턴:
+/// - Form 입력 → ViewModel 호출 → isCompleted로 시트 닫기
+
+struct EmergencyAddView: View {
+
+    @ObservedObject var viewModel: EmergencyViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("연락처 정보") {
+                    TextField("이름 (예: 엄마, 동행자)", text: $viewModel.name)
+
+                    TextField("전화번호 (예: 010-1234-5678)", text: $viewModel.phoneNumber)
+                        .keyboardType(.phonePad)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundColor(HiTripColor.error)
+                            .font(.system(size: 14))
+                    }
+                }
+            }
+            .navigationTitle("연락처 추가")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("취소") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("추가") {
+                        viewModel.addContact()
+                    }
+                    .disabled(!viewModel.isFormValid)
+                    .fontWeight(.semibold)
+                }
+            }
+            .onChange(of: viewModel.isCompleted) { completed in
+                if completed {
+                    dismiss()
+                }
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Emergency/Views/EmergencyView.swift
+++ b/HiTrip/Features/Emergency/Views/EmergencyView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+// MARK: - EmergencyView
+/// 긴급 연락처 화면
+///
+/// 구성:
+/// - 상단: 긴급 전화 퀵버튼 (112, 119 원탭 호출)
+/// - 중간: 카테고리별 연락처 리스트 (긴급/의료/관광/개인)
+/// - 개인 연락처 추가/삭제 가능
+///
+/// 새로운 패턴:
+/// - openURL: 전화 걸기 (tel://) 용
+/// - Section + ForEach with category: enum 기반 그룹핑
+
+struct EmergencyView: View {
+
+    @ObservedObject var viewModel: EmergencyViewModel
+    @Environment(\.openURL) private var openURL
+    @State private var showAddSheet = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                // MARK: - 긴급 전화 퀵버튼
+                quickCallSection
+
+                // MARK: - 카테고리별 연락처
+                ForEach(ContactCategory.allCases, id: \.self) { category in
+                    let categoryContacts = viewModel.contactsByCategory(category)
+                    if !categoryContacts.isEmpty {
+                        Section(category.rawValue) {
+                            ForEach(categoryContacts) { contact in
+                                contactRow(contact)
+                            }
+                            .onDelete { indexSet in
+                                deleteContacts(in: categoryContacts, at: indexSet)
+                            }
+                        }
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("긴급 연락")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddSheet) {
+                EmergencyAddView(viewModel: viewModel)
+            }
+            .onChange(of: showAddSheet) { isPresented in
+                if !isPresented {
+                    viewModel.fetchContacts()
+                    viewModel.resetForm()
+                }
+            }
+            .onAppear {
+                viewModel.fetchContacts()
+            }
+        }
+    }
+
+    // MARK: - 긴급 전화 퀵버튼
+
+    /// 112, 119 원탭 전화 버튼
+    /// 화면 최상단에 크게 배치하여 긴급 상황에서 빠르게 접근
+    private var quickCallSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                quickCallButton(
+                    title: "경찰",
+                    number: "112",
+                    icon: "shield.fill",
+                    color: .blue
+                )
+
+                quickCallButton(
+                    title: "소방/구급",
+                    number: "119",
+                    icon: "flame.fill",
+                    color: .red
+                )
+            }
+            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+        }
+    }
+
+    /// 퀵 전화 버튼 개별 UI
+    private func quickCallButton(
+        title: String,
+        number: String,
+        icon: String,
+        color: Color
+    ) -> some View {
+        Button {
+            if let url = viewModel.makeCallURL(phoneNumber: number) {
+                openURL(url)
+            }
+        } label: {
+            VStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 28))
+                    .foregroundColor(.white)
+
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+
+                Text(number)
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.white)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(color)
+            .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - 연락처 행
+
+    /// 각 연락처의 한 줄 표시
+    /// 탭하면 전화 연결
+    private func contactRow(_ contact: EmergencyContact) -> some View {
+        Button {
+            if let url = viewModel.makeCallURL(phoneNumber: contact.phoneNumber) {
+                openURL(url)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                // 아이콘
+                Image(systemName: contact.iconName)
+                    .font(.system(size: 18))
+                    .foregroundColor(iconColor(for: contact.category))
+                    .frame(width: 32, height: 32)
+
+                // 이름 + 전화번호
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(contact.name)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(HiTripColor.textGrayA)
+
+                    Text(contact.phoneNumber)
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.gray400)
+                }
+
+                Spacer()
+
+                // 전화 아이콘
+                Image(systemName: "phone.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(HiTripColor.primary800)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - 헬퍼
+
+    /// 카테고리별 아이콘 색상
+    private func iconColor(for category: ContactCategory) -> Color {
+        switch category {
+        case .emergency: return .red
+        case .medical:   return .orange
+        case .tourism:   return HiTripColor.primary800
+        case .personal:  return .gray
+        }
+    }
+
+    /// 스와이프 삭제 처리 — 프리셋은 삭제 불가
+    private func deleteContacts(
+        in categoryContacts: [EmergencyContact],
+        at indexSet: IndexSet
+    ) {
+        for index in indexSet {
+            let contact = categoryContacts[index]
+            if !contact.isPreset {
+                viewModel.deleteContact(id: contact.id)
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ HiTrip/
 │   ├── Chat/
 │   │   ├── ViewModels/
 │   │   └── Views/
+│   ├── Emergency/
+│   │   ├── ViewModels/
+│   │   └── Views/
 │   └── Profile/
 │       └── Views/
 └── Resources/                    # Assets, 리소스 파일
@@ -149,9 +152,13 @@ HiTrip/
 - [ ] KakaoMaps SDK 연동
 - [ ] TourAPI 관광지 검색
 
-### Phase 5 — 건강 + 긴급 연락
-- [ ] HealthKit 연동
-- [ ] 긴급 연락 플로우
+### Phase 5 — 긴급 연락 ✅
+- [x] EmergencyContact Entity (프리셋 + 개인 연락처, ContactCategory enum)
+- [x] EmergencyRepositoryProtocol + EmergencyUseCase (비즈니스 로직)
+- [x] EmergencyRepository 메모리 기반 구현 (112/119 등 프리셋 포함)
+- [x] EmergencyViewModel (카테고리 그룹핑 + 전화 URL 생성)
+- [x] EmergencyView + EmergencyAddView (퀵콜 버튼 + 연락처 관리)
+- [x] Emergency DI 연결 + HomeView 긴급 연락 탭 교체
 
 ### Phase 6 — 마무리
 - [ ] 푸시 알림 (APNs)
@@ -213,4 +220,4 @@ main ── develop ── feature/기능명
 
 ## 라이선스
 
-이 프로젝트는 2025 관광데이터 활용 공모전 출품을 위해 제작되었습니다.
+이 프로젝트는 2026 관광데이터 활용 공모전 출품을 위해 제작되었습니다.


### PR DESCRIPTION
## 개요

**긴급 연락처 기능**을 구현.
여행 중 긴급 상황에서 빠르게 전화할 수 있도록 프리셋 긴급번호(112, 119 등)와 개인 연락처 관리 기능을 제공.

<br>

## 변경 사항

### Domain Layer
- `EmergencyContact` Entity — 연락처 모델 (`isPreset`으로 기본/개인 구분, `ContactCategory` enum으로 카테고리 분류)
- `EmergencyRepositoryProtocol` — 연락처 CRUD 인터페이스
- `EmergencyUseCase` — 이름/전화번호 빈 값 검증 + Repository 위임

### Data Layer
- `EmergencyRepository` — 메모리 기반 구현. 초기화 시 프리셋 긴급번호(112, 119, 1339, 1330, 1345)가 자동 등록. 프리셋 삭제 방지 로직 포함

### Presentation Layer
- `EmergencyViewModel` — 카테고리별 그룹핑 + `tel://` URL 생성 + CRUD 상태 관리
- `EmergencyView` — 긴급 전화 퀵버튼(112/119 원탭 호출) + 카테고리별 연락처 리스트 + 스와이프 삭제
- `EmergencyAddView` — 개인 연락처 추가 시트 (이름 + 전화번호)

### DI + 탭 연결
- `AppDIContainer`에 Emergency 의존성 등록
- `HomeView` 긴급 연락 탭을 `EmergencyView`로 교체

 <br>

## 이전 Phase와 다른 점

| 비교 항목 | Schedule / Chat | Emergency |
|-----------|----------------|-----------|
| 초기 데이터 | 빈 배열 | 프리셋 번호 미리 등록 |
| 삭제 제한 | 모두 삭제 가능 | `isPreset: true`는 삭제 불가 |
| 카테고리 | String 또는 없음 | `ContactCategory` enum (CaseIterable) |
| 새로운 패턴 | - | `openURL` (전화 걸기), enum 기반 섹션 그룹핑 |

<br>

## 프리셋 긴급번호

| 카테고리 | 이름 | 번호 |
|---------|------|------|
| 긴급 | 경찰 | 112 |
| 긴급 | 소방/구급 | 119 |
| 의료 | 응급의료정보센터 | 1339 |
| 관광 | 관광불편신고 | 1330 |
| 관광 | 외국인종합안내 | 1345 |

<br>

## 주요 구현 포인트

### 1. isPreset을 통한 삭제 보호
프리셋 연락처(`isPreset: true`)는 Repository 레벨에서 삭제/수정을 차단합니다. View에서도 스와이프 삭제 시 `isPreset`을 체크하여 이중으로 보호합니다.

### 2. @Environment(\.openURL)로 전화 걸기
`tel://` URL을 `openURL`에 전달하면 iOS 전화 앱이 실행됩니다. 시뮬레이터에서는 동작하지 않으며, 실기기에서 테스트 가능합니다.


### 3. CaseIterable 활용 섹션 생성
`ContactCategory.allCases`로 모든 카테고리를 순회하면서 Section을 동적으로 생성합니다. 해당 카테고리에 연락처가 없으면 섹션 자체가 표시되지 않습니다.

<br>

## 테스트 방법

- [x] 긴급 연락 탭 진입 → 프리셋 번호(112, 119 등) 표시 확인
- [x] 퀵콜 버튼(112, 119) 탭 → 전화 앱 실행 확인 (실기기)
- [x] 연락처 행 탭 → 전화 연결 확인
- [x] + 버튼 → 개인 연락처 추가 확인
- [x] 개인 연락처 스와이프 삭제 확인
- [x] 프리셋 연락처 스와이프 삭제 시도 → 삭제 안 됨 확인
- [x] 카테고리별 섹션 그룹핑 정상 표시 확인
