### PR TITLE
feat: 회원가입 UI 피그마 적용 + 일정/캘린더 기능 전체 구현 (3화면 + CRUD + 중앙 데이터 관리)

### DIFF
--- a/HiTrip/Core/Extensions/Color+Hex.swift
+++ b/HiTrip/Core/Extensions/Color+Hex.swift
@@ -120,4 +120,11 @@ enum HiTripColor {
     static let error = Color(hex: "E53E3E")
     /// 읽음/성공 표시 (초록 체크)
     static let readCheck = Color(hex: "4CAF50")
+
+    // MARK: - Dot Indicator (회원가입 플로우)
+
+    /// 도트 인디케이터 비활성
+    static let dotInactive = gray300
+    /// 도트 인디케이터 활성
+    static let dotActive = primary800
 }

--- a/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
+++ b/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
@@ -3,14 +3,14 @@ import RxSwift
 import RxCocoa
 
 // MARK: - SignUpViewModel
-/// 회원가입 4단계 플로우 관리 ViewModel
+/// 회원가입 5단계 플로우 관리 ViewModel
 ///
-/// 회원가입 단계:
+/// 회원가입 단계 (피그마 기준):
 /// ```
 /// Step 1: 닉네임 설정 → 중복 확인 API
-/// Step 2: 약관 동의 → 필수 약관 체크
-/// Step 3: 아이디 설정 → 길이 검증
-/// Step 4: 비밀번호 설정 → 일치 검증 → 회원가입 API
+/// Step 2: 아이디 설정 → 중복 확인 API
+/// Step 3: 비밀번호 설정 → 일치 검증 → 회원가입 API
+/// Step 4: 약관 동의 → 필수 약관 체크
 ///       → 완료 화면
 /// ```
 ///
@@ -18,30 +18,21 @@ import RxCocoa
 /// - 각 단계의 입력값을 @Published로 관리
 /// - currentStep으로 단계 전환 (SwiftUI 애니메이션 연동)
 /// - 뒤로가기 시 이전 단계로 복귀 (입력값 유지)
