### PR TITLE
feat: 지도 + 스팟 추천 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ Package.resolved
 # CocoaPods (사용 시)
 Pods/
 
+# API Keys (민감 정보)
+**/APIKeys.swift
+
 # Misc
 *.swp
 *~

--- a/APIKeys.example.txt
+++ b/APIKeys.example.txt
@@ -1,0 +1,16 @@
+import Foundation
+
+// MARK: - APIKeys (예시 파일)
+///
+/// ⚠️ 실제 사용 시:
+/// 1. 이 파일을 복사하여 APIKeys.swift로 이름 변경
+/// 2. 아래 빈 문자열에 실제 키 입력
+/// 3. APIKeys.swift는 .gitignore에 등록되어 git에 올라가지 않음
+
+enum APIKeys {
+    /// 한국관광공사 TourAPI 인증키 — https://www.data.go.kr 에서 발급
+    static let tourAPIKey = ""
+
+    /// 카카오 네이티브 앱 키 — https://developers.kakao.com 에서 발급
+    static let kakaoNativeAppKey = ""
+}

--- a/HiTrip.xcodeproj/project.pbxproj
+++ b/HiTrip.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		914CACF42F7BBF5A00CA754D /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 914CACF32F7BBF5A00CA754D /* KakaoMapsSDK-SPM */; };
 		917DC0222F5586AC00D5DAA8 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 917DC0212F5586AC00D5DAA8 /* RxSwift */; };
 		917DC02F2F59742600D5DAA8 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 917DC02E2F59742600D5DAA8 /* RxCocoa */; };
 /* End PBXBuildFile section */
@@ -46,6 +47,7 @@
 			files = (
 				917DC02F2F59742600D5DAA8 /* RxCocoa in Frameworks */,
 				917DC0222F5586AC00D5DAA8 /* RxSwift in Frameworks */,
+				914CACF42F7BBF5A00CA754D /* KakaoMapsSDK-SPM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,11 +61,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		914CACF22F7BBF5A00CA754D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		917DBFC22F557C9D00D5DAA8 = {
 			isa = PBXGroup;
 			children = (
 				917DBFCD2F557C9D00D5DAA8 /* HiTrip */,
 				917DC0582F67DDA500D5DAA8 /* HiTripTests */,
+				914CACF22F7BBF5A00CA754D /* Frameworks */,
 				917DBFCC2F557C9D00D5DAA8 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -99,6 +109,7 @@
 			packageProductDependencies = (
 				917DC0212F5586AC00D5DAA8 /* RxSwift */,
 				917DC02E2F59742600D5DAA8 /* RxCocoa */,
+				914CACF32F7BBF5A00CA754D /* KakaoMapsSDK-SPM */,
 			);
 			productName = HiTrip;
 			productReference = 917DBFCB2F557C9D00D5DAA8 /* HiTrip.app */;
@@ -158,6 +169,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				917DC0172F55860900D5DAA8 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				914CACDA2F7B4BB100CA754D /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 917DBFCC2F557C9D00D5DAA8 /* Products */;
@@ -340,8 +352,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SDBJF5F47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "주변 관광지 검색을 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -353,7 +367,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.hitrip.HiTrip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hitrip.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -375,8 +389,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SDBJF5F47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "주변 관광지 검색을 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -388,7 +404,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.hitrip.HiTrip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hitrip.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -468,6 +484,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		914CACDA2F7B4BB100CA754D /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.12.10;
+			};
+		};
 		917DC0172F55860900D5DAA8 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -479,6 +503,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		914CACF32F7BBF5A00CA754D /* KakaoMapsSDK-SPM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 914CACDA2F7B4BB100CA754D /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */;
+			productName = "KakaoMapsSDK-SPM";
+		};
 		917DC0212F5586AC00D5DAA8 /* RxSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 917DC0172F55860900D5DAA8 /* XCRemoteSwiftPackageReference "RxSwift" */;

--- a/HiTrip.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HiTrip.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "17ad69a9d62bb5214561f4b13adc77420e1190aa388f7c14a5057af4cc73b509",
+  "originHash" : "ed6073165527feac3eeeecc282817afeb5430109c839b88e335093b7703ac658",
   "pins" : [
+    {
+      "identity" : "kakaomapssdk-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM.git",
+      "state" : {
+        "revision" : "cc073a32729b7f545cca49f96d0b859fa3a0d5db",
+        "version" : "2.12.10"
+      }
+    },
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",

--- a/HiTrip/App/AppDelegate.swift
+++ b/HiTrip/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import KakaoMapsSDK
 
 // MARK: - AppDelegate
 /// UIKit 생명주기 관리
@@ -16,7 +17,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        // TODO: Phase 4 — KakaoMaps SDK 초기화
+        // KakaoMaps SDK 초기화
+        // - 앱 시작 시 1회만 호출
+        // - 카카오 개발자 콘솔에서 발급받은 네이티브 앱 키 사용
+        SDKInitializer.InitSDK(appKey: APIKeys.kakaoNativeAppKey)
+
         // TODO: Phase 6 — Push 알림 권한 요청
         return true
     }

--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -63,6 +63,11 @@ final class AppDIContainer {
         EmergencyRepository()
     }()
 
+    /// 관광지 Repository — TourAPI 실제 연동
+    private lazy var spotRepository: SpotRepositoryProtocol = {
+        SpotRepository()
+    }()
+
     // MARK: - Init
 
     /// 프로덕션용 — 싱글턴으로만 사용
@@ -113,6 +118,10 @@ final class AppDIContainer {
         EmergencyUseCase(repository: emergencyRepository)
     }
 
+    func makeSpotUseCase() -> SpotUseCase {
+        SpotUseCase(repository: spotRepository)
+    }
+
     // MARK: - ViewModel Factory
 
     /// RootView에서 호출하여 LoginView에 주입
@@ -138,5 +147,10 @@ final class AppDIContainer {
     /// HomeView의 긴급 연락 탭에서 사용
     func makeEmergencyViewModel() -> EmergencyViewModel {
         EmergencyViewModel(emergencyUseCase: makeEmergencyUseCase())
+    }
+
+    /// HomeView의 스팟 추천 탭에서 사용
+    func makeSpotViewModel() -> SpotViewModel {
+        SpotViewModel(spotUseCase: makeSpotUseCase())
     }
 }

