### PR TITLE
refactor: 데이터 관리 구조 정비 — Repository 패턴 도입 + 하드코딩 제거

### DIFF
--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -63,6 +63,12 @@ final class AppDIContainer {
         EmergencyRepository()
     }()
 
+    /// 여행(Trip/Todo/Event) Repository — 현재 Mock, 나중에 서버 연동으로 교체
+    /// TripDataStore.shared가 내부적으로 직접 참조하므로 DI 등록은 참조용
+    private lazy var tripRepository: TripRepositoryProtocol = {
+        MockTripRepository()
+    }()
+
     /// 관광지 Repository — TourAPI 실제 연동
     private lazy var spotRepository: SpotRepositoryProtocol = {
         SpotRepository()

--- a/HiTrip/Core/Utils/KeychainManager.swift
+++ b/HiTrip/Core/Utils/KeychainManager.swift
@@ -35,6 +35,8 @@ final class KeychainManager {
         static let refreshToken = "com.hitrip.refreshToken"
         static let userId       = "com.hitrip.userId"
         static let userType     = "com.hitrip.userType"
+        static let userName     = "com.hitrip.userName"
+        static let userEmail    = "com.hitrip.userEmail"
     }
 
     private init() {}
@@ -79,6 +81,22 @@ final class KeychainManager {
         load(key: Keys.userType)
     }
 
+    func saveUserName(_ name: String) {
+        save(key: Keys.userName, value: name)
+    }
+
+    func getUserName() -> String? {
+        load(key: Keys.userName)
+    }
+
+    func saveUserEmail(_ email: String) {
+        save(key: Keys.userEmail, value: email)
+    }
+
+    func getUserEmail() -> String? {
+        load(key: Keys.userEmail)
+    }
+
     // MARK: - 로그인 상태 확인
 
     /// Access Token 존재 여부로 로그인 상태 판단
@@ -90,7 +108,8 @@ final class KeychainManager {
 
     /// 저장된 모든 인증 정보 삭제
     func clearAll() {
-        [Keys.accessToken, Keys.refreshToken, Keys.userId, Keys.userType]
+        [Keys.accessToken, Keys.refreshToken, Keys.userId, Keys.userType,
+         Keys.userName, Keys.userEmail]
             .forEach { delete(key: $0) }
     }
 

--- a/HiTrip/Data/Repositories/TripRepository.swift
+++ b/HiTrip/Data/Repositories/TripRepository.swift
@@ -1,0 +1,201 @@
+import Foundation
+import RxSwift
+
+// MARK: - MockTripRepository
+/// 메모리 기반 Mock 구현체
+///
+/// 앱 실행 시 Mock 데이터를 메모리에 생성하여 반환.
+/// API 연동 시 이 클래스를 RemoteTripRepository로 교체하면 된다.
+/// Protocol만 맞추면 TripDataStore 코드는 변경 불필요.
+
+final class MockTripRepository: TripRepositoryProtocol {
+
+    // MARK: - In-Memory Storage
+
+    private var trips: [Trip] = []
+    private var todos: [TripTodo] = []
+    private var events: [TripEvent] = []
+
+    init() {
+        loadMockData()
+    }
+
+    // MARK: - Trip
+
+    func fetchTrips() -> Single<[Trip]> {
+        .just(trips)
+    }
+
+    func createTrip(_ trip: Trip) -> Single<Trip> {
+        trips.append(trip)
+        return .just(trip)
+    }
+
+    func deleteTrip(id: UUID) -> Single<Void> {
+        trips.removeAll { $0.id == id }
+        todos.removeAll { $0.tripId == id }
+        events.removeAll { $0.tripId == id }
+        return .just(())
+    }
+
+    // MARK: - Todo
+
+    func fetchTodos(tripId: UUID) -> Single<[TripTodo]> {
+        .just(todos.filter { $0.tripId == tripId })
+    }
+
+    func createTodo(_ todo: TripTodo) -> Single<TripTodo> {
+        todos.append(todo)
+        return .just(todo)
+    }
+
+    func updateTodo(_ todo: TripTodo) -> Single<TripTodo> {
+        if let i = todos.firstIndex(where: { $0.id == todo.id }) {
+            todos[i] = todo
+        }
+        return .just(todo)
+    }
+
+    func deleteTodo(id: UUID) -> Single<Void> {
+        todos.removeAll { $0.id == id }
+        return .just(())
+    }
+
+    // MARK: - Event
+
+    func fetchEvents(tripId: UUID) -> Single<[TripEvent]> {
+        .just(events.filter { $0.tripId == tripId })
+    }
+
+    func createEvent(_ event: TripEvent) -> Single<TripEvent> {
+        events.append(event)
+        return .just(event)
+    }
+
+    func updateEvent(_ event: TripEvent) -> Single<TripEvent> {
+        if let i = events.firstIndex(where: { $0.id == event.id }) {
+            events[i] = event
+        }
+        return .just(event)
+    }
+
+    func deleteEvent(id: UUID) -> Single<Void> {
+        events.removeAll { $0.id == id }
+        return .just(())
+    }
+
+    // MARK: - Mock Data
+
+    private func loadMockData() {
+        let calendar = Calendar.current
+        let now = Date()
+
+        let today = now
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) ?? now
+        let dayAfter = calendar.date(byAdding: .day, value: 2, to: now) ?? now
+
+        // ── Trips ──────────────────────────────────
+
+        let trip1 = Trip(
+            title: "한라산 등반",
+            date: today,
+            location: "제주도, 대한민국",
+            thumbnailName: "mountain",
+            memberAvatars: ["person.circle.fill", "person.circle.fill"]
+        )
+        let trip2 = Trip(
+            title: "서울 타워 방문",
+            date: dayAfter,
+            location: "서울, 대한민국",
+            thumbnailName: "building",
+            memberAvatars: ["person.circle.fill"]
+        )
+        let trip3 = Trip(
+            title: "부산 해운대 해변",
+            date: calendar.date(byAdding: .day, value: 5, to: now) ?? now,
+            location: "부산, 대한민국",
+            thumbnailName: "beach",
+            memberAvatars: ["person.circle.fill", "person.circle.fill", "person.circle.fill"]
+        )
+
+        trips = [trip1, trip2, trip3]
+
+        // ── Todos ──────────────────────────────────
+
+        todos = [
+            // trip1 (한라산) — 오늘
+            TripTodo(title: "오늘 일정 확인하기", section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "다음 이동 경로 확인", section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "아침 일정 완료", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "입장권 / 예약 확인", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "다음 장소까지 이동 준비", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "교통권 / 패스 챙기기", section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "휴대폰 충전 상태 확인", section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "현지 날씨 확인", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
+            TripTodo(title: "내일 일정 미리 보기", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
+
+            // trip1 (한라산) — 내일
+            TripTodo(title: "체크아웃 준비", section: .todayPrep, date: tomorrow, tripId: trip1.id),
+            TripTodo(title: "짐 정리", section: .travelPrep, date: tomorrow, tripId: trip1.id),
+
+            // trip2 (서울 타워) — 내일
+            TripTodo(title: "현지 날씨 확인", section: .travelPrep, date: tomorrow, tripId: trip2.id),
+
+            // trip2 (서울 타워) — 모레
+            TripTodo(title: "서울 타워 티켓 예매", section: .todayPrep, date: dayAfter, tripId: trip2.id),
+            TripTodo(title: "카메라 충전", section: .travelPrep, date: dayAfter, tripId: trip2.id),
+        ]
+
+        // ── Events ─────────────────────────────────
+
+        events = [
+            // trip1 (한라산) — 오늘
+            TripEvent(
+                title: "한라산 등반 준비",
+                startTime: calendar.date(bySettingHour: 9, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: today) ?? now,
+                category: .destination,
+                tripId: trip1.id
+            ),
+            TripEvent(
+                title: "제주 올레길 걷기",
+                startTime: calendar.date(bySettingHour: 14, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 16, minute: 0, second: 0, of: today) ?? now,
+                category: .schedule,
+                tripId: trip1.id
+            ),
+            TripEvent(
+                title: "제주 해변 산책",
+                startTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: today) ?? now,
+                endTime: calendar.date(bySettingHour: 20, minute: 0, second: 0, of: today) ?? now,
+                category: .etc,
+                tripId: trip1.id
+            ),
+
+            // trip1 (한라산) — 내일
+            TripEvent(
+                title: "제주 시장 방문",
+                startTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: tomorrow) ?? now,
+                endTime: calendar.date(bySettingHour: 12, minute: 0, second: 0, of: tomorrow) ?? now,
+                category: .list,
+                tripId: trip1.id
+            ),
+
+            // trip2 (서울 타워) — 모레
+            TripEvent(
+                title: "서울 타워 관광",
+                startTime: calendar.date(bySettingHour: 15, minute: 0, second: 0, of: dayAfter) ?? now,
+                endTime: calendar.date(bySettingHour: 17, minute: 0, second: 0, of: dayAfter) ?? now,
+                category: .destination,
+                tripId: trip2.id
+            ),
+            TripEvent(
+                title: "숙소 체크인",
+                startTime: calendar.date(bySettingHour: 18, minute: 0, second: 0, of: dayAfter) ?? now,
+                endTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: dayAfter) ?? now,
+                category: .list,
+                tripId: trip2.id
+            ),
+        ]
+    }
+}