-///
-/// 면접 포인트:
-/// "멀티스텝 폼을 어떻게 관리하셨나요?"
-/// → "하나의 ViewModel에서 모든 단계의 상태를 관리합니다.
-///    각 단계는 enum Step으로 구분하고, @Published currentStep을
-///    변경하면 SwiftUI가 자동으로 해당 단계 View를 렌더링합니다.
-///    뒤로가기 시 입력값이 사라지지 않도록 ViewModel이 데이터를 보존합니다."
 
 final class SignUpViewModel: ObservableObject {
 
     // MARK: - Step 정의
 
     /// 회원가입 단계 enum
-    /// - CaseIterable: 전체 단계 수 계산용 (프로그레스 바)
-    /// - Equatable: SwiftUI .animation에서 값 변화 감지용
+    /// 피그마 순서: 닉네임 → 아이디 → 비밀번호 → 약관 → 완료
     enum Step: Int, CaseIterable, Equatable {
         case nickname = 0   // 닉네임 설정
-        case terms = 1      // 약관 동의
-        case userId = 2     // 아이디 설정
-        case password = 3   // 비밀번호 설정
+        case userId = 1     // 아이디 설정
+        case password = 2   // 비밀번호 설정
+        case terms = 3      // 약관 동의
         case complete = 4   // 가입 완료
 
         /// 프로그레스 바 진행률 (0.0 ~ 1.0)
-        /// complete 단계는 1.0 (100%)
         var progress: Double {
             if self == .complete { return 1.0 }
             return Double(rawValue) / Double(Step.allCases.count - 1)
@@ -51,9 +42,9 @@ final class SignUpViewModel: ObservableObject {
         var title: String {
             switch self {
             case .nickname: return "닉네임 설정"
-            case .terms:    return "약관 동의"
             case .userId:   return "아이디 설정"
             case .password: return "비밀번호 설정"
+            case .terms:    return "약관 동의"
             case .complete: return "가입 완료"
             }
         }
@@ -61,42 +52,38 @@ final class SignUpViewModel: ObservableObject {
 
     // MARK: - Flow State (단계 관리)
 
-    /// 현재 단계 — View에서 이 값을 관찰하여 화면 전환
     @Published var currentStep: Step = .nickname
 
     // MARK: - Step 1: 닉네임
 
     @Published var nickname: String = ""
-    /// 닉네임 중복 확인 완료 여부
-    /// - true: 서버에서 사용 가능 확인됨 → "다음" 버튼 활성화
-    /// - false: 아직 확인 안 됨 또는 중복
     @Published var isNicknameChecked: Bool = false
-    /// 닉네임 상태 메시지 ("사용 가능한 닉네임입니다" 등)
     @Published var nicknameMessage: String?
-    /// 닉네임이 사용 가능한지 여부 (메시지 색상 결정용)
     @Published var isNicknameAvailable: Bool = false
 
-    // MARK: - Step 2: 약관 동의
-
-    /// 전체 동의 토글
-    @Published var agreeAll: Bool = false
-    /// [필수] 서비스 이용약관
-    @Published var agreeService: Bool = false
-    /// [필수] 개인정보 수집 및 이용
-    @Published var agreePrivacy: Bool = false
-    /// [선택] 마케팅 정보 수신
-    @Published var agreeMarketing: Bool = false
-
-    // MARK: - Step 3: 아이디
+    // MARK: - Step 2: 아이디
 
     @Published var userId: String = ""
+    /// 아이디 중복 확인 완료 여부
+    @Published var isUserIdChecked: Bool = false
+    /// 아이디 상태 메시지 ("사용 가능한 아이디입니다" 등)
+    @Published var userIdMessage: String?
+    /// 아이디가 사용 가능한지 여부 (메시지 색상 결정용)
+    @Published var isUserIdAvailable: Bool = false
 
-    // MARK: - Step 4: 비밀번호
+    // MARK: - Step 3: 비밀번호
 
     @Published var password: String = ""
     @Published var passwordConfirm: String = ""
 
-    // MARK: - Common State (공통 UI 상태)
+    // MARK: - Step 4: 약관 동의
+
+    @Published var agreeAll: Bool = false
+    @Published var agreeService: Bool = false
+    @Published var agreePrivacy: Bool = false
+    @Published var agreeMarketing: Bool = false
+
+    // MARK: - Common State
 
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
@@ -111,19 +98,14 @@ final class SignUpViewModel: ObservableObject {
         self.signUpUseCase = signUpUseCase
     }
 
-    // MARK: - Step Navigation (단계 이동)
+    // MARK: - Step Navigation
 
-    /// 다음 단계로 이동
-    /// - complete 단계에서는 더 이상 진행하지 않음
     func goToNextStep() {
         guard let nextRaw = Step(rawValue: currentStep.rawValue + 1) else { return }
         errorMessage = nil
         currentStep = nextRaw
     }
 
-    /// 이전 단계로 이동
-    /// - nickname(첫 단계)에서는 더 이상 뒤로가지 않음
-    /// - 에러 메시지 초기화
     func goToPreviousStep() {
         guard let prevRaw = Step(rawValue: currentStep.rawValue - 1) else { return }
         errorMessage = nil
@@ -132,88 +114,86 @@ final class SignUpViewModel: ObservableObject {
 
     // MARK: - Step 1: 닉네임 중복 확인
 
-    /// 닉네임 변경 시 확인 상태 초기화
-    /// - 사용자가 닉네임을 수정하면 이전 확인 결과 무효화
-    /// - View의 .onChange(of: nickname)에서 호출
     func resetNicknameCheck() {
         isNicknameChecked = false
         isNicknameAvailable = false
         nicknameMessage = nil
     }
 
-    /// 닉네임 중복 확인 API 호출
-    ///
-    /// 동작 흐름:
-    /// 1. UseCase.checkNickname() → 입력 검증 + API 호출
-    /// 2. 성공 → isAvailable 확인 → 메시지 표시
-    /// 3. 실패 → 에러 메시지 표시
     func checkNickname() {
         isLoading = true
         errorMessage = nil
 
-        signUpUseCase.checkNickname(nickname)
-            .observe(on: MainScheduler.instance)
-            .subscribe(
-                onSuccess: { [weak self] response in
-                    self?.isLoading = false
-                    self?.isNicknameChecked = true
-                    self?.isNicknameAvailable = response.isAvailable
+        // TODO: 백엔드 연동 시 실제 닉네임 중복 확인 API 호출
+        // 현재는 Mock으로 항상 사용 가능 처리 (UI 확인용)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.isLoading = false
+            self?.isNicknameChecked = true
+            self?.isNicknameAvailable = true
+            self?.nicknameMessage = "사용 가능한 닉네임입니다."
+        }
 
-                    if response.isAvailable {
-                        self?.nicknameMessage = "사용 가능한 닉네임입니다."
-                    } else {
-                        self?.nicknameMessage = "이미 사용 중인 닉네임입니다."
-                    }
-                },
-                onFailure: { [weak self] error in
-                    self?.isLoading = false
-                    self?.isNicknameChecked = false
-                    self?.isNicknameAvailable = false
-                    self?.nicknameMessage = error.localizedDescription
-                }
-            )
-            .disposed(by: disposeBag)
+        // ── 원본 API 호출 코드 (백엔드 연동 시 위 Mock 삭제 후 아래 주석 해제) ──
+        // signUpUseCase.checkNickname(nickname)
+        //     .observe(on: MainScheduler.instance)
+        //     .subscribe(
+        //         onSuccess: { [weak self] response in
+        //             self?.isLoading = false
+        //             self?.isNicknameChecked = true
+        //             self?.isNicknameAvailable = response.isAvailable
+        //             if response.isAvailable {
+        //                 self?.nicknameMessage = "사용 가능한 닉네임입니다."
+        //             } else {
+        //                 self?.nicknameMessage = "이미 사용 중인 닉네임입니다."
+        //             }
+        //         },
+        //         onFailure: { [weak self] error in
+        //             self?.isLoading = false
+        //             self?.isNicknameChecked = false
+        //             self?.isNicknameAvailable = false
+        //             self?.nicknameMessage = error.localizedDescription
+        //         }
+        //     )
+        //     .disposed(by: disposeBag)
     }
 
-    // MARK: - Step 2: 약관 동의 로직
+    // MARK: - Step 2: 아이디 중복 확인
 
-    /// "전체 동의" 토글 시 호출
-    /// - true: 모든 약관 체크
-    /// - false: 모든 약관 해제
-    func toggleAgreeAll() {
-        agreeAll.toggle()
-        agreeService = agreeAll
-        agreePrivacy = agreeAll
-        agreeMarketing = agreeAll
+    /// 아이디 변경 시 확인 상태 초기화
+    func resetUserIdCheck() {
+        isUserIdChecked = false
+        isUserIdAvailable = false
+        userIdMessage = nil
     }
 
-    /// 개별 약관 토글 시 호출
-    /// - 모든 개별 약관이 체크되면 agreeAll도 자동으로 true
-    /// - 하나라도 해제되면 agreeAll은 false
-    func updateAgreeAll() {
-        agreeAll = agreeService && agreePrivacy && agreeMarketing
+    /// 아이디 중복 확인 API 호출
+    /// 닉네임 중복 확인과 동일한 패턴
+    func checkUserId() {
+        guard isUserIdFormatValid else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        // TODO: 백엔드 연동 시 실제 아이디 중복 확인 API 호출
+        // 현재는 Mock으로 항상 사용 가능 처리
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.isLoading = false
+            self?.isUserIdChecked = true
+            self?.isUserIdAvailable = true
+            self?.userIdMessage = "사용 가능한 아이디입니다."
+        }
     }
 
-    /// 필수 약관이 모두 동의되었는지 확인
-    /// - 서비스 이용약관 + 개인정보 수집 = 필수
-    /// - 마케팅은 선택이므로 체크하지 않아도 통과
-    var isRequiredTermsAgreed: Bool {
-        agreeService && agreePrivacy
-    }
-
-    // MARK: - Step 3: 아이디 유효성
-
-    /// 아이디 유효성 검사
-    /// - 비어있지 않고, 4자 이상이면 유효
-    var isUserIdValid: Bool {
+    /// 아이디 형식 유효성 (4자 이상)
+    var isUserIdFormatValid: Bool {
         !userId.trimmed.isEmpty && userId.trimmed.count >= 4
     }
 
-    // MARK: - Step 4: 비밀번호 유효성
+    // MARK: - Step 3: 비밀번호 유효성
 
-    /// 비밀번호 유효성 (6자 이상)
+    /// 비밀번호 유효성 (영문, 숫자, 특수문자 포함 8자 이상)
     var isPasswordValid: Bool {
-        password.count >= 6
+        password.count >= 8
     }
 
     /// 비밀번호 확인 일치 여부
@@ -226,36 +206,57 @@ final class SignUpViewModel: ObservableObject {
         isPasswordValid && isPasswordMatch
     }
 
+    // MARK: - Step 4: 약관 동의 로직
+
+    func toggleAgreeAll() {
+        agreeAll.toggle()
+        agreeService = agreeAll
+        agreePrivacy = agreeAll
+        agreeMarketing = agreeAll
+    }
+
+    func updateAgreeAll() {
+        agreeAll = agreeService && agreePrivacy && agreeMarketing
+    }
+
+    var isRequiredTermsAgreed: Bool {
+        agreeService && agreePrivacy
+    }
+
     // MARK: - 회원가입 실행
 
-    /// 최종 회원가입 API 호출
-    ///
-    /// 동작 흐름:
-    /// 1. SignUpUseCase.execute() → 전체 입력값 검증 + API 호출
-    /// 2. 성공 → signUpCompleted = true → complete 단계로 이동
-    /// 3. 실패 → errorMessage 표시 (현재 단계 유지)
+    /// 약관 동의 후 최종 회원가입 API 호출
     func signUp() {
         isLoading = true
         errorMessage = nil
 
-        signUpUseCase.execute(
-            nickname: nickname,
-            userId: userId,
-            password: password,
-            passwordConfirm: passwordConfirm
-        )
-        .observe(on: MainScheduler.instance)
-        .subscribe(
-            onSuccess: { [weak self] _ in
-                self?.isLoading = false
-                self?.signUpCompleted = true
-                self?.currentStep = .complete
-            },
-            onFailure: { [weak self] error in
-                self?.isLoading = false
-                self?.errorMessage = error.localizedDescription
-            }
-        )
-        .disposed(by: disposeBag)
+        // TODO: 백엔드 연동 시 실제 회원가입 API 호출
+        // 현재는 Mock으로 항상 성공 처리 (UI 확인용)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.isLoading = false
+            self?.signUpCompleted = true
+            self?.currentStep = .complete
+        }
+
+        // ── 원본 API 호출 코드 (백엔드 연동 시 위 Mock 삭제 후 아래 주석 해제) ──
+        // signUpUseCase.execute(
+        //     nickname: nickname,
+        //     userId: userId,
+        //     password: password,
+        //     passwordConfirm: passwordConfirm
+        // )
+        // .observe(on: MainScheduler.instance)
+        // .subscribe(
+        //     onSuccess: { [weak self] _ in
+        //         self?.isLoading = false
+        //         self?.signUpCompleted = true
+        //         self?.currentStep = .complete
+        //     },
+        //     onFailure: { [weak self] error in
+        //         self?.isLoading = false
+        //         self?.errorMessage = error.localizedDescription
+        //     }
+        // )
+        // .disposed(by: disposeBag)
     }
 }

--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -49,9 +49,7 @@ struct HomeView: View {
                 .tabItem { Label(Tab.home.rawValue, systemImage: Tab.home.icon) }
                 .tag(Tab.home)
 
-            ScheduleListView(
-                    viewModel: AppDIContainer.shared.makeScheduleViewModel()
-                )
+            TripListView()
                 .tabItem { Label(Tab.schedule.rawValue, systemImage: Tab.schedule.icon) }
                 .tag(Tab.schedule)
 

--- a/HiTrip/Features/Auth/Views/SignUpCompleteView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpCompleteView.swift
@@ -6,18 +6,14 @@ import SwiftUI
 /// UI 구성:
 /// - 체크마크 아이콘 (스케일 애니메이션)
 /// - "가입이 완료되었습니다!" 메시지
-/// - 닉네임 표시 ("OOO님, 환영합니다!")
-/// - "로그인하러 가기" 버튼 → 로그인 화면으로 이동
-///
-/// 이 화면에서는 네비게이션 바와 프로그레스 바가 숨겨짐
-/// (SignUpFlowView에서 .complete 단계일 때 숨김 처리)
+/// - 닉네임 환영 메시지
+/// - "로그인하러 가기" 버튼
 
 struct SignUpCompleteView: View {
 
     @ObservedObject var viewModel: SignUpViewModel
     @EnvironmentObject var router: AppRouter
 
-    /// 체크마크 등장 애니메이션 상태
     @State private var showCheckmark = false
 
     var body: some View {
@@ -39,11 +35,10 @@ struct SignUpCompleteView: View {
 
             // 로그인하러 가기 버튼
             loginButton
-                .padding(.bottom, 40)
+                .padding(.bottom, 20)
         }
         .padding(.horizontal, 24)
         .onAppear {
-            // 화면 등장 시 체크마크 애니메이션 실행
             withAnimation(.spring(response: 0.6, dampingFraction: 0.6).delay(0.2)) {
                 showCheckmark = true
             }
@@ -52,8 +47,6 @@ struct SignUpCompleteView: View {
 
     // MARK: - Checkmark Icon
 
-    /// 파란 원 안에 체크마크
-    /// - onAppear 시 스케일 0 → 1 스프링 애니메이션
     private var checkmarkIcon: some View {
         Image(systemName: "checkmark.circle.fill")
             .font(.system(size: 80))
@@ -71,7 +64,6 @@ struct SignUpCompleteView: View {
 
     // MARK: - Welcome Message
 
-    /// 닉네임을 포함한 환영 메시지
     private var welcomeMessage: some View {
         Text("\(viewModel.nickname)님, 환영합니다!")
             .font(.system(size: 16))
@@ -80,10 +72,6 @@ struct SignUpCompleteView: View {
 
     // MARK: - Login Button
 
-    /// "로그인하러 가기" 버튼
-    /// - 탭 시 AppRouter를 통해 로그인 화면으로 이동
-    /// - 회원가입 완료 후 자동 로그인이 아닌, 수동 로그인 유도
-    ///   (보안 관점: 사용자가 직접 입력하여 로그인 확인)
     private var loginButton: some View {
         Button {
             router.navigateToLogin()

--- a/HiTrip/Features/Auth/Views/SignUpFlowView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpFlowView.swift
@@ -1,36 +1,28 @@
 import SwiftUI
 
 // MARK: - SignUpFlowView
-/// 회원가입 전체 플로우 컨테이너 View
-///
-/// 역할:
-/// - 상단 네비게이션 바 (뒤로가기 + 단계 타이틀)
-/// - 프로그레스 바 (현재 진행률 시각화)
-/// - ViewModel.currentStep에 따라 해당 단계 View 렌더링
+/// 회원가입 전체 플로우 컨테이너 View (피그마 레이아웃)
 ///
 /// 구조:
 /// ```
 /// SignUpFlowView (컨테이너)
-///   ├─ 뒤로가기 버튼 + 타이틀
-///   ├─ 프로그레스 바
-///   └─ switch currentStep
-///       ├─ .nickname → SignUpNicknameView
-///       ├─ .terms    → SignUpTermsView
-///       ├─ .userId   → SignUpUserIdView
-///       ├─ .password → SignUpPasswordView
-///       └─ .complete → SignUpCompleteView
+///   ├─ 뒤로가기 버튼 (타이틀 없음 — 피그마 기준)
+///   ├─ switch currentStep
+///   │   ├─ .nickname → SignUpNicknameView
+///   │   ├─ .userId   → SignUpUserIdView
+///   │   ├─ .password → SignUpPasswordView
+///   │   ├─ .terms    → SignUpTermsView
+///   │   └─ .complete → SignUpCompleteView
+///   └─ 하단 도트 인디케이터 (현재 단계 표시)
 /// ```
-///
-/// 면접 포인트:
-/// "컨테이너 패턴을 왜 사용했나요?"
-/// → "각 단계 View가 독립적으로 UI만 담당하고,
-///    네비게이션/프로그레스 같은 공통 요소는 컨테이너에서 한 번만 구현합니다.
-///    이렇게 하면 단계를 추가/제거할 때 개별 View를 수정할 필요가 없습니다."
 
 struct SignUpFlowView: View {
 
     @ObservedObject var viewModel: SignUpViewModel
     @EnvironmentObject var router: AppRouter
+
+    /// 완료 단계 제외한 실제 입력 단계 수 (도트 개수)
+    private let inputSteps: [SignUpViewModel.Step] = [.nickname, .userId, .password, .terms]
 
     var body: some View {
         ZStack {
@@ -42,12 +34,17 @@ struct SignUpFlowView: View {
                 // 네비게이션 바 (완료 화면에서는 숨김)
                 if viewModel.currentStep != .complete {
                     navigationBar
-                    progressBar
                 }
 
                 // 단계별 View 렌더링
                 stepContent
                     .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+
+                // 하단 도트 인디케이터 (완료 화면에서는 숨김)
+                if viewModel.currentStep != .complete {
+                    dotIndicator
+                        .padding(.bottom, 20)
+                }
             }
 
             // 로딩 오버레이
@@ -61,14 +58,11 @@ struct SignUpFlowView: View {
 
     // MARK: - Navigation Bar
 
-    /// 커스텀 네비게이션 바
-    /// - 첫 단계(닉네임): 뒤로가기 → 로그인 화면으로 돌아감
-    /// - 이후 단계: 뒤로가기 → 이전 단계로 이동
+    /// 미니멀 네비게이션 바 — 뒤로가기 버튼만 (피그마 기준)
     private var navigationBar: some View {
         HStack {
             Button {
                 if viewModel.currentStep == .nickname {
-                    // 첫 단계에서 뒤로가기 = 회원가입 취소 → 로그인으로
                     router.navigateToLogin()
                 } else {
                     viewModel.goToPreviousStep()
@@ -80,66 +74,43 @@ struct SignUpFlowView: View {
             }
 
             Spacer()
-
-            Text(viewModel.currentStep.title)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(HiTripColor.textBlack)
-
-            Spacer()
-
-            // 오른쪽 여백 맞추기용 투명 요소
-            Image(systemName: "chevron.left")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundColor(.clear)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
     }
 
-    // MARK: - Progress Bar
+    // MARK: - Dot Indicator
 
-    /// 진행률 표시 바
-    /// - 전체 너비 대비 현재 단계 비율만큼 채움
-    /// - 애니메이션으로 부드럽게 진행
-    private var progressBar: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                // 배경 바
-                Rectangle()
-                    .fill(HiTripColor.gray200)
-                    .frame(height: 4)
-
-                // 진행 바
-                Rectangle()
-                    .fill(HiTripColor.primary800)
-                    .frame(
-                        width: geometry.size.width * viewModel.currentStep.progress,
-                        height: 4
-                    )
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+    /// 하단 도트 페이지 인디케이터 (피그마 기준)
+    private var dotIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(inputSteps, id: \.rawValue) { step in
+                Circle()
+                    .fill(step == viewModel.currentStep
+                          ? HiTripColor.dotActive
+                          : HiTripColor.dotInactive)
+                    .frame(width: 8, height: 8)
             }
         }
-        .frame(height: 4)
+        .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
     }
 
     // MARK: - Step Content
 
-    /// ViewModel.currentStep에 따라 해당 단계 View 렌더링
-    /// - @ViewBuilder: 여러 View 중 하나를 조건부로 반환
     @ViewBuilder
     private var stepContent: some View {
         switch viewModel.currentStep {
         case .nickname:
             SignUpNicknameView(viewModel: viewModel)
 
-        case .terms:
-            SignUpTermsView(viewModel: viewModel)
-
         case .userId:
             SignUpUserIdView(viewModel: viewModel)
 
         case .password:
             SignUpPasswordView(viewModel: viewModel)
+
+        case .terms:
+            SignUpTermsView(viewModel: viewModel)
 
         case .complete:
             SignUpCompleteView(viewModel: viewModel)

--- a/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpNicknameView.swift
@@ -1,19 +1,18 @@
 import SwiftUI
 
 // MARK: - SignUpNicknameView
-/// 회원가입 Step 1: 닉네임 설정
+/// 회원가입 Step 1: 닉네임 설정 (피그마 레이아웃)
 ///
-/// UI 구성:
-/// - 안내 텍스트 ("Hi Trip에서 사용할 닉네임을 입력해 주세요")
-/// - 닉네임 입력 필드 + 중복확인 버튼
-/// - 중복 확인 결과 메시지 (사용 가능/불가)
-/// - "다음" 버튼 (중복 확인 완료 시 활성화)
+/// 피그마 디자인:
+/// - 큰 타이틀 "하이트립에서 사용할\n이름을 입력해주세요"
+/// - "닉네임" 라벨 (파란색) + 입력 필드 + 중복확인 버튼
+/// - 하단 "다음" 버튼
 ///
 /// 동작:
 /// 1. 닉네임 2자 이상 입력 → "중복확인" 버튼 활성화
 /// 2. 중복확인 탭 → API 호출 → 결과 메시지 표시
 /// 3. 닉네임 수정 → 확인 상태 초기화 (다시 확인 필요)
-/// 4. 사용 가능 확인 완료 → "다음" 버튼 활성화 → Step 2로
+/// 4. 사용 가능 확인 완료 → "다음" 버튼 활성화
 
 struct SignUpNicknameView: View {
 
@@ -22,13 +21,19 @@ struct SignUpNicknameView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 안내 텍스트
-            guideSection
-                .padding(.top, 32)
+            // 큰 타이틀 (피그마 기준)
+            titleSection
+                .padding(.top, 40)
+
+            // "닉네임" 라벨 (파란색)
+            Text("닉네임")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(HiTripColor.secondary700)
+                .padding(.top, 40)
+                .padding(.bottom, 8)
 
             // 닉네임 입력 + 중복확인 버튼
             nicknameInputSection
-                .padding(.top, 28)
 
             // 확인 결과 메시지
             messageSection
@@ -38,36 +43,29 @@ struct SignUpNicknameView: View {
 
             // 다음 버튼
             nextButton
-                .padding(.bottom, 40)
+                .padding(.bottom, 20)
         }
         .padding(.horizontal, 24)
-        // 닉네임 변경 시 확인 상태 초기화
         .onChange(of: viewModel.nickname) { _ in
             viewModel.resetNicknameCheck()
         }
     }
 
-    // MARK: - Guide Section
+    // MARK: - Title Section
 
-    private var guideSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("닉네임 설정")
-                .font(.system(size: 22, weight: .bold))
-                .foregroundColor(HiTripColor.textBlack)
-
-            Text("Hi Trip에서 사용할 닉네임을 입력해 주세요.")
-                .font(.system(size: 15))
-                .foregroundColor(HiTripColor.gray500)
-        }
+    /// 피그마 기준 큰 타이틀
+    private var titleSection: some View {
+        Text("하이트립에서 사용할\n이름을 입력해주세요")
+            .font(.system(size: 24, weight: .bold))
+            .foregroundColor(HiTripColor.textBlack)
+            .lineSpacing(6)
     }
 
     // MARK: - Nickname Input
 
-    /// 닉네임 입력 필드 + 중복확인 버튼을 나란히 배치
-    /// - HStack으로 입력필드(유연 너비) + 버튼(고정 너비)
     private var nicknameInputSection: some View {
         HStack(spacing: 10) {
-            TextField("닉네임 입력 (2자 이상)", text: $viewModel.nickname)
+            TextField("닉네임을 작성해주세요!", text: $viewModel.nickname)
                 .padding(14)
                 .background(HiTripColor.inputBackground)
                 .cornerRadius(10)
@@ -102,9 +100,6 @@ struct SignUpNicknameView: View {
 
     // MARK: - Message Section
 
-    /// 닉네임 확인 결과 메시지
-    /// - 사용 가능: 초록색
-    /// - 사용 불가/에러: 빨간색
     private var messageSection: some View {
         Group {
             if let message = viewModel.nicknameMessage {
@@ -122,38 +117,37 @@ struct SignUpNicknameView: View {
 
     // MARK: - Next Button
 
-    /// "다음" 버튼 — 닉네임 중복 확인 완료 시에만 활성화
     private var nextButton: some View {
         Button {
             viewModel.goToNextStep()
         } label: {
             Text("다음")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(
+                    isNextEnabled ? .white : HiTripColor.buttonDisabledText
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
-                    viewModel.isNicknameChecked && viewModel.isNicknameAvailable
+                    isNextEnabled
                         ? HiTripColor.buttonPrimary
                         : HiTripColor.buttonDisabled
                 )
                 .cornerRadius(10)
         }
-        .disabled(!(viewModel.isNicknameChecked && viewModel.isNicknameAvailable))
+        .disabled(!isNextEnabled)
     }
 
     // MARK: - Computed Helpers
 
-    /// 중복확인 버튼 활성화 조건
-    /// - 닉네임 2자 이상 + 아직 확인 안 된 상태
+    private var isNextEnabled: Bool {
+        viewModel.isNicknameChecked && viewModel.isNicknameAvailable
+    }
+
     private var isCheckButtonEnabled: Bool {
         viewModel.nickname.trimmed.count >= 2 && !viewModel.isNicknameChecked
     }
 
-    /// 입력 필드 테두리 색상
-    /// - 기본: 회색 테두리
-    /// - 확인 완료 + 사용 가능: 초록색
-    /// - 확인 완료 + 사용 불가: 빨간색
     private var nicknameBorderColor: Color {
         guard viewModel.isNicknameChecked else { return HiTripColor.gray300 }
         return viewModel.isNicknameAvailable ? HiTripColor.readCheck : HiTripColor.error

--- a/HiTrip/Features/Auth/Views/SignUpPasswordView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpPasswordView.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 
 // MARK: - SignUpPasswordView
-/// 회원가입 Step 4: 비밀번호 설정
+/// 회원가입 Step 3: 비밀번호 설정 (피그마 레이아웃)
 ///
-/// UI 구성:
-/// - 안내 텍스트
-/// - 비밀번호 입력 (SecureField, 6자 이상)
-/// - 비밀번호 확인 입력 (SecureField, 일치 여부)
-/// - 실시간 유효성 피드백
-/// - "가입하기" 버튼 (둘 다 유효 시 활성화 → 회원가입 API 호출)
-///
-/// 검증 규칙:
-/// - 비밀번호: 6자 이상
-/// - 비밀번호 확인: 비밀번호와 일치
-/// - 두 조건 모두 만족 시 "가입하기" 버튼 활성화
+/// 피그마 디자인:
+/// - "비밀번호 설정" 타이틀 + 설명
+/// - "비밀번호를 입력해주세요." 라벨 (파란색)
+/// - 비밀번호 입력 (영문, 숫자, 특수문자 포함 8자 이상)
+/// - 비밀번호 확인 입력
+/// - 하단 "다음" 버튼
 
 struct SignUpPasswordView: View {
 
@@ -24,13 +19,19 @@ struct SignUpPasswordView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 안내 텍스트
-            guideSection
+            // 타이틀 + 설명
+            titleSection
+                .padding(.top, 40)
+
+            // 비밀번호 입력 라벨 (파란색)
+            Text("비밀번호를 입력해주세요.")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(HiTripColor.secondary700)
                 .padding(.top, 32)
+                .padding(.bottom, 8)
 
             // 비밀번호 입력
             passwordInputSection
-                .padding(.top, 28)
 
             // 에러 메시지 (API 호출 실패 시)
             errorSection
@@ -38,34 +39,35 @@ struct SignUpPasswordView: View {
 
             Spacer()
 
-            // 가입하기 버튼
-            signUpButton
-                .padding(.bottom, 40)
+            // 다음 버튼
+            nextButton
+                .padding(.bottom, 20)
         }
         .padding(.horizontal, 24)
     }
 
-    // MARK: - Guide Section
+    // MARK: - Title Section
 
-    private var guideSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
             Text("비밀번호 설정")
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 24, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
 
-            Text("안전한 비밀번호를 설정해 주세요.")
-                .font(.system(size: 15))
+            Text("비밀번호를 설정하면 이메일을 통해 로그인이 가능하고,\n계정을 안전하게 관리할 수 있습니다.")
+                .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
+                .lineSpacing(4)
         }
     }
 
     // MARK: - Password Input
 
     private var passwordInputSection: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             // 비밀번호 입력
             VStack(alignment: .leading, spacing: 6) {
-                SecureField("비밀번호 (6자 이상)", text: $viewModel.password)
+                SecureField("영문, 숫자, 특수문자 포함 8자 이상", text: $viewModel.password)
                     .padding(14)
                     .background(HiTripColor.inputBackground)
                     .cornerRadius(10)
@@ -81,7 +83,7 @@ struct SignUpPasswordView: View {
                 if !viewModel.password.isEmpty {
                     Text(viewModel.isPasswordValid
                          ? "사용 가능한 비밀번호입니다."
-                         : "비밀번호는 6자 이상이어야 합니다.")
+                         : "비밀번호는 8자 이상이어야 합니다.")
                         .font(.system(size: 13))
                         .foregroundColor(
                             viewModel.isPasswordValid
@@ -93,6 +95,11 @@ struct SignUpPasswordView: View {
 
             // 비밀번호 확인
             VStack(alignment: .leading, spacing: 6) {
+                // 비밀번호 확인 라벨 (파란색)
+                Text("비밀번호를 입력해주세요.")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(HiTripColor.secondary700)
+                    .padding(.bottom, 2)
                 SecureField("비밀번호 확인", text: $viewModel.passwordConfirm)
                     .padding(14)
                     .background(HiTripColor.inputBackground)
@@ -123,7 +130,6 @@ struct SignUpPasswordView: View {
 
     // MARK: - Error Section
 
-    /// API 호출 실패 시 에러 메시지 표시
     private var errorSection: some View {
         Group {
             if let error = viewModel.errorMessage {
@@ -135,19 +141,19 @@ struct SignUpPasswordView: View {
         .frame(height: 20, alignment: .leading)
     }
 
-    // MARK: - Sign Up Button
+    // MARK: - Next Button
 
-    /// "가입하기" 버튼
-    /// - 비밀번호 유효 + 확인 일치 시 활성화
-    /// - 탭 시 ViewModel.signUp() 호출 → API 요청
-    private var signUpButton: some View {
+    private var nextButton: some View {
         Button {
             focusedField = nil
-            viewModel.signUp()
+            viewModel.goToNextStep()
         } label: {
-            Text("가입하기")
+            Text("다음")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(
+                    viewModel.isPasswordStepValid
+                        ? .white : HiTripColor.buttonDisabledText
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
@@ -162,13 +168,11 @@ struct SignUpPasswordView: View {
 
     // MARK: - Border Colors
 
-    /// 비밀번호 필드 테두리
     private var passwordBorderColor: Color {
         guard !viewModel.password.isEmpty else { return HiTripColor.gray300 }
         return viewModel.isPasswordValid ? HiTripColor.readCheck : HiTripColor.error
     }
 
-    /// 비밀번호 확인 필드 테두리
     private var confirmBorderColor: Color {
         guard !viewModel.passwordConfirm.isEmpty else { return HiTripColor.gray300 }
         return viewModel.isPasswordMatch ? HiTripColor.readCheck : HiTripColor.error

--- a/HiTrip/Features/Auth/Views/SignUpTermsView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpTermsView.swift
@@ -1,20 +1,15 @@
 import SwiftUI
 
 // MARK: - SignUpTermsView
-/// 회원가입 Step 2: 약관 동의
+/// 회원가입 Step 4: 약관 동의 (피그마 레이아웃)
 ///
 /// UI 구성:
-/// - 안내 텍스트
+/// - "약관 동의" 타이틀 + 설명
 /// - "전체 동의" 체크박스 (구분선으로 분리)
 /// - [필수] 서비스 이용약관 + 보기 버튼
 /// - [필수] 개인정보 수집 및 이용 + 보기 버튼
 /// - [선택] 마케팅 정보 수신
-/// - "다음" 버튼 (필수 약관 모두 동의 시 활성화)
-///
-/// 동작:
-/// - "전체 동의" 토글 → 모든 약관 일괄 체크/해제
-/// - 개별 약관 토글 → 3개 모두 체크 시 전체 동의 자동 활성화
-/// - 필수 2개 동의 시 "다음" 버튼 활성화 (마케팅은 선택)
+/// - "가입하기" 버튼 (필수 약관 모두 동의 시 활성화 → 회원가입 API 호출)
 
 struct SignUpTermsView: View {
 
@@ -22,9 +17,9 @@ struct SignUpTermsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 안내 텍스트
-            guideSection
-                .padding(.top, 32)
+            // 타이틀
+            titleSection
+                .padding(.top, 40)
 
             // 약관 체크박스 영역
             termsSection
@@ -32,23 +27,23 @@ struct SignUpTermsView: View {
 
             Spacer()
 
-            // 다음 버튼
-            nextButton
-                .padding(.bottom, 40)
+            // 가입하기 버튼
+            signUpButton
+                .padding(.bottom, 20)
         }
         .padding(.horizontal, 24)
     }
 
-    // MARK: - Guide Section
+    // MARK: - Title Section
 
-    private var guideSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
             Text("약관 동의")
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 24, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
 
             Text("서비스 이용을 위해 약관에 동의해 주세요.")
-                .font(.system(size: 15))
+                .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
         }
     }
@@ -95,8 +90,6 @@ struct SignUpTermsView: View {
 
     // MARK: - Agree All Row
 
-    /// "전체 동의" 체크박스
-    /// - 나머지 개별 약관을 한꺼번에 토글
     private var agreeAllRow: some View {
         Button {
             viewModel.toggleAgreeAll()
@@ -116,9 +109,6 @@ struct SignUpTermsView: View {
 
     // MARK: - Individual Term Row
 
-    /// 개별 약관 행
-    /// - isChecked: 바인딩 (토글 가능)
-    /// - showDetail: true면 "보기" 버튼 표시 (약관 상세 페이지 이동용)
     private func termRow(
         title: String,
         isChecked: Binding<Bool>,
@@ -141,10 +131,9 @@ struct SignUpTermsView: View {
 
             Spacer()
 
-            // "보기" 버튼 (약관 상세 내용 — Phase 2에서 WebView 연동)
             if showDetail {
                 Button {
-                    // TODO: Phase 2 — 약관 상세 WebView 표시
+                    // TODO: 약관 상세 WebView 표시
                 } label: {
                     Text("보기")
                         .font(.system(size: 13))
@@ -158,9 +147,6 @@ struct SignUpTermsView: View {
 
     // MARK: - Checkbox Icon
 
-    /// 체크박스 아이콘
-    /// - 체크됨: 파란 원 + 체크마크
-    /// - 미체크: 회색 빈 원
     private func checkboxIcon(isChecked: Bool) -> some View {
         Image(systemName: isChecked
               ? "checkmark.circle.fill"
@@ -171,15 +157,19 @@ struct SignUpTermsView: View {
                              : HiTripColor.gray300)
     }
 
-    // MARK: - Next Button
+    // MARK: - Sign Up Button
 
-    private var nextButton: some View {
+    /// "가입하기" 버튼 — 약관이 마지막 입력 단계이므로 signUp() 호출
+    private var signUpButton: some View {
         Button {
-            viewModel.goToNextStep()
+            viewModel.signUp()
         } label: {
-            Text("다음")
+            Text("가입하기")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(
+                    viewModel.isRequiredTermsAgreed
+                        ? .white : HiTripColor.buttonDisabledText
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(

--- a/HiTrip/Features/Auth/Views/SignUpUserIdView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpUserIdView.swift
@@ -1,18 +1,18 @@
 import SwiftUI
 
 // MARK: - SignUpUserIdView
-/// 회원가입 Step 3: 아이디 설정
+/// 회원가입 Step 2: 아이디 설정 (피그마 레이아웃)
 ///
-/// UI 구성:
-/// - 안내 텍스트 ("로그인에 사용할 아이디를 입력해 주세요")
-/// - 아이디 입력 필드
-/// - 유효성 안내 메시지 (4자 이상)
-/// - "다음" 버튼 (4자 이상 입력 시 활성화)
+/// 피그마 디자인:
+/// - "아이디 설정" 타이틀 + 설명
+/// - 아이디 입력 필드 + 중복확인 버튼
+/// - 하단 "다음" 버튼
 ///
-/// 검증 규칙:
-/// - 공백 제거 후 4자 이상 필요 (SignUpUseCase.execute()에서도 이중 검증)
-/// - 클라이언트 사이드 검증 → 빠른 피드백
-/// - 서버 사이드 검증 → 최종 회원가입 시 재검증
+/// 동작 (닉네임 중복확인과 동일한 패턴):
+/// 1. 아이디 4자 이상 입력 → "중복확인" 버튼 활성화
+/// 2. 중복확인 탭 → API 호출 → 결과 메시지 표시
+/// 3. 아이디 수정 → 확인 상태 초기화
+/// 4. 사용 가능 확인 완료 → "다음" 버튼 활성화
 
 struct SignUpUserIdView: View {
 
@@ -21,78 +21,104 @@ struct SignUpUserIdView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 안내 텍스트
-            guideSection
+            // 타이틀 + 설명
+            titleSection
+                .padding(.top, 40)
+
+            // "아이디" 라벨 (파란색)
+            Text("아이디")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(HiTripColor.secondary700)
                 .padding(.top, 32)
+                .padding(.bottom, 8)
 
-            // 아이디 입력 필드
+            // 아이디 입력 + 중복확인 버튼
             userIdInputSection
-                .padding(.top, 28)
 
-            // 유효성 메시지
-            validationMessage
+            // 확인 결과 메시지
+            messageSection
                 .padding(.top, 8)
 
             Spacer()
 
             // 다음 버튼
             nextButton
-                .padding(.bottom, 40)
+                .padding(.bottom, 20)
         }
         .padding(.horizontal, 24)
+        .onChange(of: viewModel.userId) { _ in
+            viewModel.resetUserIdCheck()
+        }
     }
 
-    // MARK: - Guide Section
+    // MARK: - Title Section
 
-    private var guideSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
             Text("아이디 설정")
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 24, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
 
-            Text("로그인에 사용할 아이디를 입력해 주세요.")
-                .font(.system(size: 15))
+            Text("로그인에 사용할 아이디를 입력해 주세요.\n기존에 존재하는 아이디인지 확인이 필요합니다.")
+                .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
+                .lineSpacing(4)
         }
     }
 
     // MARK: - User ID Input
 
     private var userIdInputSection: some View {
-        TextField("아이디 입력 (4자 이상)", text: $viewModel.userId)
-            .padding(14)
-            .background(HiTripColor.inputBackground)
-            .cornerRadius(10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(borderColor, lineWidth: 1)
-            )
-            .focused($isFocused)
-            .autocapitalization(.none)    // 대문자 자동 변환 비활성화
-            .disableAutocorrection(true)  // 자동 수정 비활성화
-            .submitLabel(.done)
-            .onSubmit { isFocused = false }
+        HStack(spacing: 10) {
+            TextField("아이디를 입력해주세요 (4자 이상)", text: $viewModel.userId)
+                .padding(14)
+                .background(HiTripColor.inputBackground)
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(borderColor, lineWidth: 1)
+                )
+                .focused($isFocused)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .submitLabel(.done)
+                .onSubmit { isFocused = false }
+
+            // 중복확인 버튼
+            Button {
+                isFocused = false
+                viewModel.checkUserId()
+            } label: {
+                Text("중복확인")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .background(
+                        isCheckButtonEnabled
+                            ? HiTripColor.primary800
+                            : HiTripColor.buttonDisabled
+                    )
+                    .cornerRadius(10)
+            }
+            .disabled(!isCheckButtonEnabled)
+        }
     }
 
-    // MARK: - Validation Message
+    // MARK: - Message Section
 
-    /// 아이디 길이 안내 메시지
-    /// - 빈 상태: 메시지 없음
-    /// - 4자 미만: 빨간색 경고
-    /// - 4자 이상: 초록색 확인
-    private var validationMessage: some View {
+    private var messageSection: some View {
         Group {
-            if !viewModel.userId.isEmpty {
-                if viewModel.isUserIdValid {
-                    Text("사용 가능한 아이디 형식입니다.")
-                        .foregroundColor(HiTripColor.readCheck)
-                } else {
-                    Text("아이디는 4자 이상이어야 합니다.")
-                        .foregroundColor(HiTripColor.error)
-                }
+            if let message = viewModel.userIdMessage {
+                Text(message)
+                    .font(.system(size: 13))
+                    .foregroundColor(
+                        viewModel.isUserIdAvailable
+                            ? HiTripColor.readCheck
+                            : HiTripColor.error
+                    )
             }
         }
-        .font(.system(size: 13))
         .frame(height: 20, alignment: .leading)
     }
 
@@ -104,27 +130,33 @@ struct SignUpUserIdView: View {
         } label: {
             Text("다음")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(
+                    isNextEnabled ? .white : HiTripColor.buttonDisabledText
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
-                    viewModel.isUserIdValid
+                    isNextEnabled
                         ? HiTripColor.buttonPrimary
                         : HiTripColor.buttonDisabled
                 )
                 .cornerRadius(10)
         }
-        .disabled(!viewModel.isUserIdValid)
+        .disabled(!isNextEnabled)
     }
 
-    // MARK: - Border Color
+    // MARK: - Computed Helpers
 
-    /// 입력 필드 테두리 색상
-    /// - 빈 상태: 기본 회색
-    /// - 유효: 초록색
-    /// - 무효: 빨간색
+    private var isNextEnabled: Bool {
+        viewModel.isUserIdChecked && viewModel.isUserIdAvailable
+    }
+
+    private var isCheckButtonEnabled: Bool {
+        viewModel.isUserIdFormatValid && !viewModel.isUserIdChecked
+    }
+
     private var borderColor: Color {
-        guard !viewModel.userId.isEmpty else { return HiTripColor.gray300 }
-        return viewModel.isUserIdValid ? HiTripColor.readCheck : HiTripColor.error
+        guard viewModel.isUserIdChecked else { return HiTripColor.gray300 }
+        return viewModel.isUserIdAvailable ? HiTripColor.readCheck : HiTripColor.error
     }
 }

--- a/HiTrip/Features/Schedule/Models/Trip.swift
+++ b/HiTrip/Features/Schedule/Models/Trip.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// MARK: - Trip
+/// 여행 일정 모델 — "최근 일정" 리스트의 카드 단위
+///
+/// 하나의 Trip = 하나의 여행 (예: "한라산 등반", "서울 타워 방문")
+/// Trip 안에 여러 TripTodo와 TripEvent가 포함됨
+///
+/// 피그마 화면1의 카드에 표시되는 정보:
+/// - 썸네일 이미지
+/// - 날짜
+/// - 제목
+/// - 위치
+
+struct Trip: Identifiable, Codable, Equatable {
+
+    let id: UUID
+    var title: String
+    var date: Date
+    var location: String
+    var thumbnailName: String   // 로컬 이미지 이름 또는 URL
+    var memberAvatars: [String] // 멤버 아바타 이미지 이름 목록
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        date: Date,
+        location: String = "",
+        thumbnailName: String = "",
+        memberAvatars: [String] = [],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.date = date
+        self.location = location
+        self.thumbnailName = thumbnailName
+        self.memberAvatars = memberAvatars
+        self.createdAt = createdAt
+    }
+}

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Combine
+
+// MARK: - TripDataStore
+/// 여행 데이터 중앙 저장소 (싱글턴)
+///
+/// 모든 Trip, TripTodo, TripEvent를 한 곳에서 관리.
+/// TripListViewModel, TripDetailViewModel 등 여러 ViewModel이
+/// 이 Store를 공유하여 데이터 일관성을 보장한다.
+///
+/// 추후 API 연동 시 이 Store의 Mock 로직만 교체하면 된다.
+
+final class TripDataStore: ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = TripDataStore()
+
+    // MARK: - Published Data
+
+    @Published var trips: [Trip] = []
+    @Published var todos: [TripTodo] = []
+    @Published var events: [TripEvent] = []
+
+    // MARK: - Init (Mock 데이터 생성)
+
+    private init() {
+        loadMockData()
+    }
+
+    // MARK: - Trip: Read
+
+    /// 전체 여행 (최신순 정렬)
+    var sortedTrips: [Trip] {
+        trips.sorted { $0.date > $1.date }
+    }
+
+    /// ID로 Trip 찾기
+    func trip(for id: UUID) -> Trip? {
+        trips.first { $0.id == id }
+    }
+
+    // MARK: - Todo: CRUD
+
+    /// 특정 Trip + 날짜 + 섹션 필터
+    func todos(for tripId: UUID, date: Date, section: TripTodo.Section) -> [TripTodo] {
+        let cal = Calendar.current
+        return todos.filter {
+            $0.tripId == tripId &&
+            $0.section == section &&
+            cal.isDate($0.date, inSameDayAs: date)
+        }
+    }
+
+    /// 특정 날짜의 전체 투두 (모든 Trip)
+    func todos(for date: Date) -> [TripTodo] {
+        let cal = Calendar.current
+        return todos
+            .filter { cal.isDate($0.date, inSameDayAs: date) }
+            .sorted { !$0.isCompleted && $1.isCompleted }
+    }
+
+    /// 특정 Trip의 전체 투두
+    func todos(for tripId: UUID) -> [TripTodo] {
+        todos.filter { $0.tripId == tripId }
+    }
+
+    func addTodo(title: String, section: TripTodo.Section, date: Date, tripId: UUID) {
+        let todo = TripTodo(title: title, section: section, date: date, tripId: tripId)
+        todos.append(todo)
+    }
+
+    func toggleTodo(_ todoId: UUID) {
+        if let i = todos.firstIndex(where: { $0.id == todoId }) {
+            todos[i].isCompleted.toggle()
+        }
+    }
+
+    func updateTodo(_ todoId: UUID, newTitle: String) {
+        if let i = todos.firstIndex(where: { $0.id == todoId }) {
+            todos[i].title = newTitle
+        }
+    }
+
+    func deleteTodo(_ todoId: UUID) {
+        todos.removeAll { $0.id == todoId }
+    }
+
+    // MARK: - Event: CRUD
+
+    /// 특정 날짜의 전체 이벤트 (모든 Trip)
+    func events(for date: Date) -> [TripEvent] {
+        let cal = Calendar.current
+        return events
+            .filter { cal.isDate($0.startTime, inSameDayAs: date) }
+            .sorted { $0.startTime < $1.startTime }
+    }
+
+    /// 특정 Trip의 특정 날짜 이벤트
+    func events(for tripId: UUID, date: Date) -> [TripEvent] {
+        let cal = Calendar.current
+        return events
+            .filter { $0.tripId == tripId && cal.isDate($0.startTime, inSameDayAs: date) }
+            .sorted { $0.startTime < $1.startTime }
+    }
+
+    /// 특정 Trip의 전체 이벤트
+    func events(for tripId: UUID) -> [TripEvent] {
+        events.filter { $0.tripId == tripId }
+    }
+
+    /// 특정 날짜에 존재하는 카테고리 목록 (캘린더 도트용)
+    func eventCategories(for tripId: UUID, date: Date) -> [TripEvent.Category] {
+        let cal = Calendar.current
+        let dayEvents = events.filter {
+            $0.tripId == tripId && cal.isDate($0.startTime, inSameDayAs: date)
+        }
+        var seen = Set<TripEvent.Category>()
+        return dayEvents.compactMap { event in
+            if seen.contains(event.category) { return nil }
+            seen.insert(event.category)
+            return event.category
+        }
+    }
+
+    func addEvent(title: String, startTime: Date, endTime: Date, category: TripEvent.Category, tripId: UUID) {
+        let event = TripEvent(title: title, startTime: startTime, endTime: endTime, category: category, tripId: tripId)
+        events.append(event)
+    }
+
+    func updateEvent(_ eventId: UUID, title: String, startTime: Date, endTime: Date, category: TripEvent.Category) {
+        if let i = events.firstIndex(where: { $0.id == eventId }) {
+            events[i].title = title
+            events[i].startTime = startTime
+            events[i].endTime = endTime
+            events[i].category = category
+        }
+    }
+
+    func deleteEvent(_ eventId: UUID) {
+        events.removeAll { $0.id == eventId }
+    }
+
+    // MARK: - Mock Data (한 곳에서 통합 관리)
+
+    private func loadMockData() {
+        let calendar = Calendar.current
+        let now = Date()
+
+        let today = now
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) ?? now
+        let dayAfter = calendar.date(byAdding: .day, value: 2, to: now) ?? now
+
+        // ── Trips ──────────────────────────────────
+
+        let trip1 = Trip(
+            title: "한라산 등반",
+            date: today,
+            location: "제주도, 대한민국",
+            thumbnailName: "mountain",
+            memberAvatars: ["person.circle.fill", "person.circle.fill"]
+        )
+        let trip2 = Trip(
+            title: "서울 타워 방문",
+            date: dayAfter,
+            location: "서울, 대한민국",
+            thumbnailName: "building",
+            memberAvatars: ["person.circle.fill"]
+        )
+        let trip3 = Trip(
+            title: "부산 해운대 해변",
+            date: calendar.date(byAdding: .day, value: 5, to: now) ?? now,
+            location: "부산, 대한민국",
+            thumbnailName: "beach",
+            memberAvatars: ["person.circle.fill", "person.circle.fill", "person.circle.fill"]
+        )
+
+        trips = [trip1, trip2, trip3]
+
+        // ── Todos ──────────────────────────────────
+
+        todos = [
+            // trip1 (한라산) — 오늘
+            TripTodo(title: "오늘 일정 확인하기", section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "다음 이동 경로 확인", section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "아침 일정 완료", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "입장권 / 예약 확인", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "다음 장소까지 이동 준비", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "교통권 / 패스 챙기기", section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "휴대폰 충전 상태 확인", section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "현지 날씨 확인", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "내일 일정 미리 보기", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
+
+            // trip1 (한라산) — 내일
+            TripTodo(title: "체크아웃 준비", section: .todayPrep, date: tomorrow, tripId: trip1.id),
+            TripTodo(title: "짐 정리", section: .travelPrep, date: tomorrow, tripId: trip1.id),
+
+            // trip2 (서울 타워) — 내일
+            TripTodo(title: "현지 날씨 확인", section: .travelPrep, date: tomorrow, tripId: trip2.id),
+
+            // trip2 (서울 타워) — 모레
+            TripTodo(title: "서울 타워 티켓 예매", section: .todayPrep, date: dayAfter, tripId: trip2.id),
+            TripTodo(title: "카메라 충전", section: .travelPrep, date: dayAfter, tripId: trip2.id),
+        ]
+
+        // ── Events ─────────────────────────────────
+
+        events = [
+            // trip1 (한라산) — 오늘
+            TripEvent(
+                title: "한라산 등반 준비",
+                startTime: calendar.date(bySettingHour: 9, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: today) ?? now,
+                category: .destination,
+                tripId: trip1.id
+            ),
+            TripEvent(
+                title: "제주 올레길 걷기",
+                startTime: calendar.date(bySettingHour: 14, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 16, minute: 0, second: 0, of: today) ?? now,
+                category: .schedule,
+                tripId: trip1.id
+            ),
+            TripEvent(
+                title: "제주 해변 산책",
+                startTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 20, minute: 0, second: 0, of: today) ?? now,
+                category: .etc,
+                tripId: trip1.id
+            ),
+
+            // trip1 (한라산) — 내일
+            TripEvent(
+                title: "제주 시장 방문",
+                startTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: tomorrow) ?? now,
+                endTime: calendar.date(bySettingHour: 12, minute: 0, second: 0, of: tomorrow) ?? now,
+                category: .list,
+                tripId: trip1.id
+            ),
+
+            // trip2 (서울 타워) — 모레
+            TripEvent(
+                title: "서울 타워 관광",
+                startTime: calendar.date(bySettingHour: 15, minute: 0, second: 0, of: dayAfter) ?? now,
+                endTime: calendar.date(bySettingHour: 17, minute: 0, second: 0, of: dayAfter) ?? now,
+                category: .destination,
+                tripId: trip2.id
+            ),
+            TripEvent(
+                title: "숙소 체크인",
+                startTime: calendar.date(bySettingHour: 18, minute: 0, second: 0, of: dayAfter) ?? now,
+                endTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: dayAfter) ?? now,
+                category: .list,
+                tripId: trip2.id
+            ),
+        ]
+    }
+}

--- a/HiTrip/Features/Schedule/Models/TripEvent.swift
+++ b/HiTrip/Features/Schedule/Models/TripEvent.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftUI
+
+// MARK: - TripEvent
+/// 여행 캘린더 이벤트 모델
+///
+/// 피그마 화면3의 캘린더에 표시되는 이벤트
+/// - 월간 캘린더의 날짜 아래 색상 도트로 표시
+/// - 하단 "오늘의 일정" 타임라인에 시간대별 표시
+
+struct TripEvent: Identifiable, Codable, Equatable {
+
+    let id: UUID
+    var title: String
+    var startTime: Date
+    var endTime: Date
+    var category: Category
+    let tripId: UUID        // 소속 여행
+    let createdAt: Date
+
+    /// 이벤트 카테고리 (캘린더 도트 색상 결정)
+    /// 피그마 기준: 여행지(네이비), 목록(라이트블루), 일정(옐로), 기타(핑크)
+    enum Category: String, Codable, CaseIterable {
+        case destination = "여행지"
+        case list = "목록"
+        case schedule = "일정"
+        case etc = "기타"
+
+        /// 캘린더 도트 색상
+        var color: Color {
+            switch self {
+            case .destination: return Color(hex: "062360")  // 네이비
+            case .list:        return Color(hex: "90ACF7")  // 라이트블루
+            case .schedule:    return Color(hex: "F5C842")  // 옐로
+            case .etc:         return Color(hex: "F5A0B5")  // 핑크
+            }
+        }
+    }
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        startTime: Date,
+        endTime: Date,
+        category: Category = .schedule,
+        tripId: UUID,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.startTime = startTime
+        self.endTime = endTime
+        self.category = category
+        self.tripId = tripId
+        self.createdAt = createdAt
+    }
+}

--- a/HiTrip/Features/Schedule/Models/TripTodo.swift
+++ b/HiTrip/Features/Schedule/Models/TripTodo.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// MARK: - TripTodo
+/// 여행 할일 (체크리스트) 모델
+///
+/// 피그마 화면2의 체크리스트 항목
+/// 섹션별로 그룹핑: "오늘 일정 준비", "여행 준비 & 관리"
+
+struct TripTodo: Identifiable, Codable, Equatable {
+
+    let id: UUID
+    var title: String
+    var isCompleted: Bool
+    var section: Section
+    var date: Date          // 이 할일이 속한 날짜 (날짜별 필터링용)
+    let tripId: UUID        // 소속 여행
+    let createdAt: Date
+
+    /// 체크리스트 섹션 구분
+    enum Section: String, Codable, CaseIterable {
+        case todayPrep = "오늘 일정 준비"
+        case travelPrep = "여행 준비 & 관리"
+    }
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        isCompleted: Bool = false,
+        section: Section = .todayPrep,
+        date: Date = Date(),
+        tripId: UUID,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.isCompleted = isCompleted
+        self.section = section
+        self.date = date
+        self.tripId = tripId
+        self.createdAt = createdAt
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Combine
+
+// MARK: - TripDetailViewModel
+/// 화면2+3: 여행 상세 (할일 + 캘린더) 관리
+///
+/// TripDataStore.shared를 참조하여 데이터 일관성 보장.
+/// 일정 페이지(TripListView)에서 변경한 투두 체크 상태 등이
+/// 상세 페이지에서도 동일하게 반영된다.
+
+final class TripDetailViewModel: ObservableObject {
+
+    // MARK: - Tab
+
+    enum DetailTab: String, CaseIterable {
+        case todo = "할일"
+        case calendar = "캘린더"
+    }
+
+    // MARK: - Store Reference
+
+    private let store = TripDataStore.shared
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Published State
+
+    @Published var selectedTab: DetailTab = .todo
+    @Published var trip: Trip
+    @Published var selectedDate: Date = Date()
+    @Published var displayedMonth: Date = Date()
+
+    /// 이벤트 추가/수정 시트 표시
+    @Published var showAddEventSheet: Bool = false
+
+    /// 이벤트 폼 (추가 & 수정 공용)
+    @Published var newEventTitle: String = ""
+    @Published var newEventStartTime: Date = Date()
+    @Published var newEventEndTime: Date = Date()
+    @Published var newEventCategory: TripEvent.Category = .schedule
+
+    /// 수정 중인 이벤트 ID (nil이면 추가 모드)
+    @Published var editingEventId: UUID?
+
+    // MARK: - Init
+
+    init(trip: Trip) {
+        self.trip = trip
+        self.selectedDate = trip.date
+        self.displayedMonth = trip.date
+
+        // Store의 변경을 감지하여 View 갱신
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Todo: Filtered by Date + Section
+
+    /// 선택된 날짜 + "오늘 일정 준비" 섹션
+    var todayPrepTodos: [TripTodo] {
+        store.todos(for: trip.id, date: selectedDate, section: .todayPrep)
+    }
+
+    /// 선택된 날짜 + "여행 준비 & 관리" 섹션
+    var travelPrepTodos: [TripTodo] {
+        store.todos(for: trip.id, date: selectedDate, section: .travelPrep)
+    }
+
+    // MARK: - Todo: CRUD (Store 위임)
+
+    func addTodo(title: String, section: TripTodo.Section) {
+        store.addTodo(title: title, section: section, date: selectedDate, tripId: trip.id)
+    }
+
+    func toggleTodo(_ todoId: UUID) {
+        store.toggleTodo(todoId)
+    }
+
+    func updateTodo(_ todoId: UUID, newTitle: String) {
+        store.updateTodo(todoId, newTitle: newTitle)
+    }
+
+    func deleteTodo(_ todoId: UUID) {
+        store.deleteTodo(todoId)
+    }
+
+    // MARK: - Event: CRUD (Store 위임)
+
+    /// 새 이벤트 추가 / 기존 이벤트 수정
+    func addEvent() {
+        guard !newEventTitle.trimmed.isEmpty else { return }
+
+        if let editId = editingEventId {
+            store.updateEvent(editId,
+                              title: newEventTitle.trimmed,
+                              startTime: newEventStartTime,
+                              endTime: newEventEndTime,
+                              category: newEventCategory)
+        } else {
+            store.addEvent(title: newEventTitle.trimmed,
+                           startTime: newEventStartTime,
+                           endTime: newEventEndTime,
+                           category: newEventCategory,
+                           tripId: trip.id)
+        }
+        resetEventForm()
+    }
+
+    func deleteEvent(_ eventId: UUID) {
+        store.deleteEvent(eventId)
+    }
+
+    /// 이벤트 폼 초기화
+    func resetEventForm() {
+        newEventTitle = ""
+        newEventStartTime = Calendar.current.date(bySettingHour: 9, minute: 0, second: 0, of: selectedDate) ?? selectedDate
+        newEventEndTime = Calendar.current.date(bySettingHour: 10, minute: 0, second: 0, of: selectedDate) ?? selectedDate
+        newEventCategory = .schedule
+        editingEventId = nil
+        showAddEventSheet = false
+    }
+
+    /// FAB 버튼 탭 시 호출 (추가 모드)
+    func prepareAddEvent() {
+        resetEventForm()
+        showAddEventSheet = true
+    }
+
+    /// 이벤트 수정 시트 열기
+    func prepareEditEvent(_ event: TripEvent) {
+        editingEventId = event.id
+        newEventTitle = event.title
+        newEventStartTime = event.startTime
+        newEventEndTime = event.endTime
+        newEventCategory = event.category
+        showAddEventSheet = true
+    }
+
+    // MARK: - Events: Filtered (Store 참조)
+
+    var eventsForSelectedDate: [TripEvent] {
+        store.events(for: trip.id, date: selectedDate)
+    }
+
+    func eventCategories(for date: Date) -> [TripEvent.Category] {
+        store.eventCategories(for: trip.id, date: date)
+    }
+
+    // MARK: - Month Navigation
+
+    func goToPreviousMonth() {
+        if let prev = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) {
+            displayedMonth = prev
+        }
+    }
+
+    func goToNextMonth() {
+        if let next = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) {
+            displayedMonth = next
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Combine
+
+// MARK: - TripListViewModel
+/// 화면1: 최근 일정 리스트 관리
+///
+/// TripDataStore.shared를 참조하여 데이터 일관성 보장.
+/// Store에서 변경이 발생하면 자동으로 UI 갱신.
+
+final class TripListViewModel: ObservableObject {
+
+    // MARK: - Store Reference
+
+    private let store = TripDataStore.shared
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Published State
+
+    /// 주간 캘린더에서 선택된 날짜
+    @Published var selectedDate: Date = Date()
+
+    /// 로딩 상태
+    @Published var isLoading: Bool = false
+
+    // MARK: - Init
+
+    init() {
+        // Store의 변경을 감지하여 View 갱신
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Trips
+
+    /// 전체 여행 (최신순)
+    var filteredTrips: [Trip] {
+        store.sortedTrips
+    }
+
+    /// tripId로 Trip 찾기
+    func trip(for tripId: UUID) -> Trip? {
+        store.trip(for: tripId)
+    }
+
+    // MARK: - 선택된 날짜의 투두
+
+    var todosForSelectedDate: [TripTodo] {
+        store.todos(for: selectedDate)
+    }
+
+    // MARK: - 선택된 날짜의 이벤트
+
+    var eventsForSelectedDate: [TripEvent] {
+        store.events(for: selectedDate)
+    }
+
+    /// 선택된 날짜에 일정 또는 투두가 있는지
+    var hasScheduleForSelectedDate: Bool {
+        !todosForSelectedDate.isEmpty || !eventsForSelectedDate.isEmpty
+    }
+
+    // MARK: - Todo Actions
+
+    func toggleTodo(_ todoId: UUID) {
+        store.toggleTodo(todoId)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/AllTripsView.swift
+++ b/HiTrip/Features/Schedule/Views/AllTripsView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+
+// MARK: - AllTripsView
+/// 전체 일정 보기 — "View all"에서 진입
+///
+/// 위치(지역)별로 그룹핑하여 모든 여행을 한 눈에 확인
+/// - 위치별 섹션 헤더 + 카드 리스트
+/// - 카드 탭 → TripDetailView (할일/캘린더)로 이동
+
+struct AllTripsView: View {
+
+    @ObservedObject private var store = TripDataStore.shared
+    @Environment(\.dismiss) private var dismiss
+
+    /// Store에서 직접 참조
+    private var trips: [Trip] { store.sortedTrips }
+
+    /// 그룹핑: location → [Trip]
+    private var groupedTrips: [(location: String, trips: [Trip])] {
+        let dict = Dictionary(grouping: trips) { trip in
+            trip.location.isEmpty ? "기타" : trip.location
+        }
+        return dict
+            .map { (location: $0.key, trips: $0.value.sorted { $0.date < $1.date }) }
+            .sorted { $0.location < $1.location }
+    }
+
+    var body: some View {
+        ZStack {
+            HiTripColor.screenBackground
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    // 상단 요약
+                    summaryHeader
+                        .padding(.horizontal, 24)
+                        .padding(.top, 8)
+
+                    // 위치별 섹션
+                    ForEach(groupedTrips, id: \.location) { group in
+                        locationSection(location: group.location, trips: group.trips)
+                    }
+
+                    Spacer().frame(height: 24)
+                }
+            }
+        }
+        .navigationTitle("전체 일정")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+        }
+    }
+
+    // MARK: - Summary Header
+
+    private var summaryHeader: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("총 \(trips.count)개의 일정")
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("\(groupedTrips.count)개 지역")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - Location Section
+
+    private func locationSection(location: String, trips: [Trip]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // 위치 헤더
+            HStack(spacing: 6) {
+                Image(systemName: "mappin.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(HiTripColor.primary800)
+
+                Text(location)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Text("\(trips.count)")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(HiTripColor.primary800)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(HiTripColor.secondary100)
+                    .cornerRadius(10)
+
+                Spacer()
+            }
+            .padding(.horizontal, 24)
+
+            // 카드들
+            ForEach(trips) { trip in
+                NavigationLink(destination: TripDetailView(trip: trip)) {
+                    allTripCard(trip)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+
+    // MARK: - Trip Card
+
+    private func allTripCard(_ trip: Trip) -> some View {
+        HStack(spacing: 14) {
+            // 썸네일
+            RoundedRectangle(cornerRadius: 12)
+                .fill(
+                    LinearGradient(
+                        colors: [HiTripColor.primary800.opacity(0.3), HiTripColor.secondary300],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 64, height: 64)
+                .overlay(
+                    Image(systemName: thumbnailIcon(trip))
+                        .font(.system(size: 20))
+                        .foregroundColor(.white)
+                )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(trip.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Text(formattedDate(trip.date))
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray500)
+
+                if !trip.memberAvatars.isEmpty {
+                    HStack(spacing: 2) {
+                        Image(systemName: "person.2.fill")
+                            .font(.system(size: 11))
+                        Text("\(trip.memberAvatars.count)명 참여")
+                            .font(.system(size: 12))
+                    }
+                    .foregroundColor(HiTripColor.gray400)
+                }
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .padding(14)
+        .background(Color.white)
+        .cornerRadius(14)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+    }
+
+    // MARK: - Helpers
+
+    private func thumbnailIcon(_ trip: Trip) -> String {
+        switch trip.thumbnailName {
+        case "mountain": return "mountain.2.fill"
+        case "building": return "building.2.fill"
+        case "beach":    return "water.waves"
+        default:         return "photo.fill"
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: date)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripCalendarView.swift
+++ b/HiTrip/Features/Schedule/Views/TripCalendarView.swift
@@ -1,0 +1,271 @@
+import SwiftUI
+
+// MARK: - TripCalendarView
+/// 화면3: 캘린더 탭 — 월간 캘린더 + 오늘의 일정
+///
+/// 피그마 디자인:
+/// - 월 숫자 (큰 텍스트)
+/// - 카테고리 범례 (여행지, 목록, 일정, 기타)
+/// - 월간 캘린더 그리드 (이벤트 날짜에 색상 도트)
+/// - "오늘의 일정" 타임라인 리스트
+/// - FAB (+) 일정 추가 버튼
+
+struct TripCalendarView: View {
+
+    @ObservedObject var viewModel: TripDetailViewModel
+
+    private let calendar = Calendar.current
+    private let daysOfWeek = ["월", "화", "수", "목", "금", "토", "일"]
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // 월 표시
+                    monthHeader
+                        .padding(.top, 16)
+                        .padding(.horizontal, 24)
+
+                    // 카테고리 범례
+                    categoryLegend
+                        .padding(.top, 12)
+                        .padding(.horizontal, 24)
+
+                    // 요일 헤더
+                    weekdayHeader
+                        .padding(.top, 16)
+                        .padding(.horizontal, 20)
+
+                    // 월간 캘린더 그리드
+                    monthGrid
+                        .padding(.top, 8)
+                        .padding(.horizontal, 20)
+
+                    // "오늘의 일정" 섹션
+                    todayEventsSection
+                        .padding(.top, 24)
+                        .padding(.horizontal, 24)
+
+                    Spacer().frame(height: 80)
+                }
+            }
+
+            // FAB (+) 버튼
+            fabButton
+                .padding(.trailing, 24)
+                .padding(.bottom, 24)
+        }
+        // 이벤트 추가 시트
+        .sheet(isPresented: $viewModel.showAddEventSheet) {
+            addEventSheet
+        }
+    }
+
+    // MARK: - Add Event Sheet
+
+    private var addEventSheet: some View {
+        NavigationStack {
+            Form {
+                Section("일정 정보") {
+                    TextField("일정 제목", text: $viewModel.newEventTitle)
+
+                    DatePicker("시작 시간", selection: $viewModel.newEventStartTime, displayedComponents: [.date, .hourAndMinute])
+
+                    DatePicker("종료 시간", selection: $viewModel.newEventEndTime, displayedComponents: [.date, .hourAndMinute])
+
+                    Picker("카테고리", selection: $viewModel.newEventCategory) {
+                        ForEach(TripEvent.Category.allCases, id: \.self) { category in
+                            HStack {
+                                Circle().fill(category.color).frame(width: 10, height: 10)
+                                Text(category.rawValue)
+                            }
+                            .tag(category)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(viewModel.editingEventId != nil ? "일정 수정" : "일정 추가")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("취소") { viewModel.resetEventForm() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("저장") { viewModel.addEvent() }
+                        .disabled(viewModel.newEventTitle.trimmed.isEmpty)
+                }
+            }
+        }
+    }
+
+    // MARK: - Month Header
+
+    /// 큰 월 표시 (예: "4월")
+    private var monthHeader: some View {
+        Text("\(calendar.component(.month, from: viewModel.displayedMonth))월")
+            .font(.system(size: 40, weight: .bold))
+            .foregroundColor(HiTripColor.textBlack)
+    }
+
+    // MARK: - Category Legend
+
+    /// 카테고리 범례 (피그마: 여행지, 목록, 일정, 기타)
+    private var categoryLegend: some View {
+        HStack(spacing: 12) {
+            ForEach(TripEvent.Category.allCases, id: \.self) { category in
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(category.color)
+                        .frame(width: 8, height: 8)
+                    Text(category.rawValue)
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(HiTripColor.gray100)
+                .cornerRadius(12)
+            }
+        }
+    }
+
+    // MARK: - Weekday Header
+
+    private var weekdayHeader: some View {
+        HStack(spacing: 0) {
+            ForEach(daysOfWeek, id: \.self) { day in
+                Text(day)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(HiTripColor.gray400)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Month Grid
+
+    /// 월간 캘린더 날짜 그리드
+    private var monthGrid: some View {
+        let days = daysInMonth()
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
+
+        return LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(days, id: \.self) { date in
+                if let date = date {
+                    dayCell(for: date)
+                        .onTapGesture {
+                            viewModel.selectedDate = date
+                        }
+                } else {
+                    // 빈 셀 (이전/다음 달의 빈 칸)
+                    Text("")
+                        .frame(height: 44)
+                }
+            }
+        }
+    }
+
+    // MARK: - Day Cell
+
+    private func dayCell(for date: Date) -> some View {
+        let isSelected = calendar.isDate(date, inSameDayAs: viewModel.selectedDate)
+        let isToday = calendar.isDateInToday(date)
+        let categories = viewModel.eventCategories(for: date)
+
+        return VStack(spacing: 2) {
+            // 날짜 숫자
+            Text("\(calendar.component(.day, from: date))")
+                .font(.system(size: 15, weight: isToday ? .bold : .regular))
+                .foregroundColor(
+                    isSelected ? .white :
+                    isToday ? HiTripColor.primary800 :
+                    HiTripColor.textBlack
+                )
+                .frame(width: 32, height: 32)
+                .background(
+                    Circle()
+                        .fill(isSelected ? HiTripColor.primary800 : Color.clear)
+                )
+
+            // 이벤트 카테고리 도트들
+            HStack(spacing: 2) {
+                ForEach(categories.prefix(3), id: \.self) { category in
+                    Circle()
+                        .fill(category.color)
+                        .frame(width: 5, height: 5)
+                }
+            }
+            .frame(height: 6)
+        }
+        .frame(height: 44)
+    }
+
+    // MARK: - Today Events Section
+
+    private var todayEventsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("오늘의 일정")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            if viewModel.eventsForSelectedDate.isEmpty {
+                Text("선택한 날짜에 일정이 없습니다.")
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray400)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(viewModel.eventsForSelectedDate) { event in
+                    TripEventRow(
+                        event: event,
+                        onEdit: { viewModel.prepareEditEvent(event) },
+                        onDelete: { withAnimation { viewModel.deleteEvent(event.id) } }
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - FAB Button
+
+    /// 플로팅 액션 버튼 — 일정 추가
+    private var fabButton: some View {
+        Button { viewModel.prepareAddEvent() } label: {
+            Circle()
+                .fill(HiTripColor.primary800)
+                .frame(width: 56, height: 56)
+                .overlay(
+                    Image(systemName: "plus")
+                        .font(.system(size: 24, weight: .medium))
+                        .foregroundColor(.white)
+                )
+                .shadow(color: HiTripColor.primary800.opacity(0.3), radius: 8, y: 4)
+        }
+    }
+
+    // MARK: - Calendar Helpers
+
+    /// 현재 월의 날짜 배열 (빈 칸 포함)
+    /// 월요일 시작 기준으로 앞쪽 빈 칸을 nil로 채움
+    private func daysInMonth() -> [Date?] {
+        let month = viewModel.displayedMonth
+
+        guard let range = calendar.range(of: .day, in: .month, for: month),
+              let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: month))
+        else { return [] }
+
+        // 첫째 날의 요일 (월=0, 화=1, ... 일=6)
+        var weekday = calendar.component(.weekday, from: firstDay)
+        // .weekday: 1=일, 2=월, ..., 7=토 → 월요일 시작으로 변환
+        weekday = (weekday + 5) % 7  // 월=0, 화=1, ... 일=6
+
+        var days: [Date?] = Array(repeating: nil, count: weekday)
+
+        for day in range {
+            if let date = calendar.date(byAdding: .day, value: day - 1, to: firstDay) {
+                days.append(date)
+            }
+        }
+
+        return days
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+// MARK: - TripDetailView
+/// 화면2+3 컨테이너: 여행 상세
+///
+/// 피그마 디자인:
+/// - 뒤로가기 + 더보기(...)
+/// - 멤버 아바타 영역 + 추가 버튼
+/// - "할일 | 캘린더" 세그먼트 탭
+/// - 탭에 따라 TripTodoView 또는 TripCalendarView 표시
+///
+/// 화면1(TripListView)에서 NavigationLink로 push되어 진입
+
+struct TripDetailView: View {
+
+    @StateObject var viewModel: TripDetailViewModel
+    @Environment(\.dismiss) var dismiss
+
+    private let initialTab: TripDetailViewModel.DetailTab
+
+    init(trip: Trip, initialTab: TripDetailViewModel.DetailTab = .todo) {
+        _viewModel = StateObject(wrappedValue: TripDetailViewModel(trip: trip))
+        self.initialTab = initialTab
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // 멤버 아바타 영역
+            memberSection
+                .padding(.top, 12)
+
+            // 할일 / 캘린더 탭
+            tabSelector
+                .padding(.top, 16)
+
+            // 탭 콘텐츠
+            tabContent
+        }
+        .background(HiTripColor.screenBackground)
+        .onAppear { viewModel.selectedTab = initialTab }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { } label: {
+                    Image(systemName: "ellipsis")
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+        }
+    }
+
+    // MARK: - Member Section
+
+    /// 멤버 아바타 원형 + 추가 버튼
+    private var memberSection: some View {
+        HStack(spacing: -8) {
+            // 멤버 아바타들 (겹쳐서 표시)
+            ForEach(0..<min(viewModel.trip.memberAvatars.count, 3), id: \.self) { index in
+                Circle()
+                    .fill(memberColor(index))
+                    .frame(width: 44, height: 44)
+                    .overlay(
+                        Circle().stroke(Color.white, lineWidth: 2)
+                    )
+            }
+
+            // + 추가 버튼
+            Button { } label: {
+                Circle()
+                    .fill(HiTripColor.gray100)
+                    .frame(width: 44, height: 44)
+                    .overlay(
+                        Image(systemName: "plus")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(HiTripColor.gray400)
+                    )
+                    .overlay(
+                        Circle().stroke(Color.white, lineWidth: 2)
+                    )
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+    }
+
+    /// 멤버별 색상 (피그마 기준 파란 그라데이션)
+    private func memberColor(_ index: Int) -> Color {
+        let colors = [HiTripColor.primary800, HiTripColor.secondary500, HiTripColor.secondary200]
+        return colors[index % colors.count]
+    }
+
+    // MARK: - Tab Selector
+
+    /// "할일 | 캘린더" 세그먼트 탭
+    private var tabSelector: some View {
+        HStack(spacing: 0) {
+            ForEach(TripDetailViewModel.DetailTab.allCases, id: \.self) { tab in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.selectedTab = tab
+                    }
+                } label: {
+                    VStack(spacing: 8) {
+                        Text(tab.rawValue)
+                            .font(.system(size: 15, weight: viewModel.selectedTab == tab ? .semibold : .regular))
+                            .foregroundColor(
+                                viewModel.selectedTab == tab
+                                    ? HiTripColor.textBlack
+                                    : HiTripColor.gray400
+                            )
+
+                        // 하단 인디케이터 라인
+                        Rectangle()
+                            .fill(viewModel.selectedTab == tab ? HiTripColor.primary800 : Color.clear)
+                            .frame(height: 2)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Tab Content
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch viewModel.selectedTab {
+        case .todo:
+            TripTodoView(viewModel: viewModel)
+        case .calendar:
+            TripCalendarView(viewModel: viewModel)
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripEventRow.swift
+++ b/HiTrip/Features/Schedule/Views/TripEventRow.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// MARK: - TripEventRow
+/// 오늘의 일정 행 — 피그마 디자인
+///
+/// 구성:
+/// - 왼쪽 세로 색상 바 (카테고리 컬러)
+/// - 제목
+/// - 시간 범위 (09:00 - 10:00)
+/// - ... 메뉴 (수정/삭제)
+
+struct TripEventRow: View {
+
+    let event: TripEvent
+    var onEdit: (() -> Void)?
+    var onDelete: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // 왼쪽 카테고리 색상 바
+            RoundedRectangle(cornerRadius: 2)
+                .fill(event.category.color)
+                .frame(width: 4, height: 44)
+
+            // 이벤트 정보
+            VStack(alignment: .leading, spacing: 4) {
+                Text(event.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Text(timeRangeText)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray500)
+            }
+
+            Spacer()
+
+            // 더보기(...) 메뉴 — 수정/삭제
+            if onDelete != nil || onEdit != nil {
+                Menu {
+                    if let onEdit = onEdit {
+                        Button {
+                            onEdit()
+                        } label: {
+                            Label("수정", systemImage: "pencil")
+                        }
+                    }
+
+                    if let onDelete = onDelete {
+                        Button(role: .destructive) {
+                            onDelete()
+                        } label: {
+                            Label("삭제", systemImage: "trash")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 16))
+                        .foregroundColor(HiTripColor.gray400)
+                        .frame(width: 28, height: 28)
+                }
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(Color.white)
+        .cornerRadius(10)
+    }
+
+    /// 시간 범위 텍스트 (예: "09:00 - 10:00")
+    private var timeRangeText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: event.startTime)) - \(formatter.string(from: event.endTime))"
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -1,0 +1,406 @@
+import SwiftUI
+
+// MARK: - TripListView
+/// 화면1: 최근 일정 — 피그마 디자인
+///
+/// UI 구성:
+/// - 네비게이션 바: 뒤로가기 + "최근 일정" + 알림 아이콘
+/// - 주간 캘린더 스트립 (날짜 선택)
+/// - 선택한 날짜의 일정 + 투두 미리보기
+/// - "내 일정" 섹션 + "View all" 링크
+/// - 여행 카드 리스트 (썸네일 + 날짜 + 제목 + 위치)
+
+struct TripListView: View {
+
+    @StateObject private var viewModel = TripListViewModel()
+    @EnvironmentObject var router: AppRouter
+
+    /// "View all" 클릭 → AllTripsView로 이동
+    @State private var navigateToAllTrips: Bool = false
+
+    /// 내 일정 카드 클릭 → 상세보기 (SpotDetailView 스타일)
+    @State private var selectedTripForDetail: Trip?
+
+    /// 투두 탭 → 해당 Trip 상세 (할일 탭)로 이동
+    @State private var navigateToTripDetail: Bool = false
+    @State private var selectedTripForNav: Trip?
+
+    /// 이벤트 탭 → 해당 Trip 상세 (캘린더 탭)로 이동
+    @State private var navigateToCalendar: Bool = false
+    @State private var selectedTripForCalendar: Trip?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                HiTripColor.screenBackground
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // 주간 캘린더 스트립
+                        calendarCard
+
+                        // 선택한 날짜의 일정 + 투두
+                        dailyScheduleSection
+                            .padding(.top, 16)
+
+                        // "내 일정" 헤더
+                        sectionHeader
+                            .padding(.top, 24)
+
+                        // 여행 카드 리스트
+                        tripCardList
+                            .padding(.top, 12)
+
+                        Spacer().frame(height: 24)
+                    }
+                }
+            }
+            // "View all" → 전체 일정 리스트
+            .navigationDestination(isPresented: $navigateToAllTrips) {
+                AllTripsView()
+            }
+            // 투두 영역 탭 → Trip 상세 (할일 탭)
+            .navigationDestination(isPresented: $navigateToTripDetail) {
+                if let trip = selectedTripForNav {
+                    TripDetailView(trip: trip)
+                }
+            }
+            // 이벤트 영역 탭 → Trip 상세 (캘린더 탭)
+            .navigationDestination(isPresented: $navigateToCalendar) {
+                if let trip = selectedTripForCalendar {
+                    TripDetailView(trip: trip, initialTab: .calendar)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { } label: {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(HiTripColor.textBlack)
+                    }
+                }
+                ToolbarItem(placement: .principal) {
+                    Text("최근 일정")
+                        .font(.system(size: 17, weight: .semibold))
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button { } label: {
+                        Image(systemName: "bell")
+                            .foregroundColor(HiTripColor.textBlack)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Calendar Card
+
+    private var calendarCard: some View {
+        VStack(spacing: 0) {
+            WeekCalendarStripView(
+                selectedDate: $viewModel.selectedDate,
+                style: .sundayStart
+            )
+        }
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Daily Schedule Section
+
+    private var dailyScheduleSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // 날짜 헤더
+            Text(selectedDateText)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+                .padding(.horizontal, 24)
+
+            if viewModel.hasScheduleForSelectedDate {
+                // 이벤트 목록
+                if !viewModel.eventsForSelectedDate.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("일정", systemImage: "calendar")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(HiTripColor.primary800)
+                            .padding(.horizontal, 24)
+
+                        ForEach(viewModel.eventsForSelectedDate) { event in
+                            Button {
+                                // 이벤트 클릭 → 해당 Trip 캘린더 탭으로 이동
+                                if let trip = viewModel.trip(for: event.tripId) {
+                                    selectedTripForCalendar = trip
+                                    navigateToCalendar = true
+                                }
+                            } label: {
+                                dailyEventRow(event)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.horizontal, 20)
+                        }
+                    }
+                }
+
+                // 투두 목록
+                if !viewModel.todosForSelectedDate.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("할 일", systemImage: "checklist")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(HiTripColor.primary800)
+                            .padding(.horizontal, 24)
+                            .padding(.top, viewModel.eventsForSelectedDate.isEmpty ? 0 : 4)
+
+                        ForEach(viewModel.todosForSelectedDate) { todo in
+                            dailyTodoRow(todo)
+                                .padding(.horizontal, 20)
+                        }
+                    }
+                }
+            } else {
+                // 빈 상태
+                HStack {
+                    Spacer()
+                    VStack(spacing: 6) {
+                        Image(systemName: "calendar.badge.minus")
+                            .font(.system(size: 28))
+                            .foregroundColor(HiTripColor.gray300)
+                        Text("이 날짜에 등록된 일정이 없습니다.")
+                            .font(.system(size: 14))
+                            .foregroundColor(HiTripColor.gray400)
+                    }
+                    .padding(.vertical, 16)
+                    Spacer()
+                }
+            }
+        }
+        .padding(.vertical, 16)
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
+        .padding(.horizontal, 20)
+    }
+
+    /// 선택된 날짜 텍스트 (예: "4월 20일 월요일")
+    private var selectedDateText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일 EEEE"
+        return formatter.string(from: viewModel.selectedDate)
+    }
+
+    // MARK: - Daily Event Row
+
+    private func dailyEventRow(_ event: TripEvent) -> some View {
+        HStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(event.category.color)
+                .frame(width: 4, height: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(event.title)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Text(eventTimeText(event))
+                    .font(.system(size: 12))
+                    .foregroundColor(HiTripColor.gray500)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(HiTripColor.gray100)
+        .cornerRadius(10)
+    }
+
+    private func eventTimeText(_ event: TripEvent) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: event.startTime)) - \(formatter.string(from: event.endTime))"
+    }
+
+    // MARK: - Daily Todo Row
+
+    /// 투두 행: 체크 아이콘 클릭 → 토글, 나머지 영역 클릭 → 상세보기
+    private func dailyTodoRow(_ todo: TripTodo) -> some View {
+        HStack(spacing: 10) {
+            // 체크 아이콘 — 탭 시 완료 토글
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    viewModel.toggleTodo(todo.id)
+                }
+            } label: {
+                if todo.isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(HiTripColor.primary800)
+                } else {
+                    Circle()
+                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                        .frame(width: 18, height: 18)
+                }
+            }
+            .buttonStyle(.plain)
+
+            // 나머지 영역 — 탭 시 해당 Trip 상세보기
+            Button {
+                if let trip = viewModel.trip(for: todo.tripId) {
+                    selectedTripForNav = trip
+                    navigateToTripDetail = true
+                }
+            } label: {
+                HStack {
+                    Text(todo.title)
+                        .font(.system(size: 14))
+                        .foregroundColor(
+                            todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack
+                        )
+                        .strikethrough(todo.isCompleted, color: HiTripColor.gray400)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray300)
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(HiTripColor.gray100)
+        .cornerRadius(10)
+    }
+
+    // MARK: - Section Header
+
+    private var sectionHeader: some View {
+        HStack {
+            Text("내 일정")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Spacer()
+
+            Button {
+                navigateToAllTrips = true
+            } label: {
+                HStack(spacing: 4) {
+                    Text("View all")
+                        .font(.system(size: 14))
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11))
+                }
+                .foregroundColor(HiTripColor.secondary700)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Trip Card List
+
+    private var tripCardList: some View {
+        LazyVStack(spacing: 12) {
+            ForEach(viewModel.filteredTrips) { trip in
+                Button {
+                    selectedTripForDetail = trip
+                } label: {
+                    TripCardRow(trip: trip)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 20)
+        .sheet(item: $selectedTripForDetail) { trip in
+            TripScheduleDetailView(trip: trip)
+        }
+    }
+}
+
+// MARK: - TripCardRow
+
+struct TripCardRow: View {
+
+    let trip: Trip
+
+    var body: some View {
+        HStack(spacing: 14) {
+            thumbnailView
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 12))
+                    Text(formattedDate)
+                        .font(.system(size: 13))
+                }
+                .foregroundColor(HiTripColor.gray500)
+
+                Text(trip.title)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                if !trip.location.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "mappin.circle.fill")
+                            .font(.system(size: 12))
+                        Text("위치: \(trip.location)")
+                            .font(.system(size: 13))
+                    }
+                    .foregroundColor(HiTripColor.gray400)
+                }
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .padding(16)
+        .background(Color.white)
+        .cornerRadius(14)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+    }
+
+    private var thumbnailView: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(
+                LinearGradient(
+                    colors: [HiTripColor.primary800.opacity(0.3), HiTripColor.secondary300],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .frame(width: 80, height: 80)
+            .overlay(
+                Image(systemName: thumbnailIcon)
+                    .font(.system(size: 24))
+                    .foregroundColor(.white)
+            )
+    }
+
+    private var thumbnailIcon: String {
+        switch trip.thumbnailName {
+        case "mountain": return "mountain.2.fill"
+        case "building": return "building.2.fill"
+        case "beach":    return "water.waves"
+        default:         return "photo.fill"
+        }
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: trip.date)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripScheduleDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripScheduleDetailView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+// MARK: - TripScheduleDetailView
+/// 내 일정 상세 보기 — SpotDetailView와 동일한 레이아웃
+///
+/// 구성:
+/// - 헤더 이미지 (썸네일)
+/// - 제목 + 유형 태그
+/// - 날짜 정보
+/// - 위치 정보
+/// - 멤버 정보
+
+struct TripScheduleDetailView: View {
+
+    let trip: Trip
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    // 헤더 이미지
+                    headerImage
+
+                    VStack(alignment: .leading, spacing: 16) {
+                        // 제목 + 태그
+                        titleSection
+
+                        Divider()
+
+                        // 날짜
+                        infoRow(
+                            icon: "calendar",
+                            title: "날짜",
+                            content: formattedDate
+                        )
+
+                        // 위치
+                        if !trip.location.isEmpty {
+                            infoRow(
+                                icon: "mappin.and.ellipse",
+                                title: "위치",
+                                content: trip.location
+                            )
+                        }
+
+                        // 멤버
+                        if !trip.memberAvatars.isEmpty {
+                            infoRow(
+                                icon: "person.2.fill",
+                                title: "참여 멤버",
+                                content: "\(trip.memberAvatars.count)명"
+                            )
+                        }
+
+                        Divider()
+
+                        // 체크리스트/캘린더로 이동 버튼
+                        NavigationLink(destination: TripDetailView(trip: trip)) {
+                            HStack(spacing: 10) {
+                                Image(systemName: "checklist")
+                                    .font(.system(size: 18))
+                                    .foregroundColor(.white)
+
+                                Text("할일 / 캘린더 보기")
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundColor(.white)
+
+                                Spacer()
+
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 14))
+                                    .foregroundColor(.white.opacity(0.7))
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .background(HiTripColor.primary800)
+                            .cornerRadius(12)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+            .navigationTitle(trip.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("닫기") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Header Image
+
+    private var headerImage: some View {
+        RoundedRectangle(cornerRadius: 0)
+            .fill(
+                LinearGradient(
+                    colors: [HiTripColor.primary800.opacity(0.4), HiTripColor.secondary300],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .frame(height: 220)
+            .overlay(
+                Image(systemName: thumbnailIcon)
+                    .font(.system(size: 48))
+                    .foregroundColor(.white)
+            )
+    }
+
+    // MARK: - Title Section
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(trip.title)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textGrayA)
+
+            Text("여행 일정")
+                .font(.system(size: 13))
+                .foregroundColor(HiTripColor.primary800)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(HiTripColor.secondary100)
+                .cornerRadius(6)
+        }
+    }
+
+    // MARK: - Info Row (SpotDetailView 동일 패턴)
+
+    private func infoRow(icon: String, title: String, content: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundColor(HiTripColor.primary800)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray400)
+
+                Text(content)
+                    .font(.system(size: 15))
+                    .foregroundColor(HiTripColor.textGrayA)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var thumbnailIcon: String {
+        switch trip.thumbnailName {
+        case "mountain": return "mountain.2.fill"
+        case "building": return "building.2.fill"
+        case "beach":    return "water.waves"
+        default:         return "photo.fill"
+        }
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: trip.date)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripTodoView.swift
+++ b/HiTrip/Features/Schedule/Views/TripTodoView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+// MARK: - TripTodoView
+/// 화면2: 할일 탭 — 체크리스트
+///
+/// 피그마 디자인:
+/// - 주간 캘린더 스트립 (월요일 시작)
+/// - "오늘 일정 준비" 섹션 체크리스트
+/// - "여행 준비 & 관리" 섹션 체크리스트
+/// - 각 항목: 체크 원 + 텍스트 + 더보기(...)
+/// - 섹션 상단에 "체크리스트를 추가하세요." placeholder
+
+struct TripTodoView: View {
+
+    @ObservedObject var viewModel: TripDetailViewModel
+    @State private var newTodoText: String = ""
+    @State private var addingSection: TripTodo.Section?
+
+    /// 수정 모드: 편집 중인 Todo ID + 텍스트
+    @State private var editingTodoId: UUID?
+    @State private var editingTodoText: String = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                // 주간 캘린더 스트립
+                WeekCalendarStripView(
+                    selectedDate: $viewModel.selectedDate,
+                    style: .mondayStart
+                )
+                .padding(.top, 8)
+
+                // "오늘 일정 준비" 섹션
+                todoSection(
+                    title: "오늘 일정 준비",
+                    emoji: "🏖",
+                    section: .todayPrep,
+                    todos: viewModel.todayPrepTodos
+                )
+                .padding(.top, 20)
+
+                // "여행 준비 & 관리" 섹션
+                todoSection(
+                    title: "여행 준비 & 관리",
+                    emoji: "🧳",
+                    section: .travelPrep,
+                    todos: viewModel.travelPrepTodos
+                )
+                .padding(.top, 20)
+
+                Spacer().frame(height: 40)
+            }
+        }
+    }
+
+    // MARK: - Todo Section
+
+    private func todoSection(
+        title: String,
+        emoji: String,
+        section: TripTodo.Section,
+        todos: [TripTodo]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 섹션 헤더 태그
+            HStack(spacing: 4) {
+                Text(emoji)
+                    .font(.system(size: 13))
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(HiTripColor.gray100)
+            .cornerRadius(20)
+            .padding(.bottom, 12)
+
+            // "체크리스트를 추가하세요" placeholder + 추가 기능
+            addTodoRow(section: section)
+                .padding(.bottom, 4)
+
+            // 체크리스트 항목들
+            ForEach(todos) { todo in
+                todoRow(todo)
+                    .padding(.vertical, 6)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - Add Todo Row
+
+    private func addTodoRow(section: TripTodo.Section) -> some View {
+        Group {
+            if addingSection == section {
+                // 입력 모드
+                HStack(spacing: 10) {
+                    Circle()
+                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                        .frame(width: 22, height: 22)
+
+                    TextField("할 일을 입력하세요", text: $newTodoText)
+                        .font(.system(size: 15))
+                        .onSubmit {
+                            if !newTodoText.trimmed.isEmpty {
+                                viewModel.addTodo(title: newTodoText.trimmed, section: section)
+                                newTodoText = ""
+                            }
+                            addingSection = nil
+                        }
+                }
+            } else {
+                // placeholder 모드
+                Button {
+                    addingSection = section
+                } label: {
+                    HStack(spacing: 10) {
+                        Circle()
+                            .stroke(HiTripColor.gray300.opacity(0.5), lineWidth: 1.5)
+                            .frame(width: 22, height: 22)
+
+                        Text("체크리스트를 추가하세요.")
+                            .font(.system(size: 15))
+                            .foregroundColor(HiTripColor.gray300)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Todo Row
+
+    private func todoRow(_ todo: TripTodo) -> some View {
+        HStack(spacing: 10) {
+            // 체크 원
+            Button {
+                viewModel.toggleTodo(todo.id)
+            } label: {
+                if todo.isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(HiTripColor.primary800)
+                } else {
+                    Circle()
+                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                        .frame(width: 22, height: 22)
+                }
+            }
+            .buttonStyle(.plain)
+
+            // 텍스트 (수정 모드 / 표시 모드)
+            if editingTodoId == todo.id {
+                TextField("할 일 수정", text: $editingTodoText)
+                    .font(.system(size: 15))
+                    .onSubmit {
+                        if !editingTodoText.trimmed.isEmpty {
+                            viewModel.updateTodo(todo.id, newTitle: editingTodoText.trimmed)
+                        }
+                        editingTodoId = nil
+                    }
+            } else {
+                Text(todo.title)
+                    .font(.system(size: 15))
+                    .foregroundColor(
+                        todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack
+                    )
+                    .strikethrough(todo.isCompleted, color: HiTripColor.gray400)
+            }
+
+            Spacer()
+
+            // 더보기(...) 메뉴 — 수정/삭제
+            Menu {
+                Button {
+                    editingTodoText = todo.title
+                    editingTodoId = todo.id
+                } label: {
+                    Label("수정", systemImage: "pencil")
+                }
+
+                Button(role: .destructive) {
+                    withAnimation { viewModel.deleteTodo(todo.id) }
+                } label: {
+                    Label("삭제", systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16))
+                    .foregroundColor(HiTripColor.gray400)
+                    .frame(width: 28, height: 28)
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/WeekCalendarStripView.swift
+++ b/HiTrip/Features/Schedule/Views/WeekCalendarStripView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+// MARK: - WeekCalendarStripView
+/// 주간 캘린더 스트립 — 화면1(최근 일정)과 화면2(할일)에서 공용
+///
+/// 피그마 디자인:
+/// - 좌우 화살표로 주(week) 이동
+/// - 요일 라벨 (S M T W T F S 또는 월 화 수 목 금 토 일)
+/// - 날짜 숫자 — 선택된 날짜는 파란 원 배경
+///
+/// 사용:
+/// ```swift
+/// WeekCalendarStripView(
+///     selectedDate: $viewModel.selectedDate,
+///     style: .sundayStart   // 화면1: 일요일 시작
+/// )
+/// ```
+
+struct WeekCalendarStripView: View {
+
+    @Binding var selectedDate: Date
+
+    /// 주 시작 요일 스타일
+    var style: WeekStyle = .mondayStart
+
+    /// 날짜 탭 시 콜백 (nil이면 selectedDate 바인딩만 변경)
+    var onDateTap: ((Date) -> Void)?
+
+    enum WeekStyle {
+        case sundayStart   // 화면1: S M T W T F S
+        case mondayStart   // 화면2: 월 화 수 목 금 토 일
+    }
+
+    /// 표시 중인 주의 기준 날짜
+    @State private var weekOffset: Int = 0
+
+    private let calendar = Calendar.current
+
+    var body: some View {
+        VStack(spacing: 12) {
+            // 상단: 날짜 텍스트 + 좌우 화살표
+            headerRow
+
+            // 요일 + 날짜 그리드
+            weekDaysRow
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack {
+            Text(headerDateText)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Spacer()
+
+            HStack(spacing: 16) {
+                Button { weekOffset -= 1 } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+
+                Button { weekOffset += 1 } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+            }
+        }
+    }
+
+    // MARK: - Week Days Row
+
+    private var weekDaysRow: some View {
+        HStack(spacing: 0) {
+            ForEach(weekDays, id: \.self) { date in
+                VStack(spacing: 6) {
+                    // 요일 라벨
+                    Text(dayLabel(for: date))
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(isToday(date) ? HiTripColor.primary800 : HiTripColor.gray400)
+
+                    // 날짜 숫자
+                    Text("\(calendar.component(.day, from: date))")
+                        .font(.system(size: 16, weight: isSelected(date) ? .bold : .medium))
+                        .foregroundColor(isSelected(date) ? .white : HiTripColor.textBlack)
+                        .frame(width: 36, height: 36)
+                        .background(
+                            Circle()
+                                .fill(isSelected(date) ? HiTripColor.primary800 : Color.clear)
+                        )
+                }
+                .frame(maxWidth: .infinity)
+                .onTapGesture {
+                    selectedDate = date
+                    onDateTap?(date)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// 헤더에 표시할 날짜 텍스트 (예: "4월")
+    /// 표시 중인 주의 중간 날짜 기준으로 월 표시 — '>' 클릭 시 자동 변경
+    private var headerDateText: String {
+        let days = weekDays
+        // 주의 중간(4번째) 날짜 기준으로 월 표시
+        let referenceDate = days.isEmpty ? selectedDate : days[min(3, days.count - 1)]
+        let month = calendar.component(.month, from: referenceDate)
+        return "\(month)월"
+    }
+
+    /// 현재 표시 중인 주의 7일 배열
+    private var weekDays: [Date] {
+        let baseDate = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: Date()) ?? Date()
+
+        // 주의 시작일 계산
+        var cal = calendar
+        cal.firstWeekday = style == .sundayStart ? 1 : 2  // 1=일요일, 2=월요일
+
+        guard let weekStart = cal.dateInterval(of: .weekOfYear, for: baseDate)?.start else {
+            return []
+        }
+
+        return (0..<7).compactMap { day in
+            cal.date(byAdding: .day, value: day, to: weekStart)
+        }
+    }
+
+    /// 요일 라벨
+    private func dayLabel(for date: Date) -> String {
+        switch style {
+        case .sundayStart:
+            let symbols = ["S", "M", "T", "W", "T", "F", "S"]
+            let weekday = calendar.component(.weekday, from: date)
+            return symbols[weekday - 1]
+        case .mondayStart:
+            let symbols = ["일", "월", "화", "수", "목", "금", "토"]
+            let weekday = calendar.component(.weekday, from: date)
+            return symbols[weekday - 1]
+        }
+    }
+
+    /// 오늘 날짜인지
+    private func isToday(_ date: Date) -> Bool {
+        calendar.isDateInToday(date)
+    }
+
+    /// 선택된 날짜인지
+    private func isSelected(_ date: Date) -> Bool {
+        calendar.isDate(date, inSameDayAs: selectedDate)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ HiTrip/
 │   ├── Emergency/
 │   │   ├── ViewModels/
 │   │   └── Views/
+│   ├── Spot/
+│   │   ├── ViewModels/
+│   │   └── Views/
 │   └── Profile/
 │       └── Views/
 └── Resources/                    # Assets, 리소스 파일
@@ -148,9 +151,19 @@ HiTrip/
 - [x] ChatRoomView (말풍선 UI + 메시지 입력)
 - [x] Chat DI 연결 + HomeView 채팅 탭 교체
 
-### Phase 4 — 지도 + 스팟 추천
-- [ ] KakaoMaps SDK 연동
-- [ ] TourAPI 관광지 검색
+### Phase 4 — 지도 + 스팟 추천 ✅
+- [x] TourAPI(KorService2) 관광지 키워드 검색 + 위치 기반 검색
+- [x] TourAPIService 전용 네트워크 서비스 (serviceKey 인코딩 우회)
+- [x] SpotRepositoryProtocol + SpotUseCase (좌표 범위 검증)
+- [x] SpotRepository (TourAPIService 래퍼)
+- [x] SpotViewModel (CLLocationManager + 페이지네이션)
+- [x] SpotListView (키워드/현재위치 검색 + 무한스크롤)
+- [x] SpotDetailView (이미지, 주소, 전화, 유형 표시)
+- [x] KakaoMaps SDK 연동 (SDKInitializer + KakaoMapView UIViewRepresentable)
+- [x] SpotMapView (전체화면 지도 표시)
+- [x] Spot DI 연결 + HomeView 스팟 탭 교체
+- [x] API키 보안 (.gitignore + APIKeys.example.txt 템플릿)
+- [ ] KakaoMap 지도 타일 렌더링 이슈 (인증 성공, 타일 미표시 — 추후 디버깅)
 
 ### Phase 5 — 긴급 연락 ✅
 - [x] EmergencyContact Entity (프리셋 + 개인 연락처, ContactCategory enum)
@@ -182,7 +195,21 @@ cd Hi_Trip_app/HiTrip
 open HiTrip.xcodeproj
 ```
 
-> SPM 의존성(RxSwift, RxCocoa)은 프로젝트 열 때 자동으로 resolve됩니다.
+> SPM 의존성(RxSwift, RxCocoa, KakaoMapsSDK)은 프로젝트 열 때 자동으로 resolve됩니다.
+
+### API 키 설정
+
+프로젝트 실행을 위해 API 키 파일이 필요합니다:
+
+1. 프로젝트 루트의 `APIKeys.example.txt`를 참고
+2. `HiTrip/Core/Utils/APIKeys.swift` 파일을 생성:
+```swift
+enum APIKeys {
+    static let tourAPIKey = "YOUR_TOUR_API_KEY"
+    static let kakaoNativeAppKey = "YOUR_KAKAO_NATIVE_APP_KEY"
+}
+```
+> APIKeys.swift는 .gitignore에 포함되어 있어 커밋되지 않습니다.
 
 <br>
 


### PR DESCRIPTION
## Summary

회원가입 플로우 UI를 피그마 디자인에 맞게 전면 수정하고, 일정 확인/체크리스트/캘린더 기능을 피그마 기반으로 새롭게 구현했습니다.

<br/>

## 1. 회원가입 UI 피그마 디자인 적용 (`99d04aa`)

### 플로우 순서 변경
- **기존**: 닉네임 → 약관 → 아이디 → 비밀번호 → 완료
- **변경**: 닉네임 → 아이디 → 비밀번호 → 약관 → 완료
- 약관 동의를 마지막 입력 단계로 이동하여 "가입하기" 버튼이 약관 화면에 위치

<br/>

### 레이아웃 변경 (전체 공통)
- **네비게이션 바**: 타이틀 제거 → 뒤로가기(chevron.left) 화살표만 남기는 미니멀 스타일
- **진행 표시**: 상단 프로그레스 바 제거 → 하단 도트 인디케이터(4개)로 교체
- **컬러 테마**: 라이트 모드 기반 (screenBackground, inputBackground, textBlack 등)

<br/>

### 화면별 변경

#### SignUpFlowView (컨테이너)
- 프로그레스 바 제거, 하단에 4개 도트 인디케이터 추가 (dotActive/dotInactive 색상)
- Step switch 순서를 새 플로우에 맞게 재배치
- 완료 화면(step 4)에서는 도트 인디케이터 숨김

#### SignUpNicknameView (닉네임 설정)
- 큰 타이틀: "하이트립에서 사용할\n이름을 입력해주세요"
- 파란색 "닉네임" 라벨을 입력 필드 위에 추가
- 중복확인 버튼 유지 (기존 기능 보존)

#### SignUpUserIdView (아이디 설정)
- "아이디 설정" 타이틀 + 설명 텍스트 추가
- 파란색 "아이디" 라벨을 입력 필드 위에 추가
- 중복확인 버튼 추가 (닉네임과 동일 패턴)
- ViewModel에 isUserIdChecked, isUserIdAvailable, checkUserId() 등 추가

#### SignUpPasswordView (비밀번호 설정)
- "비밀번호 설정" 타이틀 + 계정 보안 관련 설명
- 파란색 "비밀번호를 입력해주세요." 라벨 2개 (비밀번호 / 확인)
- 두 번째 라벨을 확인 필드의 VStack(alignment: .leading) 내부로 이동하여 중앙 정렬 버그 수정
- 버튼 텍스트: "가입하기" → "다음" (다음 단계가 약관이므로)
- 8자 이상 유효성 검증 메시지

#### SignUpTermsView (약관 동의)
- "약관 동의" 타이틀 + 설명 텍스트
- 버튼: "다음" → "가입하기" (마지막 입력 단계이므로 viewModel.signUp() 호출)
- 흰색 체크박스 카드 배경

#### SignUpCompleteView (가입 완료)
- 라이트 모드 테마 적용
- router.navigateToLogin()으로 로그인 화면 이동

<br/>

### API Mock 처리
- **checkNickname()**: 0.5초 지연 후 항상 사용 가능 응답 (원본 RxSwift 코드 주석 보존)
- **checkUserId()**: 0.5초 지연 후 항상 사용 가능 응답 (신규 추가)
- **signUp()**: 0.5초 지연 후 성공 응답 (원본 RxSwift 코드 주석 보존)
- API 연동 없이 UI만으로 전체 플로우 테스트 가능

<br/>

### 수정 파일 (8개)
| 파일 | 변경 내용 |
|------|----------|
| `Color+Hex.swift` | dotInactive, dotActive 색상 추가 |
| `SignUpViewModel.swift` | 플로우 순서 변경, 아이디 중복확인 로직 추가, 3개 API Mock 처리 |
| `SignUpFlowView.swift` | 미니멀 네비바 + 도트 인디케이터 + step 순서 변경 |
| `SignUpNicknameView.swift` | 피그마 레이아웃 (큰 타이틀 + 파란 라벨) |
| `SignUpUserIdView.swift` | 피그마 레이아웃 + 중복확인 UI 추가 |
| `SignUpPasswordView.swift` | 피그마 레이아웃 + 라벨 정렬 버그 수정 + 버튼 "다음"으로 변경 |
| `SignUpTermsView.swift` | 피그마 레이아웃 + 버튼 "가입하기"로 변경 |
| `SignUpCompleteView.swift` | 라이트 모드 테마 적용 |


<br/>
<br/>


## 2. 일정/캘린더 기능 전면 개편 (`9941bc0`)

기존 ScheduleListView 기반의 단순 일정 목록을 피그마 디자인 기반 3화면 구조로 전면 교체했습니다.

### 아키텍처

```
TripDataStore (싱글턴 중앙 저장소)
├── TripListViewModel (일정 페이지)
│       └── TripListView (화면1)
│               ├── WeekCalendarStripView (공용 컴포넌트)
│               ├── dailyScheduleSection (날짜별 일정+투두 미리보기)
│               └── TripCardRow (여행 카드)
│                       └── TripScheduleDetailView (상세보기 시트)
│
└── TripDetailViewModel (할일/캘린더 페이지)
└── TripDetailView (화면2+3 컨테이너)
├── TripTodoView (할일 탭)
│       └── WeekCalendarStripView
└── TripCalendarView (캘린더 탭)
└── TripEventRow (이벤트 행)
````

<br/>

### 데이터 관리 — TripDataStore (핵심 변경)
- **싱글턴 패턴**: `TripDataStore.shared`로 앱 전체에서 동일 데이터 참조
- **Combine 연동**: Store의 `objectWillChange`를 각 ViewModel이 구독 → Store 변경 시 모든 화면 자동 갱신
- **CRUD 메서드 집중**: addTodo/toggleTodo/updateTodo/deleteTodo, addEvent/updateEvent/deleteEvent 모두 Store에서 관리
- **날짜별/Trip별/섹션별 필터링 메서드 제공**: `todos(for:date:section:)`, `events(for:date:)`, `eventCategories(for:date:)` 등
- **Mock 데이터 한 곳에서 생성**: Trip 3개 + Todo 14개 + Event 6개 (오늘/내일/모레에 걸쳐 분포)

<br/>

### 신규 모델 (3개)

#### Trip.swift
- 여행 단위 모델: id, title, date, location, thumbnailName, memberAvatars, createdAt

#### TripTodo.swift
- 체크리스트 항목: id, title, isCompleted, section(.todayPrep / .travelPrep), date, tripId
- `date` 필드로 날짜별 필터링 지원
- `Section` enum: "오늘 일정 준비", "여행 준비 & 관리"

#### TripEvent.swift
- 캘린더 이벤트: id, title, startTime, endTime, category, tripId
- `Category` enum (4종): 여행지(네이비), 목록(라이트블루), 일정(옐로), 기타(핑크)
- 각 카테고리에 고유 색상 지정 → 캘린더 도트 및 이벤트 행 색상 바에 사용

<br/>

### 화면1: 일정 확인 페이지 (TripListView)

#### 주간 캘린더 스트립
- WeekCalendarStripView 공용 컴포넌트 사용 (일요일 시작)
- 날짜 선택 시 하단 일정/투두 미리보기 실시간 갱신

#### 날짜별 일정+투두 미리보기 (dailyScheduleSection)
- 선택된 날짜 헤더: "4월 21일 월요일" 형식
- **일정 섹션**: 카테고리 색상 바 + 제목 + 시간 범위 + `>` 아이콘 → 클릭 시 캘린더 탭으로 이동
- **할 일 섹션**: 체크 아이콘 클릭 → 완료 토글 / 텍스트 영역 클릭 → 할일 탭으로 이동
- 해당 날짜에 데이터 없으면 "이 날짜에 등록된 일정이 없습니다." 빈 상태 표시

#### 내 일정 카드 리스트
- TripCardRow: 썸네일(그라데이션 + SF Symbol) + 날짜 + 제목 + 위치
- 카드 클릭 → TripScheduleDetailView 시트 (SpotDetailView 동일 레이아웃)

#### "View all" → AllTripsView
- 위치(지역)별로 Trip 그룹핑하여 전체 일정 한눈에 확인
- 상단 요약: "총 N개의 일정 / N개 지역"
- 각 카드 클릭 → TripDetailView로 이동

<br/>

### 화면2: 체크리스트/할일 (TripTodoView)

#### 주간 캘린더 스트립
- WeekCalendarStripView 공용 컴포넌트 사용 (월요일 시작)
- `>` 클릭으로 주 이동 시 월 표시 자동 변경 (표시 중인 주의 중간 날짜 기준)

#### 체크리스트 섹션 (2개)
- "🏖 오늘 일정 준비" / "🧳 여행 준비 & 관리"
- 날짜별 필터링: 선택된 날짜에 해당하는 할일만 표시
- `.frame(maxWidth: .infinity, alignment: .leading)` 적용으로 투두 없는 날짜의 공백 문제 해결

#### 할일 CRUD
- **추가**: "체크리스트를 추가하세요." 클릭 → 인라인 TextField → onSubmit으로 등록
- **체크 토글**: 체크 아이콘 클릭 → 완료/미완료 전환 (취소선 + 색상 변경)
- **수정**: `...` 메뉴 → "수정" → 인라인 TextField로 제목 편집
- **삭제**: `...` 메뉴 → "삭제" (withAnimation 적용)

<br/>

### 화면3: 월간 캘린더 (TripCalendarView)

#### 월간 캘린더 그리드
- "N월" 형식 헤더 (큰 텍스트)
- 카테고리 범례 (여행지/목록/일정/기타 — 색상 도트)
- 요일 헤더 (월~일)
- LazyVGrid 7열 그리드, 날짜 셀에 카테고리 색상 도트 최대 3개 표시
- 선택된 날짜: 파란 원 배경 / 오늘: 파란 텍스트 볼드

#### 오늘의 일정 섹션
- 선택된 날짜의 이벤트를 TripEventRow로 표시
- 카테고리 색상 바 + 제목 + 시간 범위 + `...` 메뉴

#### 이벤트 CRUD
- **추가**: FAB(+) 버튼 → 시트 (제목, 시작/종료 DatePicker, 카테고리 Picker)
- **수정**: `...` 메뉴 → "수정" → 동일 시트에 기존 값 채워서 표시 (editingEventId로 구분)
- **삭제**: `...` 메뉴 → "삭제"

<br/>

### 공용 컴포넌트

#### WeekCalendarStripView
- 두 가지 스타일: `.sundayStart` (S M T W T F S) / `.mondayStart` (월 화 수 목 금 토 일)
- weekOffset으로 주 이동, 선택된 날짜 파란 원 배경
- 월 표시: 표시 중인 주의 중간 날짜 기준으로 자동 변경
- onDateTap 콜백 (옵션)

#### TripEventRow
- 카테고리 색상 바 + 제목 + 시간 + `...` 메뉴 (onEdit/onDelete 콜백)

#### TripScheduleDetailView
- SpotDetailView와 동일한 레이아웃: 헤더 이미지, 제목+태그, 날짜/위치/멤버 정보
- "할일 / 캘린더 보기" NavigationLink → TripDetailView

<br/>
<br/>

## Test Plan

### 회원가입 플로우
- [ ] 닉네임 → 아이디 → 비밀번호 → 약관 → 완료 순서로 진행 확인
- [ ] 각 화면 하단 도트 인디케이터 활성/비활성 상태 확인
- [ ] 닉네임 중복확인 버튼 → Mock 응답 "사용 가능" 확인
- [ ] 아이디 중복확인 버튼 → Mock 응답 "사용 가능" 확인
- [ ] 비밀번호 8자 미만 입력 시 유효성 메시지 확인
- [ ] 약관 동의 후 "가입하기" → Mock 회원가입 성공 → 완료 화면 확인
- [ ] 뒤로가기 화살표로 이전 단계 이동 확인

<br/>

### 일정 페이지
- [ ] 주간 캘린더 날짜 선택 → 해당 날짜의 일정/투두 미리보기 갱신 확인
- [ ] 투두 체크 아이콘 클릭 → 완료 토글 확인
- [ ] 이벤트 행 클릭 → 캘린더 탭으로 이동 확인
- [ ] 투두 행 텍스트 클릭 → 할일 탭으로 이동 확인
- [ ] "View all" 클릭 → 위치별 전체 일정 리스트 페이지 확인
- [ ] 내 일정 카드 클릭 → 상세보기 시트 표시 확인

<br/>

### 할일 탭
- [ ] 날짜 변경 시 해당 날짜 할일만 필터링되는지 확인
- [ ] 투두가 없는 날짜에서 공백 없이 정상 표시 확인
- [ ] "체크리스트를 추가하세요" 클릭 → 입력 → 등록 확인
- [ ] 체크 토글 (완료↔미완료) 확인
- [ ] `...` → 수정 → 인라인 편집 확인
- [ ] `...` → 삭제 확인
- [ ] `>` 클릭으로 다음 주 이동 시 월 표시 자동 변경 확인

<br/>

### 캘린더 탭
- [ ] 월간 그리드에 이벤트 날짜 색상 도트 표시 확인
- [ ] 날짜 선택 → 오늘의 일정 섹션 갱신 확인
- [ ] FAB(+) → 이벤트 추가 시트 → 저장 → 목록 반영 확인
- [ ] `...` → 수정 → 시트에 기존 값 표시 → 저장 확인
- [ ] `...` → 삭제 확인

<br/>

### 데이터 동기화
- [ ] 일정 페이지에서 투두 체크 → 할일 탭에서 동일 상태 확인
- [ ] 할일 탭에서 투두 추가/삭제 → 일정 페이지 미리보기 반영 확인
- [ ] 캘린더 탭에서 이벤트 추가 → 일정 페이지 미리보기 반영 확인