--- a/HiTrip/Core/Network/TourAPIService.swift
+++ b/HiTrip/Core/Network/TourAPIService.swift
@@ -1,0 +1,286 @@
+import Foundation
+import RxSwift
+
+// MARK: - TourAPIService
+/// 한국관광공사 TourAPI 전용 네트워크 서비스
+///
+/// 기존 NetworkService와 다른 점:
+/// - baseURL이 TourAPI 전용 (apis.data.go.kr)
+/// - 인증 방식이 다름 (Bearer Token이 아닌 serviceKey 쿼리 파라미터)
+/// - 응답 구조가 다름 (TourAPI 고유의 JSON 래핑 구조)
+///
+/// TourAPI 응답 구조:
+/// ```json
+/// {
+///   "response": {
+///     "header": { "resultCode": "0000", "resultMsg": "OK" },
+///     "body": {
+///       "items": { "item": [...] },
+///       "totalCount": 100,
+///       "pageNo": 1
+///     }
+///   }
+/// }
+/// ```
+
+final class TourAPIService {
+
+    // MARK: - Singleton
+
+    static let shared = TourAPIService()
+
+    // MARK: - Properties
+
+    private let baseURL = "https://apis.data.go.kr/B551011/KorService2"
+    private let session: URLSession
+
+    private init() {
+        self.session = .shared
+    }
+
+    /// 테스트용
+    init(session: URLSession) {
+        self.session = session
+    }
+
+    // MARK: - 관광지 검색 (키워드)
+
+    /// 키워드 기반 관광지 검색
+    /// - TourAPI: /searchKeyword1
+    /// - Parameters:
+    ///   - keyword: 검색어 (예: "제주", "서울 궁궐")
+    ///   - pageNo: 페이지 번호 (기본 1)
+    ///   - numOfRows: 한 페이지 결과 수 (기본 20)
+    func searchKeyword(
+        keyword: String,
+        pageNo: Int = 1,
+        numOfRows: Int = 20
+    ) -> Single<[TourSpotItem]> {
+        let queryItems = [
+            URLQueryItem(name: "MobileApp", value: "HiTrip"),
+            URLQueryItem(name: "MobileOS", value: "IOS"),
+            URLQueryItem(name: "_type", value: "json"),
+            URLQueryItem(name: "keyword", value: keyword),
+            URLQueryItem(name: "pageNo", value: "\(pageNo)"),
+            URLQueryItem(name: "numOfRows", value: "\(numOfRows)"),
+            URLQueryItem(name: "arrange", value: "A"),  // A: 제목순
+        ]
+
+        return request(path: "/searchKeyword2", queryItems: queryItems)
+    }
+
+    // MARK: - 지역 기반 관광지 조회
+
+    /// 위치 기반 주변 관광지 조회
+    /// - TourAPI: /locationBasedList1
+    /// - Parameters:
+    ///   - latitude: 위도
+    ///   - longitude: 경도
+    ///   - radius: 반경 (미터, 기본 5000m = 5km)
+    func searchNearby(
+        latitude: Double,
+        longitude: Double,
+        radius: Int = 5000,
+        pageNo: Int = 1,
+        numOfRows: Int = 20
+    ) -> Single<[TourSpotItem]> {
+        let queryItems = [
+            URLQueryItem(name: "MobileApp", value: "HiTrip"),
+            URLQueryItem(name: "MobileOS", value: "IOS"),
+            URLQueryItem(name: "_type", value: "json"),
+            URLQueryItem(name: "mapX", value: "\(longitude)"),
+            URLQueryItem(name: "mapY", value: "\(latitude)"),
+            URLQueryItem(name: "radius", value: "\(radius)"),
+            URLQueryItem(name: "pageNo", value: "\(pageNo)"),
+            URLQueryItem(name: "numOfRows", value: "\(numOfRows)"),
+            URLQueryItem(name: "arrange", value: "E"),  // E: 거리순
+        ]
+
+        return request(path: "/locationBasedList2", queryItems: queryItems)
+    }
+
+    // MARK: - 공통 요청 메서드
+
+    /// TourAPI 공통 GET 요청
+    ///
+    /// ⚠️ serviceKey 인코딩 이슈:
+    /// URLComponents.queryItems는 값을 자동 percent-encoding 합니다.
+    /// TourAPI의 serviceKey에 포함된 특수문자(=, + 등)가 이중 인코딩되면
+    /// 서버가 키를 인식하지 못해 HTTP 500 에러가 발생합니다.
+    ///
+    /// 해결: serviceKey는 queryItems에 넣지 않고,
+    /// 완성된 URL 문자열에 직접 붙여서 인코딩을 우회합니다.
+    private func request(
+        path: String,
+        queryItems: [URLQueryItem]
+    ) -> Single<[TourSpotItem]> {
+        return Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(NetworkError.invalidURL))
+                return Disposables.create()
+            }
+
+            // 1) serviceKey 제외한 나머지 파라미터로 URL 조합
+            var components = URLComponents(string: self.baseURL + path)
+            components?.queryItems = queryItems
+
+            guard var urlString = components?.url?.absoluteString else {
+                single(.failure(NetworkError.invalidURL))
+                return Disposables.create()
+            }
+
+            // 2) serviceKey를 인코딩 없이 직접 붙임
+            let separator = urlString.contains("?") ? "&" : "?"
+            urlString += "\(separator)serviceKey=\(APIKeys.tourAPIKey)"
+
+            guard let url = URL(string: urlString) else {
+                single(.failure(NetworkError.invalidURL))
+                return Disposables.create()
+            }
+
+            // 🔍 DEBUG: 실제 요청 URL 출력
+            print("🌐 [TourAPI] 요청 URL: \(url.absoluteString)")
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+
+            let task = self.session.dataTask(with: request) { data, response, error in
+                // 네트워크 에러
+                if let error {
+                    print("❌ [TourAPI] 네트워크 에러: \(error.localizedDescription)")
+                    single(.failure(NetworkError.requestFailed(error.localizedDescription)))
+                    return
+                }
+
+                // HTTP 응답 확인
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    single(.failure(NetworkError.invalidResponse))
+                    return
+                }
+
+                print("📡 [TourAPI] HTTP 상태코드: \(httpResponse.statusCode)")
+
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    // 🔍 DEBUG: 에러 응답 본문 출력
+                    if let data, let body = String(data: data, encoding: .utf8) {
+                        print("❌ [TourAPI] 에러 응답 본문: \(body)")
+                    }
+                    single(.failure(NetworkError.httpError(httpResponse.statusCode)))
+                    return
+                }
+
+                guard let data else {
+                    single(.failure(NetworkError.noData))
+                    return
+                }
+
+                // TourAPI JSON 파싱
+                do {
+                    let tourResponse = try JSONDecoder().decode(
+                        TourAPIResponse.self,
+                        from: data
+                    )
+                    let items = tourResponse.response.body.items.item ?? []
+                    single(.success(items))
+                } catch {
+                    single(.failure(NetworkError.decodingFailed(error.localizedDescription)))
+                }
+            }
+
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+}
+
+// MARK: - TourAPI 응답 모델
+
+/// TourAPI의 고유한 JSON 래핑 구조를 파싱하기 위한 모델
+///
+/// 실제 데이터(item 배열)까지 3단계를 거쳐야 함:
+/// response → body → items → item
+
+struct TourAPIResponse: Decodable {
+    let response: TourResponseBody
+}
+
+struct TourResponseBody: Decodable {
+    let header: TourHeader
+    let body: TourBody
+}
+
+struct TourHeader: Decodable {
+    let resultCode: String
+    let resultMsg: String
+}
+
+struct TourBody: Decodable {
+    let items: TourItems
+    let totalCount: Int
+    let pageNo: Int
+    let numOfRows: Int
+}
+
+struct TourItems: Decodable {
+    let item: [TourSpotItem]?
+}
+
+// MARK: - TourSpotItem
+/// TourAPI에서 반환하는 관광지 개별 항목
+///
+/// 주요 필드:
+/// - contentid: 관광지 고유 ID
+/// - title: 관광지 이름
+/// - addr1: 주소
+/// - mapx/mapy: 경도/위도 (KakaoMap에 마커 표시용)
+/// - firstimage: 대표 이미지 URL
+/// - tel: 전화번호
+/// - contenttypeid: 관광지 유형 (12: 관광지, 14: 문화시설, 15: 축제, 25: 여행코스, 28: 레포츠, 32: 숙박, 38: 쇼핑, 39: 음식점)
+
+struct TourSpotItem: Decodable, Identifiable, Equatable {
+    let contentid: String
+    let title: String
+    let addr1: String?
+    let addr2: String?
+    let mapx: String?       // 경도 (longitude)
+    let mapy: String?       // 위도 (latitude)
+    let firstimage: String?
+    let firstimage2: String?
+    let tel: String?
+    let contenttypeid: String?
+
+    /// Identifiable 준수
+    var id: String { contentid }
+
+    /// 전체 주소
+    var fullAddress: String {
+        [addr1, addr2].compactMap { $0 }.joined(separator: " ")
+    }
+
+    /// 경도 (Double 변환)
+    var longitude: Double? {
+        guard let mapx else { return nil }
+        return Double(mapx)
+    }
+
+    /// 위도 (Double 변환)
+    var latitude: Double? {
+        guard let mapy else { return nil }
+        return Double(mapy)
+    }
+
+    /// 관광지 유형 이름
+    var contentTypeName: String {
+        switch contenttypeid {
+        case "12": return "관광지"
+        case "14": return "문화시설"
+        case "15": return "축제/행사"
+        case "25": return "여행코스"
+        case "28": return "레포츠"
+        case "32": return "숙박"
+        case "38": return "쇼핑"
+        case "39": return "음식점"
+        default:   return "기타"
+        }
+    }
+}

