### PR TITLE
feat: 일정/캘린더 기능 구현 + 프로필 피그마 디자인 + 탭바 재구성

### DIFF
--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -4,15 +4,13 @@ import SwiftUI
 /// 메인 홈 화면 — 5탭 네비게이션 구조
 ///
 /// 탭 구성:
-/// - 홈: 로그인 성공 확인 + 로그아웃
-/// - 일정: ScheduleListView (CRUD)
-/// - 채팅: ChatListView (1:1 메시지)
-/// - 스팟 추천: SpotListView (TourAPI 관광지 검색)
-/// - 긴급 연락: EmergencyView (긴급 전화 + 연락처 관리)
-/// - 프로필: ProfileView (프로필 조회 + 로그아웃)
+/// - 홈: TripListView (주간 캘린더 + 내 일정 카드 + 긴급 연락 바로가기)
+/// - 캘린더: ScheduleTabView (할일/캘린더 탭 — TripDetailView 래퍼)
+/// - 검색: SpotListView (TourAPI 관광지 검색)
+/// - 메시지: ChatListView (1:1 메시지)
+/// - 마이페이지: ProfileView (프로필 조회 + 로그아웃)
 ///
-/// Phase 1에서는 탭 구조만 잡고,
-/// 각 탭의 실제 콘텐츠는 해당 Phase 커밋에서 교체
+/// 긴급 연락은 홈 화면에서 바로가기로 접근 가능
 
 struct HomeView: View {
 
@@ -23,20 +21,18 @@ struct HomeView: View {
 
     enum Tab: String, CaseIterable {
         case home      = "홈"
-        case schedule  = "일정"
-        case chat      = "채팅"
-        case spots     = "스팟 추천"
-        case emergency = "긴급 연락"
-        case profile   = "프로필"
+        case calendar  = "캘린더"
+        case search    = "검색"
+        case message   = "메시지"
+        case mypage    = "마이페이지"
 
         var icon: String {
             switch self {
-            case .home:      return "house.fill"
-            case .schedule:  return "calendar"
-            case .chat:      return "bubble.left.and.bubble.right"
-            case .spots:     return "map.fill"
-            case .emergency: return "exclamationmark.triangle.fill"
-            case .profile:   return "person.fill"
+            case .home:     return "house.fill"
+            case .calendar: return "calendar"
+            case .search:   return "magnifyingglass"
+            case .message:  return "bubble.left.and.bubble.right"
+            case .mypage:   return "person.fill"
             }
         }
     }
@@ -45,108 +41,30 @@ struct HomeView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            homeTab
+            TripListView()
                 .tabItem { Label(Tab.home.rawValue, systemImage: Tab.home.icon) }
                 .tag(Tab.home)
 
-            TripListView()
-                .tabItem { Label(Tab.schedule.rawValue, systemImage: Tab.schedule.icon) }
-                .tag(Tab.schedule)
-
-            ChatListView(
-                    viewModel: AppDIContainer.shared.makeChatViewModel()
-                )
-                .tabItem { Label(Tab.chat.rawValue, systemImage: Tab.chat.icon) }
-                .tag(Tab.chat)
+            ScheduleTabView()
+                .tabItem { Label(Tab.calendar.rawValue, systemImage: Tab.calendar.icon) }
+                .tag(Tab.calendar)
 
             SpotListView(
                     viewModel: AppDIContainer.shared.makeSpotViewModel()
                 )
-                .tabItem { Label(Tab.spots.rawValue, systemImage: Tab.spots.icon) }
-                .tag(Tab.spots)
+                .tabItem { Label(Tab.search.rawValue, systemImage: Tab.search.icon) }
+                .tag(Tab.search)
 
-            EmergencyView(
-                    viewModel: AppDIContainer.shared.makeEmergencyViewModel()
+            ChatListView(
+                    viewModel: AppDIContainer.shared.makeChatViewModel()
                 )
-                .tabItem { Label(Tab.emergency.rawValue, systemImage: Tab.emergency.icon) }
-                .tag(Tab.emergency)
+                .tabItem { Label(Tab.message.rawValue, systemImage: Tab.message.icon) }
+                .tag(Tab.message)
 
             ProfileView()
-                .tabItem { Label(Tab.profile.rawValue, systemImage: Tab.profile.icon) }
-                .tag(Tab.profile)
+                .tabItem { Label(Tab.mypage.rawValue, systemImage: Tab.mypage.icon) }
+                .tag(Tab.mypage)
         }
         .tint(HiTripColor.primary800)
-    }
-
-    // MARK: - Home Tab
-
-    private var homeTab: some View {
-        NavigationStack {
-            VStack(spacing: 24) {
-                Spacer()
-
-                Text("Hi Trip")
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundColor(HiTripColor.logoText)
-
-                Text("로그인 성공!")
-                    .font(.system(size: 18))
-                    .foregroundColor(HiTripColor.gray500)
-
-                // 사용자 타입 배지 (안내사/관광객)
-                if let userType = KeychainManager.shared.getUserType() {
-                    Label(
-                        userType == "guide" ? "안내사" : "관광객",
-                        systemImage: userType == "guide"
-                            ? "person.badge.shield.checkmark"
-                            : "person"
-                    )
-                    .font(.system(size: 14))
-                    .foregroundColor(HiTripColor.primary800)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(HiTripColor.secondary100)
-                    .cornerRadius(8)
-                }
-
-                Spacer()
-
-                // 로그아웃 버튼
-                Button {
-                    KeychainManager.shared.clearAll()
-                    router.navigateToLogin()
-                } label: {
-                    Text("로그아웃")
-                        .font(.system(size: 14))
-                        .foregroundColor(HiTripColor.error)
-                }
-                .padding(.bottom, 20)
-            }
-        }
-    }
-
-    // MARK: - Placeholder Tab
-
-    /// Phase 2+ 에서 실제 View로 교체될 임시 탭
-    private func placeholderTab(
-        _ title: String,
-        icon: String,
-        phase: Int
-    ) -> some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                Spacer()
-                Image(systemName: icon)
-                    .font(.system(size: 40))
-                    .foregroundColor(HiTripColor.gray300)
-                Text(title)
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(HiTripColor.textGrayA)
-                Text("Phase \(phase)에서 구현 예정")
-                    .font(.system(size: 14))
-                    .foregroundColor(HiTripColor.gray400)
-                Spacer()
-            }
-        }
     }
 }