--- a/HiTrip/Domain/Repositories/TripRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/TripRepositoryProtocol.swift
@@ -1,0 +1,54 @@
+import Foundation
+import RxSwift
+
+// MARK: - TripRepositoryProtocol
+/// 여행 데이터 접근 인터페이스 (Domain 레이어)
+///
+/// TripDataStore가 이 Protocol을 통해 데이터를 읽고 쓴다.
+/// 현재는 MockTripRepository(메모리)를 사용하지만,
+/// API 연동 시 RemoteTripRepository로 교체하면 된다.
+///
+/// TripDataStore는 Repository에서 받은 데이터를 @Published에 저장하고,
+/// 여러 ViewModel이 Store를 구독하여 UI를 갱신한다.
+
+protocol TripRepositoryProtocol {
+
+    // MARK: - Trip
+
+    /// 전체 여행 목록 조회
+    func fetchTrips() -> Single<[Trip]>
+
+    /// 여행 추가
+    func createTrip(_ trip: Trip) -> Single<Trip>
+
+    /// 여행 삭제
+    func deleteTrip(id: UUID) -> Single<Void>
+
+    // MARK: - Todo
+
+    /// 특정 여행의 전체 할일 조회
+    func fetchTodos(tripId: UUID) -> Single<[TripTodo]>
+
+    /// 할일 추가
+    func createTodo(_ todo: TripTodo) -> Single<TripTodo>
+
+    /// 할일 수정 (제목 변경, 완료 토글 등)
+    func updateTodo(_ todo: TripTodo) -> Single<TripTodo>
+
+    /// 할일 삭제
+    func deleteTodo(id: UUID) -> Single<Void>
+
+    // MARK: - Event
+
+    /// 특정 여행의 전체 이벤트 조회
+    func fetchEvents(tripId: UUID) -> Single<[TripEvent]>
+
+    /// 이벤트 추가
+    func createEvent(_ event: TripEvent) -> Single<TripEvent>
+
+    /// 이벤트 수정
+    func updateEvent(_ event: TripEvent) -> Single<TripEvent>
+
+    /// 이벤트 삭제
+    func deleteEvent(id: UUID) -> Single<Void>
+}