--- a/HiTrip/Data/Repositories/SpotRepository.swift
+++ b/HiTrip/Data/Repositories/SpotRepository.swift
@@ -1,0 +1,43 @@
+import Foundation
+import RxSwift
+
+// MARK: - SpotRepository
+/// 관광지 저장소 구현체 (TourAPI 연동)
+///
+/// 이전 Repository들과 다른 점:
+/// - 메모리 저장이 아닌 **실제 외부 API 호출**
+/// - TourAPIService를 통해 한국관광공사 서버에서 데이터를 가져옴
+///
+/// 이것이 Clean Architecture + DIP의 실전 적용:
+/// - Schedule/Chat: 메모리 저장 → 나중에 서버로 교체
+/// - Spot: 처음부터 실제 API 호출
+/// - UseCase는 둘 다 동일한 방식으로 사용 (Protocol만 알면 됨)
+
+final class SpotRepository: SpotRepositoryProtocol {
+
+    // MARK: - Dependencies
+
+    private let tourAPIService: TourAPIService
+
+    init(tourAPIService: TourAPIService = .shared) {
+        self.tourAPIService = tourAPIService
+    }
+
+    // MARK: - 키워드 검색
+
+    /// TourAPIService.searchKeyword 호출
+    func searchByKeyword(keyword: String, pageNo: Int) -> Single<[TourSpotItem]> {
+        return tourAPIService.searchKeyword(keyword: keyword, pageNo: pageNo)
+    }
+
+    // MARK: - 위치 기반 검색
+
+    /// TourAPIService.searchNearby 호출
+    func searchNearby(latitude: Double, longitude: Double, pageNo: Int) -> Single<[TourSpotItem]> {
+        return tourAPIService.searchNearby(
+            latitude: latitude,
+            longitude: longitude,
+            pageNo: pageNo
+        )
+    }
+}

--- a/HiTrip/Domain/Repositories/SpotRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/SpotRepositoryProtocol.swift
@@ -1,0 +1,25 @@
+import Foundation
+import RxSwift
+
+// MARK: - SpotRepositoryProtocol
+/// 관광지 데이터 접근 인터페이스 (Domain 레이어)
+///
+/// 이전 Repository들과 다른 점:
+/// - CRUD가 아닌 **검색(Read only)** 위주
+/// - 사용자가 데이터를 생성/수정/삭제하지 않고, TourAPI에서 조회만 함
+///
+/// 동일한 DIP 패턴:
+/// - Domain은 Protocol만 알고, 구현체(TourAPI 호출)는 모름
+
+protocol SpotRepositoryProtocol {
+
+    /// 키워드 기반 관광지 검색
+    /// - Parameter keyword: 검색어
+    func searchByKeyword(keyword: String, pageNo: Int) -> Single<[TourSpotItem]>
+
+    /// 위치 기반 주변 관광지 검색
+    /// - Parameters:
+    ///   - latitude: 위도
+    ///   - longitude: 경도
+    func searchNearby(latitude: Double, longitude: Double, pageNo: Int) -> Single<[TourSpotItem]>
+}