--- a/HiTrip/Features/Profile/Views/ProfileEditView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileEditView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+// MARK: - ProfileEditView
+/// 프로필 수정 화면 — 피그마 디자인
+///
+/// UI 구성:
+/// - 네비바: 뒤로가기 + "프로필 수정" + 완료 버튼
+/// - 아바타 + 이름 + "프로필 변경하기" 링크
+/// - 폼: 닉네임, 생년월일, 거주 국가, 휴대번호
+
+struct ProfileEditView: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Form State
+
+    @State private var nickname: String = ""
+    @State private var birthday: Date = Date()
+    @State private var showBirthdayPicker: Bool = false
+    @State private var country: String = "대한민국"
+    @State private var countryCode: String = "+82"
+    @State private var phoneNumber: String = ""
+
+    /// 저장 완료 알림
+    @State private var showSaveAlert: Bool = false
+
+    var body: some View {
+        ZStack {
+            HiTripColor.screenBackground
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    // 아바타 + 이름 + 프로필 변경하기
+                    profileAvatarSection
+                        .padding(.top, 24)
+
+                    // 폼 영역
+                    formSection
+                        .padding(.top, 28)
+                        .padding(.horizontal, 24)
+
+                    Spacer().frame(height: 40)
+                }
+            }
+        }
+        .navigationTitle("프로필 수정")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                        .frame(width: 40, height: 40)
+                        .background(Color.white)
+                        .clipShape(Circle())
+                        .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("완료") {
+                    saveProfile()
+                }
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.primary800)
+            }
+        }
+        .alert("저장 완료", isPresented: $showSaveAlert) {
+            Button("확인") { dismiss() }
+        } message: {
+            Text("프로필이 저장되었습니다.")
+        }
+    }
+
+    // MARK: - Avatar Section
+
+    private var profileAvatarSection: some View {
+        VStack(spacing: 8) {
+            // 아바타
+            ZStack {
+                Circle()
+                    .fill(Color(hex: "FADADD").opacity(0.5))
+                    .frame(width: 110, height: 110)
+
+                Text("🙋‍♀️")
+                    .font(.system(size: 56))
+            }
+
+            // 이름
+            Text(userName)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+                .padding(.top, 4)
+
+            // 프로필 변경하기 링크
+            Button { } label: {
+                Text("프로필 변경하기")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(HiTripColor.primary800)
+            }
+        }
+    }
+
+    // MARK: - Form Section
+
+    private var formSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // 닉네임
+            formField(
+                label: "닉네임",
+                placeholder: "15자 이내 영문, 숫자로 입력해주세요",
+                text: $nickname
+            )
+
+            // 생년월일
+            birthdayField
+
+            // 거주 국가
+            formField(
+                label: "거주 국가",
+                placeholder: "국가를 입력해주세요",
+                text: $country
+            )
+
+            // 휴대번호
+            phoneField
+        }
+    }
+
+    // MARK: - Form Field (텍스트 입력)
+
+    private func formField(label: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            TextField(placeholder, text: text)
+                .font(.system(size: 15))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+                .background(HiTripColor.gray100)
+                .cornerRadius(12)
+        }
+    }
+
+    // MARK: - Birthday Field
+
+    private var birthdayField: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("생년월일")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Button {
+                showBirthdayPicker.toggle()
+            } label: {
+                HStack {
+                    Text(birthdayText)
+                        .font(.system(size: 15))
+                        .foregroundColor(
+                            birthdayText == "생년월일을 선택해주세요"
+                                ? HiTripColor.gray400
+                                : HiTripColor.textBlack
+                        )
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+                .background(HiTripColor.gray100)
+                .cornerRadius(12)
+            }
+            .buttonStyle(.plain)
+
+            if showBirthdayPicker {
+                DatePicker(
+                    "",
+                    selection: $birthday,
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.wheel)
+                .labelsHidden()
+                .environment(\.locale, Locale(identifier: "ko_KR"))
+            }
+        }
+    }
+
+    /// 생년월일 표시 텍스트
+    private var birthdayText: String {
+        "생년월일을 선택해주세요"
+    }
+
+    // MARK: - Phone Field
+
+    private var phoneField: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("휴대번호")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            HStack(spacing: 8) {
+                // 국가 코드
+                Menu {
+                    Button("+82 🇰🇷") { countryCode = "+82" }
+                    Button("+1 🇺🇸") { countryCode = "+1" }
+                    Button("+81 🇯🇵") { countryCode = "+81" }
+                    Button("+86 🇨🇳") { countryCode = "+86" }
+                    Button("+213 🇩🇿") { countryCode = "+213" }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(countryCode)
+                            .font(.system(size: 15))
+                            .foregroundColor(HiTripColor.textBlack)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 11))
+                            .foregroundColor(HiTripColor.gray400)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 14)
+                    .background(HiTripColor.gray100)
+                    .cornerRadius(12)
+                }
+
+                // 전화번호
+                TextField("전화번호를 입력해주세요", text: $phoneNumber)
+                    .font(.system(size: 15))
+                    .keyboardType(.phonePad)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .background(HiTripColor.gray100)
+                    .cornerRadius(12)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func saveProfile() {
+        // Mock: 프로필 저장 (추후 API 연동)
+        showSaveAlert = true
+    }
+
+    // MARK: - Helpers
+
+    private var userName: String {
+        KeychainManager.shared.getUserId() ?? "이연세"
+    }
+}