--- a/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
@@ -61,8 +61,9 @@ final class ChatViewModel: ObservableObject {
     init(chatUseCase: ChatUseCase) {
         self.chatUseCase = chatUseCase
         // Keychain에서 현재 로그인 유저 정보 가져오기
-        self.currentUserId = KeychainManager.shared.getUserId() ?? "me"
-        self.currentUserName = KeychainManager.shared.getUserId() ?? "나"
+        let keychain = KeychainManager.shared
+        self.currentUserId = keychain.getUserId() ?? "guest"
+        self.currentUserName = keychain.getUserName() ?? keychain.getUserId() ?? "사용자"
     }
 
     // MARK: - ChatRoom (채팅방)

--- a/HiTrip/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/HiTrip/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Combine
+
+// MARK: - ProfileViewModel
+/// 프로필 화면의 ViewModel
+///
+/// 유저 정보(이름, 이메일)와 통계 수치를 중앙 관리.
+/// KeychainManager에서 유저 기본 정보를 읽고,
+/// 프로필 수정 시 저장까지 담당한다.
+///
+/// 추후 API 연동 시 UserRepository를 주입받아
+/// 서버에서 프로필 데이터를 fetch/update하도록 확장한다.
+
+final class ProfileViewModel: ObservableObject {
+
+    // MARK: - Published: 프로필 표시 데이터
+
+    @Published var userName: String = ""
+    @Published var userEmail: String = ""
+
+    // MARK: - Published: 통계 (추후 API로 대체)
+
+    @Published var points: Int = 0
+    @Published var tripCount: Int = 0
+    @Published var bucketListCount: Int = 0
+
+    // MARK: - Published: 편집 폼 상태
+
+    @Published var editNickname: String = ""
+    @Published var editBirthday: Date = Date()
+    @Published var showBirthdayPicker: Bool = false
+    @Published var editCountry: String = "대한민국"
+    @Published var editCountryCode: String = "+82"
+    @Published var editPhoneNumber: String = ""
+
+    /// 저장 완료 알림
+    @Published var showSaveAlert: Bool = false
+
+    // MARK: - Dependencies
+
+    private let keychain = KeychainManager.shared
+
+    // MARK: - Init
+
+    init() {
+        loadProfile()
+    }
+
+    // MARK: - Load Profile
+
+    /// Keychain + Mock 통계 데이터 로드
+    /// 추후 API 연동 시 이 메서드 내부를 서버 호출로 교체
+    func loadProfile() {
+        // 유저 기본 정보 (Keychain에서 읽기)
+        userName = keychain.getUserName() ?? keychain.getUserId() ?? "사용자"
+        userEmail = keychain.getUserEmail() ?? "이메일 없음"
+
+        // 통계 데이터 (추후 API 응답으로 대체)
+        // TODO: UserRepository.fetchStats() → points, tripCount, bucketListCount
+        points = 50
+        tripCount = TripDataStore.shared.trips.count
+        bucketListCount = 200
+
+        // 편집 폼 초기값 세팅
+        editNickname = userName
+    }
+
+    // MARK: - Save Profile
+
+    /// 프로필 수정 저장
+    /// 추후 API 연동 시 UserRepository.updateProfile()로 교체
+    func saveProfile() {
+        // Keychain에 업데이트
+        if !editNickname.trimmed.isEmpty {
+            keychain.saveUserName(editNickname.trimmed)
+        }
+
+        // 로컬 상태 반영
+        userName = editNickname.trimmed.isEmpty ? userName : editNickname.trimmed
+
+        // TODO: API 연동 시 서버에도 저장
+        // userRepository.updateProfile(nickname: editNickname, birthday: editBirthday, ...)
+
+        showSaveAlert = true
+    }
+
+    // MARK: - Computed
+
+    /// 통계 표시용 포맷된 문자열
+    var pointsText: String { "\(points)" }
+    var tripCountText: String { "\(tripCount)" }
+    var bucketListCountText: String { "\(bucketListCount)" }
+
+    /// 생년월일 표시 텍스트
+    var birthdayText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: editBirthday)
+    }
+
+    /// 생년월일이 기본값(오늘)인지 여부 — placeholder 표시용
+    var isBirthdayDefault: Bool {
+        Calendar.current.isDateInToday(editBirthday)
+    }
+}