--- a/HiTrip/Domain/UseCases/SpotUseCase.swift
+++ b/HiTrip/Domain/UseCases/SpotUseCase.swift
@@ -1,0 +1,78 @@
+import Foundation
+import RxSwift
+
+// MARK: - SpotUseCase
+/// 관광지 검색 비즈니스 로직
+///
+/// 이전 UseCase들과 다른 점:
+/// - CRUD가 아닌 검색 전용
+/// - 검증: 빈 키워드 방지, 좌표 유효성 확인
+///
+/// 동일한 패턴: Protocol에만 의존 (DIP)
+
+final class SpotUseCase {
+
+    private let repository: SpotRepositoryProtocol
+
+    init(repository: SpotRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - 키워드 검색
+
+    /// 키워드로 관광지 검색
+    ///
+    /// 검증: 키워드가 비어있으면 에러
+    func searchByKeyword(keyword: String, pageNo: Int = 1) -> Single<[TourSpotItem]> {
+        guard !keyword.trimmed.isEmpty else {
+            return .error(SpotError.emptyKeyword)
+        }
+
+        return repository.searchByKeyword(keyword: keyword, pageNo: pageNo)
+    }
+
+    // MARK: - 위치 기반 검색
+
+    /// 현재 위치 주변 관광지 검색
+    ///
+    /// 검증: 좌표가 한국 범위 내인지 대략적 확인
+    func searchNearby(
+        latitude: Double,
+        longitude: Double,
+        pageNo: Int = 1
+    ) -> Single<[TourSpotItem]> {
+        // 한국 좌표 범위 대략적 검증 (위도 33~39, 경도 124~132)
+        guard (33...39).contains(latitude),
+              (124...132).contains(longitude) else {
+            return .error(SpotError.invalidLocation)
+        }
+
+        return repository.searchNearby(
+            latitude: latitude,
+            longitude: longitude,
+            pageNo: pageNo
+        )
+    }
+}
+
+// MARK: - SpotError
+/// 관광지 검색 관련 에러
+enum SpotError: LocalizedError, Equatable {
+    case emptyKeyword
+    case invalidLocation
+    case noResults
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyKeyword:
+            return "검색어를 입력해주세요."
+        case .invalidLocation:
+            return "현재 위치를 확인할 수 없습니다."
+        case .noResults:
+            return "검색 결과가 없습니다."
+        case .serverError(let msg):
+            return msg
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// - 홈: 로그인 성공 확인 + 로그아웃
 /// - 일정: ScheduleListView (CRUD)
 /// - 채팅: ChatListView (1:1 메시지)
-/// - 스팟 추천: Phase 4에서 구현
+/// - 스팟 추천: SpotListView (TourAPI 관광지 검색)
 /// - 긴급 연락: EmergencyView (긴급 전화 + 연락처 관리)
 /// - 프로필: ProfileView (프로필 조회 + 로그아웃)
 ///
@@ -61,7 +61,9 @@ struct HomeView: View {
                 .tabItem { Label(Tab.chat.rawValue, systemImage: Tab.chat.icon) }
                 .tag(Tab.chat)
 
-            placeholderTab("스팟 추천", icon: "map.fill", phase: 4)
+            SpotListView(
+                    viewModel: AppDIContainer.shared.makeSpotViewModel()
+                )
                 .tabItem { Label(Tab.spots.rawValue, systemImage: Tab.spots.icon) }
                 .tag(Tab.spots)
 

--- a/HiTrip/Features/Spot/ViewModels/SpotViewModel.swift
+++ b/HiTrip/Features/Spot/ViewModels/SpotViewModel.swift
@@ -1,0 +1,191 @@
+import Foundation
+import RxSwift
+import CoreLocation
+
+// MARK: - SpotViewModel
+/// 관광지 검색 화면의 ViewModel
+///
+/// 이전 ViewModel들과 다른 점:
+/// - CRUD가 아닌 검색 전용
+/// - CLLocationManager로 현재 위치 가져오기
+/// - 페이지네이션 (더보기 기능)
+///
+/// 동일한 @Published 패턴
+
+final class SpotViewModel: NSObject, ObservableObject {
+
+    // MARK: - 검색 상태
+
+    /// 검색 결과 목록
+    @Published var spots: [TourSpotItem] = []
+
+    /// 검색어 입력 — TextField와 바인딩
+    @Published var searchText: String = ""
+
+    /// 검색 모드 (키워드 / 주변)
+    @Published var searchMode: SearchMode = .keyword
+
+    // MARK: - UI 상태
+
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    /// 더 불러올 데이터가 있는지
+    @Published var hasMore: Bool = false
+
+    // MARK: - 위치 상태
+
+    /// 현재 위치
+    @Published var currentLocation: CLLocation?
+
+    /// 위치 권한 상태
+    @Published var locationAuthStatus: CLAuthorizationStatus = .notDetermined
+
+    // MARK: - Dependencies
+
+    private let spotUseCase: SpotUseCase
+    private let disposeBag = DisposeBag()
+    private let locationManager = CLLocationManager()
+
+    /// 현재 페이지 번호
+    private var currentPage: Int = 1
+
+    init(spotUseCase: SpotUseCase) {
+        self.spotUseCase = spotUseCase
+        super.init()
+        setupLocationManager()
+    }
+
+    // MARK: - 검색 모드
+
+    enum SearchMode: String, CaseIterable {
+        case keyword = "키워드 검색"
+        case nearby = "주변 검색"
+    }
+
+    // MARK: - 키워드 검색
+
+    /// 키워드로 관광지 검색
+    /// 새 검색 시 기존 결과 초기화
+    func searchByKeyword() {
+        currentPage = 1
+        spots = []
+        isLoading = true
+        errorMessage = nil
+
+        spotUseCase.searchByKeyword(keyword: searchText, pageNo: currentPage)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] items in
+                    self?.isLoading = false
+                    self?.spots = items
+                    self?.hasMore = items.count >= 20
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 다음 페이지 로드 (키워드)
+    func loadMoreKeyword() {
+        guard !isLoading, hasMore else { return }
+
+        currentPage += 1
+        isLoading = true
+
+        spotUseCase.searchByKeyword(keyword: searchText, pageNo: currentPage)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] items in
+                    self?.isLoading = false
+                    self?.spots.append(contentsOf: items)
+                    self?.hasMore = items.count >= 20
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 주변 검색
+
+    /// 현재 위치 기반 주변 관광지 검색
+    func searchNearby() {
+        guard let location = currentLocation else {
+            errorMessage = "위치 정보를 가져오는 중입니다..."
+            requestLocation()
+            return
+        }
+
+        currentPage = 1
+        spots = []
+        isLoading = true
+        errorMessage = nil
+
+        spotUseCase.searchNearby(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            pageNo: currentPage
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] items in
+                self?.isLoading = false
+                self?.spots = items
+                self?.hasMore = items.count >= 20
+            },
+            onFailure: { [weak self] error in
+                self?.isLoading = false
+                self?.errorMessage = error.localizedDescription
+            }
+        )
+        .disposed(by: disposeBag)
+    }
+
+    // MARK: - 위치 관리
+
+    /// CLLocationManager 초기 설정
+    private func setupLocationManager() {
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+    }
+
+    /// 위치 권한 요청
+    func requestLocation() {
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.requestLocation()
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+/// 위치 업데이트 콜백
+///
+/// NSObject 상속 + CLLocationManagerDelegate 채택이 필요
+/// → SpotViewModel이 class이고 NSObject를 상속하는 이유
+
+extension SpotViewModel: CLLocationManagerDelegate {
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        currentLocation = locations.last
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        errorMessage = "위치를 가져올 수 없습니다: \(error.localizedDescription)"
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        locationAuthStatus = manager.authorizationStatus
+
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            locationManager.requestLocation()
+        default:
+            break
+        }
+    }
+}

--- a/HiTrip/Features/Spot/Views/KakaoMapView.swift
+++ b/HiTrip/Features/Spot/Views/KakaoMapView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import KakaoMapsSDK
+
+// MARK: - KakaoMapView
+/// KakaoMapsSDK의 KMViewContainer를 SwiftUI에서 사용하기 위한 래퍼
+///
+/// SwiftUI는 UIKit 뷰를 직접 사용할 수 없어서
+/// UIViewRepresentable 프로토콜로 감싸야 함.
+///
+/// 핵심 라이프사이클:
+/// 1. makeUIView → KMViewContainer 생성
+/// 2. prepareEngine() → 엔진 준비
+/// 3. containerDidResized() → 컨테이너 크기 확정 시 엔진 활성화
+/// 4. addViews() → 엔진 활성화 후 지도 뷰 추가
+/// 5. onDisappear → pauseEngine / dismantleUIView → resetEngine
+
+struct KakaoMapView: UIViewRepresentable {
+
+    // MARK: - Properties
+
+    let latitude: Double
+    let longitude: Double
+    @Binding var draw: Bool
+
+    // MARK: - UIViewRepresentable
+
+    func makeUIView(context: Context) -> KMViewContainer {
+        let view = KMViewContainer()
+        view.sizeToFit()
+        context.coordinator.createController(view)
+        return view
+    }
+
+    /// draw 상태에 따라 엔진 활성화/일시정지
+    ///
+    /// ⚠️ 주의: activateEngine은 containerDidResized 이후에 호출해야 함.
+    /// 컨테이너 크기가 확정되기 전에 활성화하면 렌더링 영역이 0이라 지도가 안 보임.
+    /// 그래서 첫 활성화는 containerDidResized에서 하고,
+    /// 여기서는 이미 활성화된 이후의 재개/일시정지만 담당.
+    func updateUIView(_ uiView: KMViewContainer, context: Context) {
+        if draw {
+            if context.coordinator.isEnginePrepared {
+                context.coordinator.controller?.activateEngine()
+            }
+        } else {
+            context.coordinator.controller?.pauseEngine()
+        }
+    }
+
+    static func dismantleUIView(_ uiView: KMViewContainer, coordinator: Coordinator) {
+        coordinator.controller?.resetEngine()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(latitude: latitude, longitude: longitude)
+    }
+
+    // MARK: - Coordinator
+
+    class Coordinator: NSObject, MapControllerDelegate {
+
+        var controller: KMController?
+        let latitude: Double
+        let longitude: Double
+
+        /// containerDidResized가 한 번이라도 호출되었는지
+        var isEnginePrepared = false
+
+        /// 첫 번째 containerDidResized에서만 엔진 활성화
+        var first = true
+
+        init(latitude: Double, longitude: Double) {
+            self.latitude = latitude
+            self.longitude = longitude
+            super.init()
+        }
+
+        func createController(_ view: KMViewContainer) {
+            controller = KMController(viewContainer: view)
+            controller?.delegate = self
+            controller?.prepareEngine()
+        }
+
+        // MARK: - MapControllerDelegate
+
+        /// 엔진 준비 완료 → 지도 뷰 추가
+        func addViews() {
+            let defaultPosition = MapPoint(
+                longitude: longitude,
+                latitude: latitude
+            )
+            let mapviewInfo = MapviewInfo(
+                viewName: "spotMap",
+                viewInfoName: "map",
+                defaultPosition: defaultPosition,
+                defaultLevel: 15
+            )
+
+            controller?.addView(mapviewInfo)
+        }
+
+        func addViewSucceeded(_ viewName: String, viewInfoName: String) {
+            print("✅ [KakaoMap] addViewSucceeded: \(viewName)")
+
+            // 지도 뷰가 추가된 후 렌더링 영역 재설정
+            let mapView = controller?.getView("spotMap") as? KakaoMap
+            print("🗺️ [KakaoMap] mapView: \(String(describing: mapView))")
+        }
+
+        func addViewFailed(_ viewName: String, viewInfoName: String) {
+            print("❌ [KakaoMap] addViewFailed: \(viewName)")
+        }
+
+        /// 컨테이너 크기가 확정될 때 호출
+        ///
+        /// 이 시점에서 지도의 렌더링 영역(viewRect)을 설정하고,
+        /// 첫 호출 시 엔진을 활성화해야 지도가 정상 렌더링됨.
+        func containerDidResized(_ size: CGSize) {
+            print("📐 [KakaoMap] containerDidResized: \(size)")
+
+            let mapView = controller?.getView("spotMap") as? KakaoMap
+            mapView?.viewRect = CGRect(origin: .zero, size: size)
+
+            if first {
+                first = false
+                isEnginePrepared = true
+                controller?.activateEngine()
+            }
+        }
+
+        func authenticationSucceeded() {
+            print("✅ [KakaoMap] 인증 성공")
+        }
+
+        func authenticationFailed(_ errorCode: Int, desc: String) {
+            print("❌ [KakaoMap] 인증 실패: code=\(errorCode), \(desc)")
+        }
+    }
+}

--- a/HiTrip/Features/Spot/Views/SpotDetailView.swift
+++ b/HiTrip/Features/Spot/Views/SpotDetailView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+// MARK: - SpotDetailView
+/// 관광지 상세 화면 (Sheet)
+///
+/// TourAPI에서 가져온 관광지 정보를 보여줌:
+/// - 대표 이미지
+/// - 이름, 주소, 유형, 전화번호
+/// - "지도 보기" 버튼 → SpotMapView (전체화면 KakaoMap)
+/// - 전화 걸기 버튼 (tel://)
+
+struct SpotDetailView: View {
+
+    let spot: TourSpotItem
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    /// SpotMapView 표시 여부
+    @State private var showMap = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    // MARK: - 대표 이미지
+                    spotHeaderImage
+
+                    VStack(alignment: .leading, spacing: 16) {
+                        // MARK: - 제목 + 유형
+                        titleSection
+
+                        Divider()
+
+                        // MARK: - 지도 보기 버튼
+                        if spot.latitude != nil && spot.longitude != nil {
+                            mapButton
+                        }
+
+                        // MARK: - 주소
+                        if !spot.fullAddress.isEmpty {
+                            infoRow(
+                                icon: "mappin.and.ellipse",
+                                title: "주소",
+                                content: spot.fullAddress
+                            )
+                        }
+
+                        // MARK: - 전화번호
+                        if let tel = spot.tel, !tel.isEmpty {
+                            Button {
+                                let cleaned = tel.replacingOccurrences(of: " ", with: "")
+                                    .replacingOccurrences(of: "-", with: "")
+                                if let url = URL(string: "tel://\(cleaned)") {
+                                    openURL(url)
+                                }
+                            } label: {
+                                infoRow(
+                                    icon: "phone.fill",
+                                    title: "전화",
+                                    content: tel,
+                                    isLink: true
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        Divider()
+
+                        // MARK: - 관광지 유형
+                        infoRow(
+                            icon: "tag.fill",
+                            title: "유형",
+                            content: spot.contentTypeName
+                        )
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+            .navigationTitle(spot.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("닫기") {
+                        dismiss()
+                    }
+                }
+            }
+            .fullScreenCover(isPresented: $showMap) {
+                SpotMapView(spot: spot)
+            }
+        }
+    }
+
+    // MARK: - 지도 보기 버튼
+
+    /// KakaoMap 전체화면으로 이동하는 버튼
+    /// Metal 기반 KakaoMap은 ScrollView 안에서 GPU 충돌이 발생하므로
+    /// 별도의 전체화면(fullScreenCover)으로 표시
+    private var mapButton: some View {
+        Button {
+            showMap = true
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "map.fill")
+                    .font(.system(size: 18))
+                    .foregroundColor(.white)
+
+                Text("지도에서 위치 보기")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.white)
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(HiTripColor.primary800)
+            .cornerRadius(12)
+        }
+    }
+
+    // MARK: - 헤더 이미지
+
+    private var spotHeaderImage: some View {
+        Group {
+            if let imageURL = spot.firstimage, let url = URL(string: imageURL) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    case .failure:
+                        headerPlaceholder
+                    case .empty:
+                        ZStack {
+                            headerPlaceholder
+                            ProgressView()
+                        }
+                    @unknown default:
+                        headerPlaceholder
+                    }
+                }
+            } else {
+                headerPlaceholder
+            }
+        }
+        .frame(height: 220)
+        .clipped()
+    }
+
+    private var headerPlaceholder: some View {
+        Rectangle()
+            .fill(HiTripColor.gray100)
+            .overlay(
+                VStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 32))
+                        .foregroundColor(HiTripColor.gray300)
+                    Text("이미지 없음")
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.gray400)
+                }
+            )
+    }
+
+    // MARK: - 제목 섹션
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(spot.title)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textGrayA)
+
+            Text(spot.contentTypeName)
+                .font(.system(size: 13))
+                .foregroundColor(HiTripColor.primary800)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(HiTripColor.secondary100)
+                .cornerRadius(6)
+        }
+    }
+
+    // MARK: - 정보 행
+
+    private func infoRow(
+        icon: String,
+        title: String,
+        content: String,
+        isLink: Bool = false
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundColor(HiTripColor.primary800)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray400)
+
+                Text(content)
+                    .font(.system(size: 15))
+                    .foregroundColor(isLink ? .blue : HiTripColor.textGrayA)
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Spot/Views/SpotListView.swift
+++ b/HiTrip/Features/Spot/Views/SpotListView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+// MARK: - SpotListView
+/// 관광지 검색 목록 화면
+///
+/// 구성:
+/// - 상단: 검색 모드 선택 (키워드/주변) + 검색바
+/// - 중간: 검색 결과 리스트 (이미지 + 이름 + 주소 + 유형 뱃지)
+/// - 탭하면 SpotDetailView로 이동
+///
+/// 새로운 패턴:
+/// - Picker(.segmented)로 검색 모드 전환
+/// - AsyncImage로 원격 이미지 로드
+/// - onAppear last item 으로 페이지네이션
+
+struct SpotListView: View {
+
+    @ObservedObject var viewModel: SpotViewModel
+    @State private var selectedSpot: TourSpotItem?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // MARK: - 검색 모드 + 검색바
+                searchHeader
+
+                // MARK: - 결과 목록
+                if viewModel.isLoading && viewModel.spots.isEmpty {
+                    loadingView
+                } else if viewModel.spots.isEmpty {
+                    emptyStateView
+                } else {
+                    spotList
+                }
+            }
+            .navigationTitle("스팟 추천")
+            .sheet(item: $selectedSpot) { spot in
+                SpotDetailView(spot: spot)
+            }
+        }
+    }
+
+    // MARK: - 검색 헤더
+
+    private var searchHeader: some View {
+        VStack(spacing: 12) {
+            // 검색 모드 선택
+            Picker("검색 모드", selection: $viewModel.searchMode) {
+                ForEach(SpotViewModel.SearchMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 16)
+
+            // 키워드 검색바
+            if viewModel.searchMode == .keyword {
+                HStack(spacing: 8) {
+                    TextField("관광지 검색 (예: 제주, 경복궁)", text: $viewModel.searchText)
+                        .font(.system(size: 15))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(HiTripColor.gray100)
+                        .cornerRadius(10)
+
+                    Button {
+                        viewModel.searchByKeyword()
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(width: 40, height: 40)
+                            .background(HiTripColor.primary800)
+                            .cornerRadius(10)
+                    }
+                    .disabled(viewModel.searchText.trimmed.isEmpty)
+                }
+                .padding(.horizontal, 16)
+            } else {
+                // 주변 검색 버튼
+                Button {
+                    viewModel.searchNearby()
+                } label: {
+                    Label("현재 위치에서 검색", systemImage: "location.fill")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(HiTripColor.primary800)
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal, 16)
+            }
+
+            // 에러 메시지
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.error)
+                    .padding(.horizontal, 16)
+            }
+        }
+        .padding(.vertical, 12)
+        .background(Color(UIColor.systemBackground))
+    }
+
+    // MARK: - 결과 리스트
+
+    private var spotList: some View {
+        List {
+            ForEach(viewModel.spots) { spot in
+                Button {
+                    selectedSpot = spot
+                } label: {
+                    spotRow(spot)
+                }
+                .buttonStyle(.plain)
+                .onAppear {
+                    // 마지막 항목이 보이면 다음 페이지 로드 (페이지네이션)
+                    if spot.id == viewModel.spots.last?.id && viewModel.hasMore {
+                        viewModel.loadMoreKeyword()
+                    }
+                }
+            }
+
+            // 로딩 인디케이터 (더보기 중)
+            if viewModel.isLoading && !viewModel.spots.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .padding()
+                    Spacer()
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - 관광지 행
+
+    private func spotRow(_ spot: TourSpotItem) -> some View {
+        HStack(spacing: 12) {
+            // 대표 이미지
+            spotImage(spot.firstimage)
+
+            // 정보
+            VStack(alignment: .leading, spacing: 4) {
+                // 제목
+                Text(spot.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(HiTripColor.textGrayA)
+                    .lineLimit(1)
+
+                // 주소
+                if !spot.fullAddress.isEmpty {
+                    Text(spot.fullAddress)
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.gray400)
+                        .lineLimit(1)
+                }
+
+                // 유형 뱃지
+                Text(spot.contentTypeName)
+                    .font(.system(size: 11))
+                    .foregroundColor(HiTripColor.primary800)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(HiTripColor.secondary100)
+                    .cornerRadius(4)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - 이미지 로드
+
+    /// AsyncImage로 원격 이미지 로드
+    /// 이미지가 없으면 기본 아이콘 표시
+    private func spotImage(_ urlString: String?) -> some View {
+        Group {
+            if let urlString, let url = URL(string: urlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    case .failure:
+                        imagePlaceholder
+                    case .empty:
+                        ProgressView()
+                    @unknown default:
+                        imagePlaceholder
+                    }
+                }
+            } else {
+                imagePlaceholder
+            }
+        }
+        .frame(width: 72, height: 72)
+        .cornerRadius(8)
+        .clipped()
+    }
+
+    /// 이미지 없을 때 기본 표시
+    private var imagePlaceholder: some View {
+        Rectangle()
+            .fill(HiTripColor.gray100)
+            .overlay(
+                Image(systemName: "photo")
+                    .foregroundColor(HiTripColor.gray300)
+            )
+    }
+
+    // MARK: - 빈 상태 / 로딩
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "map")
+                .font(.system(size: 48))
+                .foregroundColor(HiTripColor.gray300)
+            Text("관광지를 검색해보세요")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(HiTripColor.textGrayA)
+            Text("키워드 또는 현재 위치로 검색할 수 있어요")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray400)
+            Spacer()
+        }
+    }
+
+    private var loadingView: some View {
+        VStack {
+            Spacer()
+            ProgressView("검색 중...")
+            Spacer()
+        }
+    }
+}