--- a/HiTrip/Features/Profile/Views/ProfileView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileView.swift
@@ -1,46 +1,85 @@
 import SwiftUI
 
 // MARK: - ProfileView
-/// 프로필 화면
+/// 프로필 메인 화면 — 피그마 디자인
 ///
 /// UI 구성:
-/// - 프로필 아바타 (이니셜 원형 뱃지)
-/// - 사용자 정보 (이름, 아이디, 유저 타입)
-/// - 메뉴 섹션 (알림 설정, 이용약관, 버전 정보)
-/// - 로그아웃 버튼
-///
-/// 현재는 Keychain에 저장된 정보로 표시
-/// 서버 연동 후 API에서 받아온 정보로 교체 예정
+/// - 네비바: 뒤로가기 + "프로필" + 편집 아이콘
+/// - 프로필 아바타 (분홍 원형 배경)
+/// - 이름 + 이메일
+/// - 통계 카드 (포인트, 여행, 버킷리스트)
+/// - 메뉴 리스트 (프로필, 북마크, 여행, 설정, 버전정보)
 
 struct ProfileView: View {
 
     @EnvironmentObject var router: AppRouter
+    @Environment(\.dismiss) private var dismiss
 
-    /// 로그아웃 확인 Alert 표시 여부
+    /// 로그아웃 확인 Alert
     @State private var showLogoutAlert = false
+
+    /// 프로필 수정 화면 이동
+    @State private var showEditProfile = false
 
     var body: some View {
         NavigationStack {
-            List {
-                // 프로필 헤더
-                profileHeader
-                    .listRowBackground(Color.clear)
+            ZStack {
+                HiTripColor.screenBackground
+                    .ignoresSafeArea()
 
-                // 계정 정보
-                accountSection
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // 프로필 헤더 (아바타 + 이름 + 이메일)
+                        profileHeader
+                            .padding(.top, 20)
 
-                // 앱 설정
-                settingsSection
+                        // 통계 카드
+                        statsCard
+                            .padding(.top, 24)
+                            .padding(.horizontal, 24)
 
-                // 앱 정보
-                appInfoSection
+                        // 메뉴 리스트
+                        menuList
+                            .padding(.top, 28)
 
-                // 로그아웃
-                logoutSection
+                        // 로그아웃
+                        logoutButton
+                            .padding(.top, 16)
+                            .padding(.horizontal, 24)
+
+                        Spacer().frame(height: 40)
+                    }
+                }
             }
-            .listStyle(.insetGrouped)
             .navigationTitle("프로필")
-            // 로그아웃 확인 Alert
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(HiTripColor.textBlack)
+                            .frame(width: 40, height: 40)
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button { showEditProfile = true } label: {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(HiTripColor.primary800)
+                            .frame(width: 40, height: 40)
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $showEditProfile) {
+                ProfileEditView()
+            }
             .alert("로그아웃", isPresented: $showLogoutAlert) {
                 Button("로그아웃", role: .destructive) {
                     KeychainManager.shared.clearAll()
@@ -55,178 +94,146 @@ struct ProfileView: View {
 
     // MARK: - Profile Header
 
-    /// 프로필 아바타 + 이름 + 유저 타입 뱃지
     private var profileHeader: some View {
-        VStack(spacing: 12) {
-            // 아바타 (이니셜 표시)
+        VStack(spacing: 8) {
+            // 아바타 (분홍 원형 배경 + 이모지)
             ZStack {
                 Circle()
-                    .fill(HiTripColor.primary800)
-                    .frame(width: 80, height: 80)
+                    .fill(Color(hex: "FADADD").opacity(0.5))
+                    .frame(width: 110, height: 110)
 
-                Text(avatarInitial)
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundColor(.white)
+                Text("🙋‍♀️")
+                    .font(.system(size: 56))
             }
 
-            // 사용자 이름
+            // 이름
             Text(userName)
-                .font(.system(size: 20, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
+                .padding(.top, 8)
 
-            // 유저 타입 뱃지 (안내사/관광객)
-            Text(userTypeBadge)
-                .font(.system(size: 13, weight: .medium))
+            // 이메일
+            Text(userEmail)
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+
+    // MARK: - Stats Card
+
+    private var statsCard: some View {
+        HStack(spacing: 0) {
+            statItem(title: "포인트", value: "50")
+
+            Divider()
+                .frame(height: 40)
+
+            statItem(title: "여행", value: "40")
+
+            Divider()
+                .frame(height: 40)
+
+            statItem(title: "버킷리스트", value: "200")
+        }
+        .padding(.vertical, 18)
+        .background(Color.white)
+        .cornerRadius(14)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+    }
+
+    private func statItem(title: String, value: String) -> some View {
+        VStack(spacing: 6) {
+            Text(title)
+                .font(.system(size: 13))
+                .foregroundColor(HiTripColor.gray500)
+
+            Text(value)
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.primary800)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(HiTripColor.secondary100)
-                .cornerRadius(12)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
     }
 
-    // MARK: - Account Section
+    // MARK: - Menu List
 
-    /// 계정 정보 섹션
-    private var accountSection: some View {
-        Section("계정 정보") {
-            // 아이디
-            HStack {
-                Label("아이디", systemImage: "person.text.rectangle")
-                    .foregroundColor(HiTripColor.textGrayA)
-                Spacer()
-                Text(userId)
+    private var menuList: some View {
+        VStack(spacing: 0) {
+            menuRow(icon: "person.crop.circle", title: "프로필") {
+                showEditProfile = true
+            }
+
+            menuDivider
+
+            menuRow(icon: "bookmark", title: "북마크") { }
+
+            menuDivider
+
+            menuRow(icon: "airplane", title: "여행") { }
+
+            menuDivider
+
+            menuRow(icon: "gearshape", title: "설정") { }
+
+            menuDivider
+
+            menuRow(icon: "info.circle", title: "버전정보") { }
+        }
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .padding(.horizontal, 24)
+    }
+
+    private func menuRow(icon: String, title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 20))
                     .foregroundColor(HiTripColor.gray500)
-            }
+                    .frame(width: 28)
 
-            // 유저 타입
-            HStack {
-                Label("유형", systemImage: "person.crop.rectangle")
-                    .foregroundColor(HiTripColor.textGrayA)
+                Text(title)
+                    .font(.system(size: 16))
+                    .foregroundColor(HiTripColor.textBlack)
+
                 Spacer()
-                Text(userTypeBadge)
-                    .foregroundColor(HiTripColor.gray500)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray300)
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 18)
         }
+        .buttonStyle(.plain)
     }
 
-    // MARK: - Settings Section
-
-    /// 앱 설정 섹션 (Phase 6에서 실제 동작 연결)
-    private var settingsSection: some View {
-        Section("설정") {
-            // 알림 설정
-            NavigationLink {
-                placeholderView("알림 설정", phase: 6)
-            } label: {
-                Label("알림 설정", systemImage: "bell")
-                    .foregroundColor(HiTripColor.textGrayA)
-            }
-
-            // 언어 설정
-            NavigationLink {
-                placeholderView("언어 설정", phase: 6)
-            } label: {
-                Label("언어", systemImage: "globe")
-                    .foregroundColor(HiTripColor.textGrayA)
-            }
-        }
+    private var menuDivider: some View {
+        Divider()
+            .padding(.leading, 62)
     }
 
-    // MARK: - App Info Section
+    // MARK: - Logout Button
 
-    /// 앱 정보 섹션
-    private var appInfoSection: some View {
-        Section("앱 정보") {
-            // 이용약관
-            NavigationLink {
-                placeholderView("이용약관", phase: 6)
-            } label: {
-                Label("이용약관", systemImage: "doc.text")
-                    .foregroundColor(HiTripColor.textGrayA)
-            }
-
-            // 개인정보처리방침
-            NavigationLink {
-                placeholderView("개인정보처리방침", phase: 6)
-            } label: {
-                Label("개인정보처리방침", systemImage: "lock.shield")
-                    .foregroundColor(HiTripColor.textGrayA)
-            }
-
-            // 버전 정보
-            HStack {
-                Label("버전", systemImage: "info.circle")
-                    .foregroundColor(HiTripColor.textGrayA)
-                Spacer()
-                Text(appVersion)
-                    .foregroundColor(HiTripColor.gray400)
-            }
-        }
-    }
-
-    // MARK: - Logout Section
-
-    /// 로그아웃 버튼
-    private var logoutSection: some View {
-        Section {
-            Button(role: .destructive) {
-                showLogoutAlert = true
-            } label: {
-                HStack {
-                    Spacer()
-                    Text("로그아웃")
-                    Spacer()
-                }
-            }
-        }
-    }
-
-    // MARK: - Placeholder View
-
-    /// Phase 6에서 구현 예정인 상세 화면
-    private func placeholderView(_ title: String, phase: Int) -> some View {
-        VStack(spacing: 16) {
-            Spacer()
-            Text(title)
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(HiTripColor.textGrayA)
-            Text("Phase \(phase)에서 구현 예정")
-                .font(.system(size: 14))
+    private var logoutButton: some View {
+        Button {
+            showLogoutAlert = true
+        } label: {
+            Text("로그아웃")
+                .font(.system(size: 15))
                 .foregroundColor(HiTripColor.gray400)
-            Spacer()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
         }
-        .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
     }
 
-    // MARK: - Computed Helpers
+    // MARK: - Helpers
 
-    /// Keychain에서 사용자 이름 조회 (없으면 기본값)
     private var userName: String {
-        KeychainManager.shared.getUserId() ?? "Hi Trip 사용자"
+        KeychainManager.shared.getUserId() ?? "이연세"
     }
 
-    /// 아바타 이니셜 (이름 첫 글자)
-    private var avatarInitial: String {
-        String(userName.prefix(1))
-    }
-
-    /// 사용자 아이디
-    private var userId: String {
-        KeychainManager.shared.getUserId() ?? "-"
-    }
-
-    /// 유저 타입 표시 텍스트
-    private var userTypeBadge: String {
-        guard let type = KeychainManager.shared.getUserType() else { return "미설정" }
-        return type == "guide" ? "안내사" : "관광객"
-    }
-
-    /// 앱 버전 (Bundle에서 자동 조회)
-    private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    private var userEmail: String {
+        "hitrip@gmail.com"
     }
 }

--- a/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+// MARK: - ScheduleTabView
+/// 하단 탭바에서 "일정" 탭을 눌렀을 때 바로 보여주는 래퍼 뷰
+///
+/// TripDetailView는 Trip 파라미터가 필수이므로,
+/// TripDataStore에서 첫 번째 여행을 자동으로 선택하여 표시한다.
+/// 여행이 없으면 빈 상태 안내를 보여준다.
+
+struct ScheduleTabView: View {
+
+    @ObservedObject private var store = TripDataStore.shared
+
+    /// Store의 첫 번째 여행 (정렬 기준: 날짜순)
+    private var firstTrip: Trip? {
+        store.sortedTrips.first
+    }
+
+    var body: some View {
+        NavigationStack {
+            if let trip = firstTrip {
+                TripDetailView(trip: trip)
+            } else {
+                emptyState
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "calendar.badge.plus")
+                .font(.system(size: 48))
+                .foregroundColor(HiTripColor.gray300)
+
+            Text("등록된 일정이 없습니다")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("여행 일정을 추가해보세요!")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+
+            Spacer()
+        }
+        .navigationTitle("일정")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 // MARK: - TripListView
-/// 화면1: 최근 일정 — 피그마 디자인
+/// 홈 화면 — 피그마 디자인
 ///
 /// UI 구성:
-/// - 네비게이션 바: 뒤로가기 + "최근 일정" + 알림 아이콘
+/// - 네비바: "Hi Trip" 로고 + 알림 아이콘
 /// - 주간 캘린더 스트립 (날짜 선택)
-/// - 선택한 날짜의 일정 + 투두 미리보기
 /// - "내 일정" 섹션 + "View all" 링크
 /// - 여행 카드 리스트 (썸네일 + 날짜 + 제목 + 위치)
+/// - 긴급 연락망 바로가기 배너
 
 struct TripListView: View {
 
@@ -21,13 +21,8 @@ struct TripListView: View {
     /// 내 일정 카드 클릭 → 상세보기 (SpotDetailView 스타일)
     @State private var selectedTripForDetail: Trip?
 
-    /// 투두 탭 → 해당 Trip 상세 (할일 탭)로 이동
-    @State private var navigateToTripDetail: Bool = false
-    @State private var selectedTripForNav: Trip?
-
-    /// 이벤트 탭 → 해당 Trip 상세 (캘린더 탭)로 이동
-    @State private var navigateToCalendar: Bool = false
-    @State private var selectedTripForCalendar: Trip?
+    /// 긴급 연락 페이지 이동
+    @State private var showEmergency: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -40,10 +35,6 @@ struct TripListView: View {
                         // 주간 캘린더 스트립
                         calendarCard
 
-                        // 선택한 날짜의 일정 + 투두
-                        dailyScheduleSection
-                            .padding(.top, 16)
-
                         // "내 일정" 헤더
                         sectionHeader
                             .padding(.top, 24)
@@ -51,6 +42,11 @@ struct TripListView: View {
                         // 여행 카드 리스트
                         tripCardList
                             .padding(.top, 12)
+
+                        // 긴급 연락망 바로가기
+                        emergencyBanner
+                            .padding(.top, 24)
+                            .padding(.horizontal, 20)
 
                         Spacer().frame(height: 24)
                     }
@@ -60,28 +56,16 @@ struct TripListView: View {
             .navigationDestination(isPresented: $navigateToAllTrips) {
                 AllTripsView()
             }
-            // 투두 영역 탭 → Trip 상세 (할일 탭)
-            .navigationDestination(isPresented: $navigateToTripDetail) {
-                if let trip = selectedTripForNav {
-                    TripDetailView(trip: trip)
-                }
+            // 긴급 연락 → EmergencyView
+            .navigationDestination(isPresented: $showEmergency) {
+                EmergencyView(viewModel: AppDIContainer.shared.makeEmergencyViewModel())
             }
-            // 이벤트 영역 탭 → Trip 상세 (캘린더 탭)
-            .navigationDestination(isPresented: $navigateToCalendar) {
-                if let trip = selectedTripForCalendar {
-                    TripDetailView(trip: trip, initialTab: .calendar)
-                }
-            }
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button { } label: {
-                        Image(systemName: "chevron.left")
-                            .foregroundColor(HiTripColor.textBlack)
-                    }
-                }
-                ToolbarItem(placement: .principal) {
-                    Text("최근 일정")
-                        .font(.system(size: 17, weight: .semibold))
+                    Text("Hi Trip")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(HiTripColor.primary800)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button { } label: {
@@ -107,177 +91,6 @@ struct TripListView: View {
         .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
         .padding(.horizontal, 20)
         .padding(.top, 8)
-    }
-
-    // MARK: - Daily Schedule Section
-
-    private var dailyScheduleSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // 날짜 헤더
-            Text(selectedDateText)
-                .font(.system(size: 16, weight: .bold))
-                .foregroundColor(HiTripColor.textBlack)
-                .padding(.horizontal, 24)
-
-            if viewModel.hasScheduleForSelectedDate {
-                // 이벤트 목록
-                if !viewModel.eventsForSelectedDate.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("일정", systemImage: "calendar")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(HiTripColor.primary800)
-                            .padding(.horizontal, 24)
-
-                        ForEach(viewModel.eventsForSelectedDate) { event in
-                            Button {
-                                // 이벤트 클릭 → 해당 Trip 캘린더 탭으로 이동
-                                if let trip = viewModel.trip(for: event.tripId) {
-                                    selectedTripForCalendar = trip
-                                    navigateToCalendar = true
-                                }
-                            } label: {
-                                dailyEventRow(event)
-                            }
-                            .buttonStyle(.plain)
-                            .padding(.horizontal, 20)
-                        }
-                    }
-                }
-
-                // 투두 목록
-                if !viewModel.todosForSelectedDate.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("할 일", systemImage: "checklist")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(HiTripColor.primary800)
-                            .padding(.horizontal, 24)
-                            .padding(.top, viewModel.eventsForSelectedDate.isEmpty ? 0 : 4)
-
-                        ForEach(viewModel.todosForSelectedDate) { todo in
-                            dailyTodoRow(todo)
-                                .padding(.horizontal, 20)
-                        }
-                    }
-                }
-            } else {
-                // 빈 상태
-                HStack {
-                    Spacer()
-                    VStack(spacing: 6) {
-                        Image(systemName: "calendar.badge.minus")
-                            .font(.system(size: 28))
-                            .foregroundColor(HiTripColor.gray300)
-                        Text("이 날짜에 등록된 일정이 없습니다.")
-                            .font(.system(size: 14))
-                            .foregroundColor(HiTripColor.gray400)
-                    }
-                    .padding(.vertical, 16)
-                    Spacer()
-                }
-            }
-        }
-        .padding(.vertical, 16)
-        .background(Color.white)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
-        .padding(.horizontal, 20)
-    }
-
-    /// 선택된 날짜 텍스트 (예: "4월 20일 월요일")
-    private var selectedDateText: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M월 d일 EEEE"
-        return formatter.string(from: viewModel.selectedDate)
-    }
-
-    // MARK: - Daily Event Row
-
-    private func dailyEventRow(_ event: TripEvent) -> some View {
-        HStack(spacing: 10) {
-            RoundedRectangle(cornerRadius: 2)
-                .fill(event.category.color)
-                .frame(width: 4, height: 36)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(event.title)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(HiTripColor.textBlack)
-
-                Text(eventTimeText(event))
-                    .font(.system(size: 12))
-                    .foregroundColor(HiTripColor.gray500)
-            }
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: 12))
-                .foregroundColor(HiTripColor.gray300)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-        .background(HiTripColor.gray100)
-        .cornerRadius(10)
-    }
-
-    private func eventTimeText(_ event: TripEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return "\(formatter.string(from: event.startTime)) - \(formatter.string(from: event.endTime))"
-    }
-
-    // MARK: - Daily Todo Row
-
-    /// 투두 행: 체크 아이콘 클릭 → 토글, 나머지 영역 클릭 → 상세보기
-    private func dailyTodoRow(_ todo: TripTodo) -> some View {
-        HStack(spacing: 10) {
-            // 체크 아이콘 — 탭 시 완료 토글
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    viewModel.toggleTodo(todo.id)
-                }
-            } label: {
-                if todo.isCompleted {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(HiTripColor.primary800)
-                } else {
-                    Circle()
-                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
-                        .frame(width: 18, height: 18)
-                }
-            }
-            .buttonStyle(.plain)
-
-            // 나머지 영역 — 탭 시 해당 Trip 상세보기
-            Button {
-                if let trip = viewModel.trip(for: todo.tripId) {
-                    selectedTripForNav = trip
-                    navigateToTripDetail = true
-                }
-            } label: {
-                HStack {
-                    Text(todo.title)
-                        .font(.system(size: 14))
-                        .foregroundColor(
-                            todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack
-                        )
-                        .strikethrough(todo.isCompleted, color: HiTripColor.gray400)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12))
-                        .foregroundColor(HiTripColor.gray300)
-                }
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-        .background(HiTripColor.gray100)
-        .cornerRadius(10)
     }
 
     // MARK: - Section Header
@@ -322,6 +135,55 @@ struct TripListView: View {
         .sheet(item: $selectedTripForDetail) { trip in
             TripScheduleDetailView(trip: trip)
         }
+    }
+
+    // MARK: - Emergency Banner
+
+    private var emergencyBanner: some View {
+        Button {
+            showEmergency = true
+        } label: {
+            HStack(spacing: 14) {
+                // 아이콘 영역
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(
+                            LinearGradient(
+                                colors: [Color.red.opacity(0.8), Color.orange.opacity(0.7)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 52, height: 52)
+
+                    Image(systemName: "phone.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(.white)
+                }
+
+                // 텍스트 영역
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("긴급 연락망")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(HiTripColor.textBlack)
+
+                    Text("경찰·소방·의료 등 긴급 연락처 확인")
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray300)
+            }
+            .padding(16)
+            .background(Color.white)
+            .cornerRadius(14)
+            .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        }
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
## 프로필/탭바/홈 화면 UI 재구성

프로필 화면을 피그마 디자인에 맞춰 전면 재작성하고, 하단 탭바를 5탭 구조로 재구성.

#### 프로필 (ProfileView 전면 재작성 + ProfileEditView 신규)

- 프로필 메인: 분홍 원형 아바타 + 이름/이메일 + 통계 카드(포인트/여행/버킷리스트) + 메뉴 리스트(프로필/북마크/여행/설정/버전정보) + 로그아웃
- 프로필 수정: 아바타 + "프로필 변경하기" 링크 + 폼(닉네임, 생년월일 DatePicker, 거주 국가, 휴대번호 국가코드 Menu)

#### 탭바 재구성 (6탭 → 5탭)

| 탭 | 아이콘 | 화면 |
|---|---|---|
| 홈 | house.fill | TripListView (캘린더 스트립 + 내 일정 + 긴급 연락 배너) |
| 캘린더 | calendar | ScheduleTabView → TripDetailView (할일/캘린더 직접 접근) |
| 검색 | magnifyingglass | SpotListView |
| 메시지 | bubble.left.and.bubble.right | ChatListView |
| 마이페이지 | person.fill | ProfileView |

#### 긴급 연락망 홈 접근

- 긴급 연락 탭을 제거하고, 홈 화면 하단에 빨강→주황 그라데이션 배너 카드로 배치
- 탭 → NavigationLink로 기존 EmergencyView 이동

#### ScheduleTabView 신규

- TripDetailView가 Trip 파라미터 필수이므로, TripDataStore 첫 번째 여행을 자동 선택하는 래퍼 뷰
- 여행 없을 시 빈 상태 안내 화면 표시