--- a/HiTrip/Features/Profile/Views/ProfileEditView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileEditView.swift
@@ -7,22 +7,14 @@ import SwiftUI
 /// - 네비바: 뒤로가기 + "프로필 수정" + 완료 버튼
 /// - 아바타 + 이름 + "프로필 변경하기" 링크
 /// - 폼: 닉네임, 생년월일, 거주 국가, 휴대번호
+///
+/// ProfileView에서 공유되는 ProfileViewModel을 받아서
+/// 수정 폼 상태와 저장 로직을 ViewModel에 위임한다.
 
 struct ProfileEditView: View {
 
     @Environment(\.dismiss) private var dismiss
-
-    // MARK: - Form State
-
-    @State private var nickname: String = ""
-    @State private var birthday: Date = Date()
-    @State private var showBirthdayPicker: Bool = false
-    @State private var country: String = "대한민국"
-    @State private var countryCode: String = "+82"
-    @State private var phoneNumber: String = ""
-
-    /// 저장 완료 알림
-    @State private var showSaveAlert: Bool = false
+    @ObservedObject var viewModel: ProfileViewModel
 
     var body: some View {
         ZStack {
@@ -61,13 +53,13 @@ struct ProfileEditView: View {
             }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("완료") {
-                    saveProfile()
+                    viewModel.saveProfile()
                 }
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(HiTripColor.primary800)
             }
         }
-        .alert("저장 완료", isPresented: $showSaveAlert) {
+        .alert("저장 완료", isPresented: $viewModel.showSaveAlert) {
             Button("확인") { dismiss() }
         } message: {
             Text("프로필이 저장되었습니다.")
@@ -89,7 +81,7 @@ struct ProfileEditView: View {
             }
 
             // 이름
-            Text(userName)
+            Text(viewModel.userName)
                 .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
                 .padding(.top, 4)
@@ -111,7 +103,7 @@ struct ProfileEditView: View {
             formField(
                 label: "닉네임",
                 placeholder: "15자 이내 영문, 숫자로 입력해주세요",
-                text: $nickname
+                text: $viewModel.editNickname
             )
 
             // 생년월일
@@ -121,7 +113,7 @@ struct ProfileEditView: View {
             formField(
                 label: "거주 국가",
                 placeholder: "국가를 입력해주세요",
-                text: $country
+                text: $viewModel.editCountry
             )
 
             // 휴대번호
@@ -155,13 +147,13 @@ struct ProfileEditView: View {
                 .foregroundColor(HiTripColor.textBlack)
 
             Button {
-                showBirthdayPicker.toggle()
+                viewModel.showBirthdayPicker.toggle()
             } label: {
                 HStack {
-                    Text(birthdayText)
+                    Text(viewModel.isBirthdayDefault ? "생년월일을 선택해주세요" : viewModel.birthdayText)
                         .font(.system(size: 15))
                         .foregroundColor(
-                            birthdayText == "생년월일을 선택해주세요"
+                            viewModel.isBirthdayDefault
                                 ? HiTripColor.gray400
                                 : HiTripColor.textBlack
                         )
@@ -174,10 +166,10 @@ struct ProfileEditView: View {
             }
             .buttonStyle(.plain)
 
-            if showBirthdayPicker {
+            if viewModel.showBirthdayPicker {
                 DatePicker(
                     "",
-                    selection: $birthday,
+                    selection: $viewModel.editBirthday,
                     displayedComponents: .date
                 )
                 .datePickerStyle(.wheel)
@@ -185,11 +177,6 @@ struct ProfileEditView: View {
                 .environment(\.locale, Locale(identifier: "ko_KR"))
             }
         }
-    }
-
-    /// 생년월일 표시 텍스트
-    private var birthdayText: String {
-        "생년월일을 선택해주세요"
     }
 
     // MARK: - Phone Field
@@ -203,14 +190,14 @@ struct ProfileEditView: View {
             HStack(spacing: 8) {
                 // 국가 코드
                 Menu {
-                    Button("+82 🇰🇷") { countryCode = "+82" }
-                    Button("+1 🇺🇸") { countryCode = "+1" }
-                    Button("+81 🇯🇵") { countryCode = "+81" }
-                    Button("+86 🇨🇳") { countryCode = "+86" }
-                    Button("+213 🇩🇿") { countryCode = "+213" }
+                    Button("+82 🇰🇷") { viewModel.editCountryCode = "+82" }
+                    Button("+1 🇺🇸") { viewModel.editCountryCode = "+1" }
+                    Button("+81 🇯🇵") { viewModel.editCountryCode = "+81" }
+                    Button("+86 🇨🇳") { viewModel.editCountryCode = "+86" }
+                    Button("+213 🇩🇿") { viewModel.editCountryCode = "+213" }
                 } label: {
                     HStack(spacing: 4) {
-                        Text(countryCode)
+                        Text(viewModel.editCountryCode)
                             .font(.system(size: 15))
                             .foregroundColor(HiTripColor.textBlack)
                         Image(systemName: "chevron.down")
@@ -224,7 +211,7 @@ struct ProfileEditView: View {
                 }
 
                 // 전화번호
-                TextField("전화번호를 입력해주세요", text: $phoneNumber)
+                TextField("전화번호를 입력해주세요", text: $viewModel.editPhoneNumber)
                     .font(.system(size: 15))
                     .keyboardType(.phonePad)
                     .padding(.horizontal, 16)
@@ -233,18 +220,5 @@ struct ProfileEditView: View {
                     .cornerRadius(12)
             }
         }
-    }
-
-    // MARK: - Actions
-
-    private func saveProfile() {
-        // Mock: 프로필 저장 (추후 API 연동)
-        showSaveAlert = true
-    }
-
-    // MARK: - Helpers
-
-    private var userName: String {
-        KeychainManager.shared.getUserId() ?? "이연세"
     }
 }

--- a/HiTrip/Features/Profile/Views/ProfileView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileView.swift
@@ -14,6 +14,7 @@ struct ProfileView: View {
 
     @EnvironmentObject var router: AppRouter
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = ProfileViewModel()
 
     /// 로그아웃 확인 Alert
     @State private var showLogoutAlert = false
@@ -78,7 +79,10 @@ struct ProfileView: View {
                 }
             }
             .navigationDestination(isPresented: $showEditProfile) {
-                ProfileEditView()
+                ProfileEditView(viewModel: viewModel)
+            }
+            .onAppear {
+                viewModel.loadProfile()
             }
             .alert("로그아웃", isPresented: $showLogoutAlert) {
                 Button("로그아웃", role: .destructive) {
@@ -107,13 +111,13 @@ struct ProfileView: View {
             }
 
             // 이름
-            Text(userName)
+            Text(viewModel.userName)
                 .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
                 .padding(.top, 8)
 
             // 이메일
-            Text(userEmail)
+            Text(viewModel.userEmail)
                 .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
         }
@@ -123,17 +127,17 @@ struct ProfileView: View {
 
     private var statsCard: some View {
         HStack(spacing: 0) {
-            statItem(title: "포인트", value: "50")
+            statItem(title: "포인트", value: viewModel.pointsText)
 
             Divider()
                 .frame(height: 40)
 
-            statItem(title: "여행", value: "40")
+            statItem(title: "여행", value: viewModel.tripCountText)
 
             Divider()
                 .frame(height: 40)
 
-            statItem(title: "버킷리스트", value: "200")
+            statItem(title: "버킷리스트", value: viewModel.bucketListCountText)
         }
         .padding(.vertical, 18)
         .background(Color.white)
@@ -227,13 +231,4 @@ struct ProfileView: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private var userName: String {
-        KeychainManager.shared.getUserId() ?? "이연세"
-    }
-
-    private var userEmail: String {
-        "hitrip@gmail.com"
-    }
 }

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import RxSwift
 
 // MARK: - TripDataStore
 /// 여행 데이터 중앙 저장소 (싱글턴)
@@ -8,7 +9,9 @@ import Combine
 /// TripListViewModel, TripDetailViewModel 등 여러 ViewModel이
 /// 이 Store를 공유하여 데이터 일관성을 보장한다.
 ///
-/// 추후 API 연동 시 이 Store의 Mock 로직만 교체하면 된다.
+/// Repository를 통해 데이터를 읽고 쓰며,
+/// API 연동 시 MockTripRepository → RemoteTripRepository로 교체하면 된다.
+/// Store 외부 코드(ViewModel, View)는 변경 불필요.
 
 final class TripDataStore: ObservableObject {
 
@@ -22,10 +25,62 @@ final class TripDataStore: ObservableObject {
     @Published var todos: [TripTodo] = []
     @Published var events: [TripEvent] = []
 
-    // MARK: - Init (Mock 데이터 생성)
+    // MARK: - Dependencies
 
+    /// 데이터 소스 — 현재 Mock, 추후 Remote로 교체
+    private let repository: TripRepositoryProtocol
+    private let disposeBag = DisposeBag()
+
+    // MARK: - Init
+
+    /// 프로덕션 (Mock Repository)
     private init() {
-        loadMockData()
+        self.repository = MockTripRepository()
+        loadInitialData()
+    }
+
+    /// 테스트용 — 커스텀 Repository 주입
+    init(repository: TripRepositoryProtocol) {
+        self.repository = repository
+        loadInitialData()
+    }
+
+    /// Repository에서 초기 데이터 로드
+    private func loadInitialData() {
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] trips in
+                self?.trips = trips
+                // 각 Trip의 Todo/Event도 로드
+                for trip in trips {
+                    self?.loadTodos(for: trip.id)
+                    self?.loadEvents(for: trip.id)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    /// 특정 Trip의 Todo 로드
+    private func loadTodos(for tripId: UUID) {
+        repository.fetchTodos(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] fetchedTodos in
+                // 기존 해당 Trip의 todo 제거 후 새로 추가
+                self?.todos.removeAll { $0.tripId == tripId }
+                self?.todos.append(contentsOf: fetchedTodos)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    /// 특정 Trip의 Event 로드
+    private func loadEvents(for tripId: UUID) {
+        repository.fetchEvents(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] fetchedEvents in
+                self?.events.removeAll { $0.tripId == tripId }
+                self?.events.append(contentsOf: fetchedEvents)
+            })
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Trip: Read
@@ -68,22 +123,39 @@ final class TripDataStore: ObservableObject {
     func addTodo(title: String, section: TripTodo.Section, date: Date, tripId: UUID) {
         let todo = TripTodo(title: title, section: section, date: date, tripId: tripId)
         todos.append(todo)
+
+        // Repository에도 저장 (향후 API 동기화)
+        repository.createTodo(todo)
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 
     func toggleTodo(_ todoId: UUID) {
         if let i = todos.firstIndex(where: { $0.id == todoId }) {
             todos[i].isCompleted.toggle()
+
+            repository.updateTodo(todos[i])
+                .subscribe()
+                .disposed(by: disposeBag)
         }
     }
 
     func updateTodo(_ todoId: UUID, newTitle: String) {
         if let i = todos.firstIndex(where: { $0.id == todoId }) {
             todos[i].title = newTitle
+
+            repository.updateTodo(todos[i])
+                .subscribe()
+                .disposed(by: disposeBag)
         }
     }
 
     func deleteTodo(_ todoId: UUID) {
         todos.removeAll { $0.id == todoId }
+
+        repository.deleteTodo(id: todoId)
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Event: CRUD
@@ -126,6 +198,10 @@ final class TripDataStore: ObservableObject {
     func addEvent(title: String, startTime: Date, endTime: Date, category: TripEvent.Category, tripId: UUID) {
         let event = TripEvent(title: title, startTime: startTime, endTime: endTime, category: category, tripId: tripId)
         events.append(event)
+
+        repository.createEvent(event)
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 
     func updateEvent(_ eventId: UUID, title: String, startTime: Date, endTime: Date, category: TripEvent.Category) {
@@ -134,125 +210,18 @@ final class TripDataStore: ObservableObject {
             events[i].startTime = startTime
             events[i].endTime = endTime
             events[i].category = category
+
+            repository.updateEvent(events[i])
+                .subscribe()
+                .disposed(by: disposeBag)
         }
     }
 
     func deleteEvent(_ eventId: UUID) {
         events.removeAll { $0.id == eventId }
-    }
 
-    // MARK: - Mock Data (한 곳에서 통합 관리)
-
-    private func loadMockData() {
-        let calendar = Calendar.current
-        let now = Date()
-
-        let today = now
-        let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) ?? now
-        let dayAfter = calendar.date(byAdding: .day, value: 2, to: now) ?? now
-
-        // ── Trips ──────────────────────────────────
-
-        let trip1 = Trip(
-            title: "한라산 등반",
-            date: today,
-            location: "제주도, 대한민국",
-            thumbnailName: "mountain",
-            memberAvatars: ["person.circle.fill", "person.circle.fill"]
-        )
-        let trip2 = Trip(
-            title: "서울 타워 방문",
-            date: dayAfter,
-            location: "서울, 대한민국",
-            thumbnailName: "building",
-            memberAvatars: ["person.circle.fill"]
-        )
-        let trip3 = Trip(
-            title: "부산 해운대 해변",
-            date: calendar.date(byAdding: .day, value: 5, to: now) ?? now,
-            location: "부산, 대한민국",
-            thumbnailName: "beach",
-            memberAvatars: ["person.circle.fill", "person.circle.fill", "person.circle.fill"]
-        )
-
-        trips = [trip1, trip2, trip3]
-
-        // ── Todos ──────────────────────────────────
-
-        todos = [
-            // trip1 (한라산) — 오늘
-            TripTodo(title: "오늘 일정 확인하기", section: .todayPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "다음 이동 경로 확인", section: .todayPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "아침 일정 완료", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "입장권 / 예약 확인", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "다음 장소까지 이동 준비", isCompleted: true, section: .todayPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "교통권 / 패스 챙기기", section: .travelPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "휴대폰 충전 상태 확인", section: .travelPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "현지 날씨 확인", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
-            TripTodo(title: "내일 일정 미리 보기", isCompleted: true, section: .travelPrep, date: today, tripId: trip1.id),
-
-            // trip1 (한라산) — 내일
-            TripTodo(title: "체크아웃 준비", section: .todayPrep, date: tomorrow, tripId: trip1.id),
-            TripTodo(title: "짐 정리", section: .travelPrep, date: tomorrow, tripId: trip1.id),
-
-            // trip2 (서울 타워) — 내일
-            TripTodo(title: "현지 날씨 확인", section: .travelPrep, date: tomorrow, tripId: trip2.id),
-
-            // trip2 (서울 타워) — 모레
-            TripTodo(title: "서울 타워 티켓 예매", section: .todayPrep, date: dayAfter, tripId: trip2.id),
-            TripTodo(title: "카메라 충전", section: .travelPrep, date: dayAfter, tripId: trip2.id),
-        ]
-
-        // ── Events ─────────────────────────────────
-
-        events = [
-            // trip1 (한라산) — 오늘
-            TripEvent(
-                title: "한라산 등반 준비",
-                startTime: calendar.date(bySettingHour: 9, minute: 0, second: 0, of: today) ?? now,
-                endTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: today) ?? now,
-                category: .destination,
-                tripId: trip1.id
-            ),
-            TripEvent(
-                title: "제주 올레길 걷기",
-                startTime: calendar.date(bySettingHour: 14, minute: 0, second: 0, of: today) ?? now,
-                endTime: calendar.date(bySettingHour: 16, minute: 0, second: 0, of: today) ?? now,
-                category: .schedule,
-                tripId: trip1.id
-            ),
-            TripEvent(
-                title: "제주 해변 산책",
-                startTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: today) ?? now,
-                endTime: calendar.date(bySettingHour: 20, minute: 0, second: 0, of: today) ?? now,
-                category: .etc,
-                tripId: trip1.id
-            ),
-
-            // trip1 (한라산) — 내일
-            TripEvent(
-                title: "제주 시장 방문",
-                startTime: calendar.date(bySettingHour: 10, minute: 0, second: 0, of: tomorrow) ?? now,
-                endTime: calendar.date(bySettingHour: 12, minute: 0, second: 0, of: tomorrow) ?? now,
-                category: .list,
-                tripId: trip1.id
-            ),
-
-            // trip2 (서울 타워) — 모레
-            TripEvent(
-                title: "서울 타워 관광",
-                startTime: calendar.date(bySettingHour: 15, minute: 0, second: 0, of: dayAfter) ?? now,
-                endTime: calendar.date(bySettingHour: 17, minute: 0, second: 0, of: dayAfter) ?? now,
-                category: .destination,
-                tripId: trip2.id
-            ),
-            TripEvent(
-                title: "숙소 체크인",
-                startTime: calendar.date(bySettingHour: 18, minute: 0, second: 0, of: dayAfter) ?? now,
-                endTime: calendar.date(bySettingHour: 19, minute: 0, second: 0, of: dayAfter) ?? now,
-                category: .list,
-                tripId: trip2.id
-            ),
-        ]
+        repository.deleteEvent(id: eventId)
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 데이터 관리 구조 정비 — 도메인별 패턴 적용

앱 전체의 데이터 관리 로직을 점검하고, 각 도메인 특성에 맞는 패턴으로 정비했습니다. 하드코딩된 값들을 제거하고, API 연동 시 구현체만 교체하면 되는 Repository 패턴 구조를 확립했습니다.

<br/>

### 1. 여행/할일/이벤트 — 중앙 Store + Repository 패턴

여러 화면(홈, 캘린더 탭, AllTripsView, 상세보기)이 동시에 같은 데이터를 참조하고 수정하므로, `TripDataStore` 싱글턴이 모든 데이터를 `@Published`로 관리하고 ViewModel들이 Combine으로 구독하는 구조를 유지합니다.

이번 커밋에서 추가된 부분:

- **`TripRepositoryProtocol`** (Domain 레이어) — Trip/Todo/Event CRUD 인터페이스 정의
- **`MockTripRepository`** (Data 레이어) — 기존 `TripDataStore.loadMockData()` 로직을 Repository로 분리. Mock 데이터가 Store에서 완전히 독립
- **`TripDataStore` 리팩터링** — Repository를 주입받아 초기 데이터를 로드하고, 모든 CRUD 메서드에서 로컬 상태 + Repository 동시 동기화. 테스트용 `init(repository:)` 생성자 추가

```
[홈 화면] → [TripListVM] ──┐
[캘린더 탭] → [TripDetailVM] ─┤→ [TripDataStore] → [MockTripRepository]
[AllTripsView] ─────────────┘                           ↓ (향후)
[RemoteTripRepository] → API
```

API 연동 시 `RemoteTripRepository`를 만들어서 Store 생성자에 넣어주기만 하면 ViewModel/View 코드 변경 불필요.

<br/>

### 2. 유저/인증 — Keychain + ProfileViewModel

유저 정보는 로그인 시 한 번 저장하고 이후 읽기 위주이므로, 중앙 Store 없이 Keychain + ViewModel 조합으로 처리합니다.

- **`KeychainManager`** — `userName`, `userEmail` 저장/조회 메서드 추가. `clearAll()`에 새 키 포함
- **`ProfileViewModel`** (신규) — Keychain에서 유저 정보를 읽어 `@Published`로 관리. 통계 수치를 ViewModel에서 관리하여 View의 하드코딩 제거. 여행 수는 `TripDataStore.shared.trips.count`로 실제 데이터 연동. `saveProfile()`이 Keychain에 저장 (API 연동 지점 마련)
- **`ProfileView` / `ProfileEditView`** — 기존 `"이연세"`, `"hitrip@gmail.com"`, `"50"/"40"/"200"` 등 하드코딩 전부 제거. 동일한 viewModel을 공유하여 수정 → 메인 화면 자동 반영

```
[ProfileView] ←→ [ProfileViewModel] → KeychainManager
[ProfileEditView] ↗  (같은 VM 공유)
```

<br/>

### 3. 긴급 연락처 — Repository 패턴 유지

단일 화면에서만 사용하므로 중앙 Store 없이 기존 `EmergencyRepository` + `EmergencyViewModel` 구조를 유지합니다. 프리셋 연락처(112, 119 등)는 Repository에 내장, 개인 연락처는 메모리 관리.

<br/>

### 4. 채팅 — Repository 패턴 유지 (향후 Store 확장 예정)

현재 `ChatViewModel` 하나가 목록과 메시지를 모두 관리하므로 문제가 없어 기존 구조를 유지합니다. 실시간 채팅(WebSocket) 연동 시 `ChatDataStore` 싱글턴으로 확장 예정.

- **`ChatViewModel`** — fallback 값 정리: `"me"` → `"guest"`, `"나"` → `KeychainManager.getUserName()` 우선 참조

<br/>

### 5. 관광지 검색 — API 직접 연동 유지

매번 새로 fetch하는 일회성 검색 결과이므로 중앙 Store 불필요. 기존 `TourAPIService` → `SpotRepository` → `SpotViewModel` 구조 유지.


<br/>
<br/>


## 전체 데이터 관리 구조

| 도메인 | 패턴 | 이유 |
|---|---|---|
| 여행/할일/이벤트 | 중앙 Store + Repository | 4개 이상 화면이 동시 참조 + 상호 수정 |
| 유저/인증 | Keychain + ViewModel | 읽기 위주, 수정 지점 단일 |
| 긴급 연락처 | Repository + ViewModel | 단일 화면 사용 |
| 채팅 | Repository + ViewModel | 현재 단일 VM, 향후 WebSocket 시 Store 추가 |
| 관광지 검색 | API + ViewModel | 일회성 검색 결과 |


<br/>
<br/>


## Test plan

- [ ] 홈 탭에서 여행 카드 목록 정상 표시 (TripDataStore → MockTripRepository 데이터 로드)
- [ ] 캘린더 탭에서 할일 추가/체크/삭제 후 홈 탭 복귀 시 데이터 일관성 확인
- [ ] 마이페이지 → 프로필 표시 (이름, 이메일, 통계 수치) 정상 확인
- [ ] 프로필 수정 → 닉네임 변경 → 완료 → 프로필 메인에 반영 확인
- [ ] 긴급 연락망 배너 → EmergencyView 프리셋 연락처 표시 확인
- [ ] 채팅 → 메시지 전송 시 발신자 이름 표시 확인
- [ ] Xcode 빌드(Cmd+B) 에러 없음 확인