--- a/HiTrip/Features/Spot/Views/SpotMapView.swift
+++ b/HiTrip/Features/Spot/Views/SpotMapView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+// MARK: - SpotMapView
+/// 관광지 위치를 전체화면 KakaoMap으로 보여주는 뷰
+///
+/// SpotDetailView에서 "지도 보기" 버튼을 누르면 Sheet로 표시됨.
+/// ScrollView 밖에서 KakaoMap을 렌더링하므로 Metal GPU 이슈 없음.
+
+struct SpotMapView: View {
+
+    let spot: TourSpotItem
+    @Environment(\.dismiss) private var dismiss
+    @State private var drawMap = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if let lat = spot.latitude, let lng = spot.longitude {
+                    KakaoMapView(
+                        latitude: lat,
+                        longitude: lng,
+                        draw: $drawMap
+                    )
+                    .ignoresSafeArea()
+                } else {
+                    VStack(spacing: 12) {
+                        Image(systemName: "map.fill")
+                            .font(.system(size: 40))
+                            .foregroundColor(HiTripColor.gray300)
+                        Text("위치 정보가 없습니다")
+                            .font(.system(size: 15))
+                            .foregroundColor(HiTripColor.gray400)
+                    }
+                }
+            }
+            .navigationTitle(spot.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("닫기") {
+                        dismiss()
+                    }
+                }
+            }
+            .onAppear { drawMap = true }
+            .onDisappear { drawMap = false }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

- **TourAPI(공공데이터포털 국문관광정보서비스) 연동**과 **KakaoMaps SDK 연동**을 구현.
- 키워드 기반 관광지 검색, GPS 위치 기반 주변 검색, 관광지 상세 정보 표시, 지도 표시 기능을 제공.

기존과 동일하게 Clean Architecture(Domain → Data → Presentation) + MVVM 패턴을 적용했으며, Phase 4의 특징은 **최초의 실제 외부 API 연동** (이전까지는 메모리 기반 저장소)이라는 점.

<br/>

## 변경 사항

### Domain Layer
- `SpotRepositoryProtocol` — 관광지 검색 인터페이스 (키워드 검색 + 위치 기반 검색). 외부 API 조회만 수행하므로 **Read-only** (CUD 없음)
- `SpotUseCase` — 빈 키워드 검증 + 한국 좌표 범위 검증 (위도 33~39, 경도 124~132)

### Data Layer
- `TourAPIService` — TourAPI(KorService2) 전용 네트워크 서비스. 기존 NetworkService와 별도 분리
- `SpotRepository` — TourAPIService를 래핑하는 Repository 구현체

### Presentation Layer
- `SpotViewModel` — CLLocationManager로 GPS 위치 획득 + 키워드/위치 검색 + 페이지네이션 관리
- `SpotListView` — 키워드/현재위치 검색 모드 전환 + 관광지 목록 + 무한스크롤
- `SpotDetailView` — 관광지 상세 정보 (이미지, 주소, 전화, 유형 + 지도 보기 버튼)
- `KakaoMapView` — KakaoMapsSDK의 KMViewContainer를 SwiftUI에서 사용하기 위한 UIViewRepresentable 래퍼
- `SpotMapView` — 전체화면 KakaoMap 지도 표시 (Metal 렌더링 이슈 우회용 별도 뷰)

### DI + TAB 연결
- `AppDIContainer`에 Spot 의존성 등록 (spotRepository, makeSpotUseCase, makeSpotViewModel)
- `HomeView` 스팟 탭 placeholder → `SpotListView`로 교체

### SDK + 보안
- `AppDelegate`에서 `SDKInitializer.InitSDK(appKey:)` 호출 (KakaoMaps SDK 초기화)
- `.gitignore`에 `**/APIKeys.swift` 추가 (API 키 커밋 방지)
- `APIKeys.example.txt` — 팀원용 API 키 템플릿 (프로젝트 루트에 배치)
- KakaoMapsSDK-SPM 2.12.10 패키지 추가

<br/>

## 이전과 다른 점

| 비교 항목 | Schedule / Chat / Emergency | Spot |
|-----------|----------------------------|------|
| 데이터 소스 | 메모리 기반 저장소 | **실제 외부 API** (TourAPI) |
| Repository | 앱 내부 CRUD | Read-only (API 조회만) |
| 네트워크 | 미사용 | TourAPIService (URLSession + RxSwift Single) |
| 인증 방식 | - | serviceKey 쿼리 파라미터 |
| 응답 파싱 | - | 3단계 JSON 래핑 (response → body → items → item) |
| 위치 서비스 | 미사용 | CLLocationManager + GPS 권한 |
| 외부 SDK | 미사용 | KakaoMapsSDK (Metal 기반 지도 렌더링) |
| 이미지 로딩 | 미사용 | AsyncImage (원격 URL) |
| 페이지네이션 | 미사용 | currentPage + hasMore 플래그 |
| API 키 보안 | 미사용 | .gitignore + 예시 템플릿 |

<br/>

## TourAPIService 상세 설명

### 기존 NetworkService와 분리한 이유

기존 NetworkService는 자체 백엔드 서버에 맞춰져 있어 TourAPI와 호환되지 않습니다:

| 항목 | 기존 NetworkService | TourAPIService |
|------|-------------------|----------------|
| baseURL | 자체 서버 | `apis.data.go.kr/B551011/KorService2` |
| 인증 | Bearer Token (Header) | serviceKey (Query Parameter) |
| 응답 구조 | `{ data, error }` | `{ response: { body: { items: { item } } } }` |
| 메서드 | 범용 `request<T>()` | 전용 `searchKeyword()`, `searchNearby()` |

### TourAPI 응답 모델 구조

```
TourAPIResponse
└── response: TourResponseBody
    ├── header: TourHeader (resultCode, resultMsg)
    └── body: TourBody
        ├── items: TourItems
        │   └── item: [TourSpotItem]?  ← 실제 관광지 데이터
        ├── totalCount: Int
        ├── pageNo: Int
        └── numOfRows: Int
```

### TourSpotItem 주요 필드

| 필드 | 타입 | 설명 |
|------|------|------|
| contentid | String | 관광지 고유 ID (Identifiable) |
| title | String | 관광지 이름 |
| addr1, addr2 | String? | 주소 (computed: fullAddress) |
| mapx, mapy | String? | 경도/위도 (computed: longitude, latitude → Double?) |
| firstimage | String? | 대표 이미지 URL (AsyncImage용) |
| tel | String? | 전화번호 (tel:// URL 생성용) |
| contenttypeid | String? | 관광지 유형 코드 (computed: contentTypeName) |

### contenttypeid 매핑

| 코드 | 유형 |
|------|------|
| 12 | 관광지 |
| 14 | 문화시설 |
| 15 | 축제/행사 |
| 25 | 여행코스 |
| 28 | 레포츠 |
| 32 | 숙박 |
| 38 | 쇼핑 |
| 39 | 음식점 |

### serviceKey 인코딩 우회

TourAPI 연동 시 가장 큰 이슈였습니다. Swift의 `URLComponents.queryItems`는 값을 자동 percent-encoding하는데, TourAPI의 serviceKey가 이중 인코딩되면 서버가 인식하지 못해 HTTP 500 에러가 발생합니다.

**해결**: serviceKey를 `queryItems`에서 제외하고, 완성된 URL 문자열에 직접 append하여 인코딩을 우회했습니다.

```swift
// 다른 파라미터는 URLQueryItem으로 정상 처리
var components = URLComponents(string: baseURL + path)
components?.queryItems = queryItems  // serviceKey 미포함

// serviceKey만 문자열로 직접 연결 (인코딩 우회)
urlString += "&serviceKey=\(APIKeys.tourAPIKey)"
```

### KorService1 → KorService2 변경

data.go.kr에서 발급받은 API 키는 **KorService2**(신규 버전)용이었으나, 초기 구현 시 KorService1(구버전)을 사용하여 HTTP 500/404 에러가 발생했습니다.

- baseURL: `KorService1` → `KorService2`
- 키워드 검색: `/searchKeyword1` → `/searchKeyword2`
- 위치 기반: `/locationBasedList1` → `/locationBasedList2`

<br/>

## KakaoMaps SDK 연동 상세

### UIViewRepresentable 패턴

KakaoMapsSDK는 UIKit 기반(`KMViewContainer`)이므로, SwiftUI에서 사용하려면 `UIViewRepresentable`로 래핑해야 합니다.

| 메서드 | 역할 |
|--------|------|
| `makeUIView()` | KMViewContainer 생성 + KMController 준비 |
| `updateUIView()` | draw 상태에 따라 엔진 활성화/일시정지 |
| `dismantleUIView()` | 엔진 리셋 (메모리 해제) |
| `makeCoordinator()` | MapControllerDelegate 구현체 생성 |

### Coordinator (MapControllerDelegate)

| 콜백 메서드 | 호출 시점 |
|------------|----------|
| `addViews()` | 엔진 준비 완료 → MapviewInfo로 지도 생성 |
| `addViewSucceeded()` | 지도 뷰 추가 성공 |
| `addViewFailed()` | 지도 뷰 추가 실패 |
| `containerDidResized()` | 컨테이너 크기 변경 → viewRect 설정 + 첫 호출 시 엔진 활성화 |
| `authenticationSucceeded()` | API 키 인증 성공 |
| `authenticationFailed()` | API 키 인증 실패 |

### ScrollView + Metal 충돌 → 전체화면 분리

KakaoMapsSDK v2는 Metal 기반 렌더링을 사용합니다. ScrollView 내부에서 Metal 뷰를 렌더링하면 `IOGPUMetalError: GPU Timeout Error`가 발생합니다.

**해결**: SpotDetailView에서 인라인 지도 대신 "지도에서 위치 보기" 버튼 → `fullScreenCover`로 `SpotMapView`를 별도 전체화면으로 표시합니다.

```
SpotDetailView (ScrollView 안)
├── 이미지, 제목, 주소, 전화, 유형
└── "지도에서 위치 보기" 버튼
     └── fullScreenCover → SpotMapView (ScrollView 밖, 전체화면)
         └── KakaoMapView (Metal 렌더링 정상 동작)
```

<br/>

## SpotViewModel 상세 설명

### NSObject 상속이 필요한 이유

`CLLocationManagerDelegate`는 Objective-C 프로토콜이므로, Swift 클래스가 이를 채택하려면 `NSObject`를 상속해야 합니다. 이전 Phase의 ViewModel들은 `ObservableObject`만 채택했지만, GPS 기능이 필요한 SpotViewModel은 `NSObject` 상속이 추가되었습니다.

### 검색 모드 전환

```swift
enum SearchMode {
    case keyword   // 키워드 검색 (텍스트 입력)
    case nearby    // 현재위치 기반 (GPS)
}
```

Picker(.segmented)로 모드를 전환하며, 각 모드에 맞는 UI와 검색 동작이 달라집니다.

### 페이지네이션

`currentPage`과 `hasMore` 플래그를 사용하여 무한스크롤을 구현합니다:
- 검색 시 `currentPage = 1`로 리셋
- 결과가 `numOfRows`보다 적으면 `hasMore = false`
- 리스트 마지막 아이템 `onAppear` 시 `loadMoreKeyword()` 호출

<br/>

## 트러블슈팅

### KakaoMap 지도 타일 미표시 (보류)

| 항목 | 상태 |
|------|------|
| SDK 초기화 | ✅ 성공 |
| API 키 인증 | ✅ `Authentication OK!!` |
| 지도 뷰 추가 | ✅ `Add viewInfo[map] OK` |
| 지도 타일 렌더링 | ❌ 화면에 표시 안 됨 |

- **시뮬레이터**: `[E][K3fCore] unsupported image format` + `MTLCommandBufferErrorDomain error 2`
- **실기기**: `IOGPUMetalError: GPU Timeout Error`
- **추정 원인**: KakaoMapsSDK v2의 Metal 렌더링 파이프라인과 SwiftUI UIViewRepresentable 간 호환성 문제
- **다음 단계**: 카카오 데브톡 문의 또는 UIKit ViewController 래핑 방식으로 재시도

<br/>

## 테스트 방법

- [x] APIKeys.swift 생성 (TourAPI 키 + 카카오 네이티브 앱 키 입력)
- [x] 카카오 개발자 콘솔에서 iOS 플랫폼 등록 (Bundle ID: `com.hitrip.app`)
- [x] 카카오 개발자 콘솔 → Product Settings → Kakao Map 활성화
- [x] 스팟 탭 진입 → 키워드 검색 (예: "제주") → 검색 결과 리스트 표시 확인
- [x] 검색 결과 항목 탭 → 상세 화면 (이미지, 주소, 전화, 유형) 표시 확인
- [x] 전화번호 탭 → 전화 앱 실행 확인 (실기기)
- [x] 현재위치 탭 → "현재 위치에서 검색" 버튼 (시뮬레이터: Features → Location → Custom Location 설정)
- [x] 리스트 하단까지 스크롤 → 무한스크롤 추가 데이터 로드 확인
- [x] "지도에서 위치 보기" 버튼 → 전체화면 지도 표시 확인 (인증 성공 로그 확인)
- [ ] KakaoMap 지도 타일 실제 렌더링 확인 (보류)
