### PR TITLE
feat: 캘린더/체크리스트 페이지 피그마 UI 리디자인 + 내 일정 상세보기 연결

### DIFF
--- a/HiTrip/Core/Extensions/Color+Hex.swift
+++ b/HiTrip/Core/Extensions/Color+Hex.swift
@@ -121,6 +121,11 @@ enum HiTripColor {
     /// 읽음/성공 표시 (초록 체크)
     static let readCheck = Color(hex: "4CAF50")
 
+    // MARK: - Section Tag
+
+    /// #F4F3F9 — 체크리스트 섹션 태그 배경 (연보라)
+    static let sectionTagBackground = Color(hex: "F4F3F9")
+
     // MARK: - Dot Indicator (회원가입 플로우)
 
     /// 도트 인디케이터 비활성

--- a/HiTrip/Core/Extensions/Trip+SpotItem.swift
+++ b/HiTrip/Core/Extensions/Trip+SpotItem.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// MARK: - Trip → TourSpotItem 변환
+/// 내 일정 카드를 SpotDetailView로 표시하기 위한 변환
+///
+/// Trip의 정보를 TourSpotItem으로 매핑하여
+/// 검색 탭과 동일한 상세보기 UI를 재활용한다.
+///
+/// 사용 예시:
+/// ```swift
+/// let spot = trip.toSpotItem()
+/// SpotDetailView(spot: spot)
+/// ```
+
+extension Trip {
+
+    /// Trip → TourSpotItem 변환
+    ///
+    /// - contentid: Trip.id 문자열
+    /// - title: Trip.title
+    /// - addr1: Trip.location
+    /// - firstimage: Trip.thumbnailName (URL이면 그대로, 로컬이면 nil)
+    /// - contenttypeid: "25" (여행코스)
+    func toSpotItem() -> TourSpotItem {
+        TourSpotItem(
+            contentid: id.uuidString,
+            title: title,
+            addr1: location.isEmpty ? nil : location,
+            addr2: nil,
+            mapx: nil,
+            mapy: nil,
+            firstimage: thumbnailName.hasPrefix("http") ? thumbnailName : nil,
+            firstimage2: nil,
+            tel: nil,
+            contenttypeid: "25"  // 여행코스
+        )
+    }
+}

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -95,6 +95,14 @@ final class TripDataStore: ObservableObject {
         trips.first { $0.id == id }
     }
 
+    /// 특정 날짜의 Trip 목록 (날짜 일치)
+    func trips(for date: Date) -> [Trip] {
+        let cal = Calendar.current
+        return trips
+            .filter { cal.isDate($0.date, inSameDayAs: date) }
+            .sorted { $0.date < $1.date }
+    }
+
     // MARK: - Todo: CRUD
 
     /// 특정 Trip + 날짜 + 섹션 필터

--- a/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
@@ -13,8 +13,8 @@ final class TripDetailViewModel: ObservableObject {
     // MARK: - Tab
 
     enum DetailTab: String, CaseIterable {
-        case todo = "할일"
-        case calendar = "캘린더"
+        case mySchedule = "내 일정"
+        case todo = "할 일"
     }
 
     // MARK: - Store Reference
@@ -24,7 +24,7 @@ final class TripDetailViewModel: ObservableObject {
 
     // MARK: - Published State
 
-    @Published var selectedTab: DetailTab = .todo
+    @Published var selectedTab: DetailTab = .mySchedule
     @Published var trip: Trip
     @Published var selectedDate: Date = Date()
     @Published var displayedMonth: Date = Date()
@@ -55,6 +55,18 @@ final class TripDetailViewModel: ObservableObject {
                 self?.objectWillChange.send()
             }
             .store(in: &cancellables)
+    }
+
+    // MARK: - Trip: 선택 날짜에 해당하는 일정 목록
+
+    /// 선택된 날짜의 여행 일정 (전체 Store 기준)
+    var tripsForSelectedDate: [Trip] {
+        store.trips(for: selectedDate)
+    }
+
+    /// 전체 여행 일정 (날짜 무관)
+    var allTrips: [Trip] {
+        store.sortedTrips
     }
 
     // MARK: - Todo: Filtered by Date + Section

--- a/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
+++ b/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+// MARK: - MyScheduleListView
+/// "내 일정" 탭 — 여행 카드 리스트
+///
+/// 기능:
+/// - 선택된 날짜에 해당하는 일정만 필터링 (없으면 전체 표시)
+/// - 카드 탭 → SpotDetailView (검색과 동일한 상세보기)
+/// - Trip→TourSpotItem 변환으로 SpotDetailView 재활용
+///
+/// 피그마 디자인:
+/// - 각 카드: 개별 흰색 카드(radius 16) — 카드 간 gap 분리
+/// - 썸네일(85x85, radius 16) + 날짜 + 제목(볼드) + 위치 + chevron
+
+struct MyScheduleListView: View {
+
+    @ObservedObject var viewModel: TripDetailViewModel
+
+    /// SpotDetailView 표시용
+    @State private var selectedSpot: TourSpotItem?
+
+    /// 날짜 포맷터 — "2026년 1월 23일"
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter
+    }
+
+    /// 표시할 일정 목록: 선택 날짜에 해당하는 일정만
+    private var displayTrips: [Trip] {
+        viewModel.tripsForSelectedDate
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if displayTrips.isEmpty {
+                    emptyState
+                        .padding(.top, 60)
+                } else {
+                    tripCardList
+                        .padding(.top, 16)
+                        .padding(.horizontal, 20)
+                }
+
+                Spacer().frame(height: 40)
+            }
+        }
+        .sheet(item: $selectedSpot) { spot in
+            SpotDetailView(spot: spot)
+        }
+    }
+
+    // MARK: - Trip Card List
+
+    /// 각 카드가 개별 분리 + gap
+    private var tripCardList: some View {
+        VStack(spacing: 12) {
+            ForEach(displayTrips) { trip in
+                Button {
+                    selectedSpot = trip.toSpotItem()
+                } label: {
+                    tripCardRow(trip)
+                }
+                .buttonStyle(.plain)
+                .background(Color.white)
+                .cornerRadius(16)
+                .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+            }
+        }
+    }
+
+    // MARK: - Trip Card Row
+
+    /// 피그마: 썸네일 | 날짜 + 제목 + 위치 | chevron
+    private func tripCardRow(_ trip: Trip) -> some View {
+        HStack(spacing: 14) {
+            // 썸네일 (85x85, radius 16)
+            tripThumbnail(for: trip)
+                .frame(width: 85, height: 85)
+                .cornerRadius(16)
+
+            // 텍스트 정보 — 각 요소 사이 gap
+            VStack(alignment: .leading, spacing: 8) {
+                // 날짜
+                HStack(spacing: 5) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray500)
+
+                    Text(dateFormatter.string(from: trip.date))
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+
+                // 제목
+                Text(trip.title)
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+                    .lineLimit(1)
+
+                // 위치
+                if !trip.location.isEmpty {
+                    HStack(spacing: 5) {
+                        Image(systemName: "location.circle")
+                            .font(.system(size: 12))
+                            .foregroundColor(HiTripColor.gray400)
+
+                        Text("위치: \(trip.location)")
+                            .font(.system(size: 13))
+                            .foregroundColor(HiTripColor.gray400)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // 오른쪽 chevron
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - Thumbnail
+
+    /// 썸네일: 이미지가 없으면 회색 + 아이콘 placeholder
+    private func tripThumbnail(for trip: Trip) -> some View {
+        Group {
+            if !trip.thumbnailName.isEmpty, let _ = UIImage(named: trip.thumbnailName) {
+                Image(trip.thumbnailName)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                ZStack {
+                    HiTripColor.gray200
+                    Image(systemName: "airplane")
+                        .font(.system(size: 24))
+                        .foregroundColor(HiTripColor.gray400)
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "airplane.departure")
+                .font(.system(size: 40))
+                .foregroundColor(HiTripColor.gray300)
+
+            Text("등록된 일정이 없습니다")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("여행 일정을 추가해보세요!")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -4,12 +4,11 @@ import SwiftUI
 /// 화면2+3 컨테이너: 여행 상세
 ///
 /// 피그마 디자인:
-/// - 뒤로가기 + 더보기(...)
-/// - 멤버 아바타 영역 + 추가 버튼
-/// - "할일 | 캘린더" 세그먼트 탭
-/// - 탭에 따라 TripTodoView 또는 TripCalendarView 표시
-///
-/// 화면1(TripListView)에서 NavigationLink로 push되어 진입
+/// - 뒤로가기(←) + 더보기(...)
+/// - 주간 캘린더 스트립 (흰색 카드, radius 24) — 탭 공용
+/// - "내 일정 | 할일" 세그먼트 탭 (인디케이터 3px, radius 10)
+/// - 내 일정 탭: 여행 카드 리스트 (썸네일 + 날짜 + 제목 + 위치)
+/// - 할일 탭: 체크리스트 (TripTodoView)
 
 struct TripDetailView: View {
 
@@ -18,34 +17,29 @@ struct TripDetailView: View {
 
     private let initialTab: TripDetailViewModel.DetailTab
 
-    init(trip: Trip, initialTab: TripDetailViewModel.DetailTab = .todo) {
+    init(trip: Trip, initialTab: TripDetailViewModel.DetailTab = .mySchedule) {
         _viewModel = StateObject(wrappedValue: TripDetailViewModel(trip: trip))
         self.initialTab = initialTab
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            // 멤버 아바타 영역
-            memberSection
+            // 주간 캘린더 스트립 — 양 탭 공용
+            calendarCard
                 .padding(.top, 12)
+                .padding(.horizontal, 20)
 
-            // 할일 / 캘린더 탭
+            // "내 일정 | 할일" 탭 셀렉터
             tabSelector
                 .padding(.top, 16)
 
             // 탭 콘텐츠
             tabContent
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .onAppear { viewModel.selectedTab = initialTab }
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button { dismiss() } label: {
-                    Image(systemName: "chevron.left")
-                        .foregroundColor(HiTripColor.textBlack)
-                }
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button { } label: {
                     Image(systemName: "ellipsis")
@@ -55,50 +49,22 @@ struct TripDetailView: View {
         }
     }
 
-    // MARK: - Member Section
+    // MARK: - Calendar Card (탭 공용)
 
-    /// 멤버 아바타 원형 + 추가 버튼
-    private var memberSection: some View {
-        HStack(spacing: -8) {
-            // 멤버 아바타들 (겹쳐서 표시)
-            ForEach(0..<min(viewModel.trip.memberAvatars.count, 3), id: \.self) { index in
-                Circle()
-                    .fill(memberColor(index))
-                    .frame(width: 44, height: 44)
-                    .overlay(
-                        Circle().stroke(Color.white, lineWidth: 2)
-                    )
-            }
-
-            // + 추가 버튼
-            Button { } label: {
-                Circle()
-                    .fill(HiTripColor.gray100)
-                    .frame(width: 44, height: 44)
-                    .overlay(
-                        Image(systemName: "plus")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(HiTripColor.gray400)
-                    )
-                    .overlay(
-                        Circle().stroke(Color.white, lineWidth: 2)
-                    )
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, 24)
-    }
-
-    /// 멤버별 색상 (피그마 기준 파란 그라데이션)
-    private func memberColor(_ index: Int) -> Color {
-        let colors = [HiTripColor.primary800, HiTripColor.secondary500, HiTripColor.secondary200]
-        return colors[index % colors.count]
+    /// 주간 캘린더 카드 — 흰색 배경, radius 24
+    private var calendarCard: some View {
+        WeekCalendarStripView(
+            selectedDate: $viewModel.selectedDate,
+            style: .sundayStart
+        )
+        .background(Color.white)
+        .cornerRadius(24)
+        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
     }
 
     // MARK: - Tab Selector
 
-    /// "할일 | 캘린더" 세그먼트 탭
+    /// "내 일정 | 할일" 세그먼트 탭
     private var tabSelector: some View {
         HStack(spacing: 0) {
             ForEach(TripDetailViewModel.DetailTab.allCases, id: \.self) { tab in
@@ -116,10 +82,10 @@ struct TripDetailView: View {
                                     : HiTripColor.gray400
                             )
 
-                        // 하단 인디케이터 라인
-                        Rectangle()
-                            .fill(viewModel.selectedTab == tab ? HiTripColor.primary800 : Color.clear)
-                            .frame(height: 2)
+                        // 하단 인디케이터 라인 (3px, radius 10, 검정)
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(viewModel.selectedTab == tab ? HiTripColor.textBlack : Color.clear)
+                            .frame(height: 3)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -133,10 +99,10 @@ struct TripDetailView: View {
     @ViewBuilder
     private var tabContent: some View {
         switch viewModel.selectedTab {
+        case .mySchedule:
+            MyScheduleListView(viewModel: viewModel)
         case .todo:
             TripTodoView(viewModel: viewModel)
-        case .calendar:
-            TripCalendarView(viewModel: viewModel)
         }
     }
 }

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -87,7 +87,7 @@ struct TripListView: View {
             )
         }
         .background(Color.white)
-        .cornerRadius(16)
+        .cornerRadius(24)
         .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
         .padding(.horizontal, 20)
         .padding(.top, 8)

--- a/HiTrip/Features/Schedule/Views/TripTodoView.swift
+++ b/HiTrip/Features/Schedule/Views/TripTodoView.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 
 // MARK: - TripTodoView
-/// 화면2: 할일 탭 — 체크리스트
+/// 할 일 탭 — 체크리스트
 ///
 /// 피그마 디자인:
-/// - 주간 캘린더 스트립 (월요일 시작)
-/// - "오늘 일정 준비" 섹션 체크리스트
-/// - "여행 준비 & 관리" 섹션 체크리스트
-/// - 각 항목: 체크 원 + 텍스트 + 더보기(...)
-/// - 섹션 상단에 "체크리스트를 추가하세요." placeholder
+/// - "✈️ 오늘 일정 준비" 섹션 (배경 #F4F3F9, radius 18)
+/// - "🧳 여행 준비 & 관리" 섹션
+/// - 각 항목: 체크 원(고정 22x22) + 텍스트 + 더보기(...)
+/// - "체크리스트를 추가하세요." placeholder
+///
+/// 주간 캘린더 스트립은 TripDetailView에서 공용으로 표시
 
 struct TripTodoView: View {
 
@@ -20,20 +21,16 @@ struct TripTodoView: View {
     @State private var editingTodoId: UUID?
     @State private var editingTodoText: String = ""
 
+    /// 섹션 헤더 배경색
+    private let sectionTagBackground = HiTripColor.sectionTagBackground
+
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                // 주간 캘린더 스트립
-                WeekCalendarStripView(
-                    selectedDate: $viewModel.selectedDate,
-                    style: .mondayStart
-                )
-                .padding(.top, 8)
-
                 // "오늘 일정 준비" 섹션
                 todoSection(
                     title: "오늘 일정 준비",
-                    emoji: "🏖",
+                    emoji: "✈️",
                     section: .todayPrep,
                     todos: viewModel.todayPrepTodos
                 )
@@ -46,7 +43,7 @@ struct TripTodoView: View {
                     section: .travelPrep,
                     todos: viewModel.travelPrepTodos
                 )
-                .padding(.top, 20)
+                .padding(.top, 24)
 
                 Spacer().frame(height: 40)
             }
@@ -62,7 +59,7 @@ struct TripTodoView: View {
         todos: [TripTodo]
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 섹션 헤더 태그
+            // 섹션 헤더 태그 (pill, 배경 #F4F3F9, radius 18)
             HStack(spacing: 4) {
                 Text(emoji)
                     .font(.system(size: 13))
@@ -72,18 +69,16 @@ struct TripTodoView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .background(HiTripColor.gray100)
-            .cornerRadius(20)
-            .padding(.bottom, 12)
+            .background(sectionTagBackground)
+            .cornerRadius(18)
+            .padding(.bottom, 14)
 
             // "체크리스트를 추가하세요" placeholder + 추가 기능
             addTodoRow(section: section)
-                .padding(.bottom, 4)
 
             // 체크리스트 항목들
             ForEach(todos) { todo in
                 todoRow(todo)
-                    .padding(.vertical, 6)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -111,6 +106,7 @@ struct TripTodoView: View {
                             addingSection = nil
                         }
                 }
+                .padding(.vertical, 4)
             } else {
                 // placeholder 모드
                 Button {
@@ -125,6 +121,7 @@ struct TripTodoView: View {
                             .font(.system(size: 15))
                             .foregroundColor(HiTripColor.gray300)
                     }
+                    .padding(.vertical, 4)
                 }
                 .buttonStyle(.plain)
             }
@@ -135,19 +132,21 @@ struct TripTodoView: View {
 
     private func todoRow(_ todo: TripTodo) -> some View {
         HStack(spacing: 10) {
-            // 체크 원
+            // 체크 원 — 고정 프레임으로 위치 이동 방지
             Button {
                 viewModel.toggleTodo(todo.id)
             } label: {
-                if todo.isCompleted {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 22))
-                        .foregroundColor(HiTripColor.primary800)
-                } else {
-                    Circle()
-                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
-                        .frame(width: 22, height: 22)
+                ZStack {
+                    if todo.isCompleted {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 22))
+                            .foregroundColor(HiTripColor.primary800)
+                    } else {
+                        Circle()
+                            .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                    }
                 }
+                .frame(width: 22, height: 22)
             }
             .buttonStyle(.plain)
 
@@ -193,5 +192,6 @@ struct TripTodoView: View {
                     .frame(width: 28, height: 28)
             }
         }
+        .padding(.vertical, 4)
     }
 }

--- a/HiTrip/Features/Schedule/Views/WeekCalendarStripView.swift
+++ b/HiTrip/Features/Schedule/Views/WeekCalendarStripView.swift
@@ -1,34 +1,27 @@
 import SwiftUI
 
 // MARK: - WeekCalendarStripView
-/// 주간 캘린더 스트립 — 화면1(최근 일정)과 화면2(할일)에서 공용
+/// 주간 캘린더 스트립 — 공용 컴포넌트
 ///
 /// 피그마 디자인:
-/// - 좌우 화살표로 주(week) 이동
-/// - 요일 라벨 (S M T W T F S 또는 월 화 수 목 금 토 일)
-/// - 날짜 숫자 — 선택된 날짜는 파란 원 배경
-///
-/// 사용:
-/// ```swift
-/// WeekCalendarStripView(
-///     selectedDate: $viewModel.selectedDate,
-///     style: .sundayStart   // 화면1: 일요일 시작
-/// )
-/// ```
+/// - 헤더: "10월 22일" + 좌우 화살표(< >)
+/// - 요일 라벨: S M T W T F S (일요일 시작)
+/// - 날짜 숫자: 선택된 날짜는 파란 둥근사각 배경 (radius 16)
+/// - 전체 카드: 흰색 배경, radius 24 (외부에서 적용)
 
 struct WeekCalendarStripView: View {
 
     @Binding var selectedDate: Date
 
     /// 주 시작 요일 스타일
-    var style: WeekStyle = .mondayStart
+    var style: WeekStyle = .sundayStart
 
     /// 날짜 탭 시 콜백 (nil이면 selectedDate 바인딩만 변경)
     var onDateTap: ((Date) -> Void)?
 
     enum WeekStyle {
-        case sundayStart   // 화면1: S M T W T F S
-        case mondayStart   // 화면2: 월 화 수 목 금 토 일
+        case sundayStart   // S M T W T F S
+        case mondayStart   // 월 화 수 목 금 토 일
     }
 
     /// 표시 중인 주의 기준 날짜
@@ -37,19 +30,24 @@ struct WeekCalendarStripView: View {
     private let calendar = Calendar.current
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 0) {
             // 상단: 날짜 텍스트 + 좌우 화살표
             headerRow
 
-            // 요일 + 날짜 그리드
-            weekDaysRow
+            // 요일 라벨 + 날짜 숫자 (간격 좁게)
+            VStack(spacing: 4) {
+                weekdayLabels
+                weekDaysRow
+            }
+            .padding(.top, 16)
         }
         .padding(.horizontal, 20)
-        .padding(.vertical, 12)
+        .padding(.vertical, 16)
     }
 
     // MARK: - Header
 
+    /// 피그마: "10월 22일" + < > 화살표
     private var headerRow: some View {
         HStack {
             Text(headerDateText)
@@ -74,46 +72,51 @@ struct WeekCalendarStripView: View {
         }
     }
 
+    // MARK: - Weekday Labels
+
+    /// 요일 라벨 행 (S M T W T F S)
+    private var weekdayLabels: some View {
+        HStack(spacing: 0) {
+            ForEach(weekDays, id: \.self) { date in
+                Text(dayLabel(for: date))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(HiTripColor.gray400)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
     // MARK: - Week Days Row
 
+    /// 날짜 숫자 행 — 선택된 날짜는 파란 RoundedRectangle(16)
     private var weekDaysRow: some View {
         HStack(spacing: 0) {
             ForEach(weekDays, id: \.self) { date in
-                VStack(spacing: 6) {
-                    // 요일 라벨
-                    Text(dayLabel(for: date))
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(isToday(date) ? HiTripColor.primary800 : HiTripColor.gray400)
-
-                    // 날짜 숫자
-                    Text("\(calendar.component(.day, from: date))")
-                        .font(.system(size: 16, weight: isSelected(date) ? .bold : .medium))
-                        .foregroundColor(isSelected(date) ? .white : HiTripColor.textBlack)
-                        .frame(width: 36, height: 36)
-                        .background(
-                            Circle()
-                                .fill(isSelected(date) ? HiTripColor.primary800 : Color.clear)
-                        )
-                }
-                .frame(maxWidth: .infinity)
-                .onTapGesture {
-                    selectedDate = date
-                    onDateTap?(date)
-                }
+                Text("\(calendar.component(.day, from: date))")
+                    .font(.system(size: 16, weight: isSelected(date) ? .bold : .medium))
+                    .foregroundColor(isSelected(date) ? .white : HiTripColor.textBlack)
+                    .frame(width: 40, height: 40)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(isSelected(date) ? HiTripColor.primary800 : Color.clear)
+                    )
+                    .frame(maxWidth: .infinity)
+                    .onTapGesture {
+                        selectedDate = date
+                        onDateTap?(date)
+                    }
             }
         }
     }
 
     // MARK: - Helpers
 
-    /// 헤더에 표시할 날짜 텍스트 (예: "4월")
-    /// 표시 중인 주의 중간 날짜 기준으로 월 표시 — '>' 클릭 시 자동 변경
+    /// 헤더 날짜 텍스트 — 피그마: "10월 22일"
+    /// 선택된 날짜 기준으로 표시
     private var headerDateText: String {
-        let days = weekDays
-        // 주의 중간(4번째) 날짜 기준으로 월 표시
-        let referenceDate = days.isEmpty ? selectedDate : days[min(3, days.count - 1)]
-        let month = calendar.component(.month, from: referenceDate)
-        return "\(month)월"
+        let month = calendar.component(.month, from: selectedDate)
+        let day = calendar.component(.day, from: selectedDate)
+        return "\(month)월 \(day)일"
     }
 
     /// 현재 표시 중인 주의 7일 배열
@@ -145,11 +148,6 @@ struct WeekCalendarStripView: View {
             let weekday = calendar.component(.weekday, from: date)
             return symbols[weekday - 1]
         }
-    }
-
-    /// 오늘 날짜인지
-    private func isToday(_ date: Date) -> Bool {
-        calendar.isDateInToday(date)
     }
 
     /// 선택된 날짜인지


### PR DESCRIPTION
## Summary

- 캘린더/체크리스트 페이지를 피그마 디자인에 맞춰 전면 재구성
- "내 일정" 탭에서 카드 탭 시 SpotDetailView(검색 상세보기) 연결
- 선택 날짜에 해당하는 일정만 필터링하여 표시

<br/>

## Changes

### UI 리디자인

- **TripDetailView** 전면 재구성
: 멤버 아바타 섹션 제거, 주간 캘린더 스트립을 탭 상단으로 이동(양 탭 공용), 배경색 흰색, `<` 뒤로가기 버튼 제거
- **탭 구성 변경**
: "할일 | 캘린더" → "내 일정 | 할 일", 기본 탭 `.mySchedule`
- **탭 인디케이터** 
: `Rectangle(2px)` → `RoundedRectangle(cornerRadius: 10, 3px)`, 색상 검정
- **WeekCalendarStripView**
: 헤더 "4월" → "10월 22일" 형식, 선택 날짜 `Circle` → `RoundedRectangle(cornerRadius: 16)`, 요일/숫자 행 분리 및 간격 조정, 카드 radius 24
- **TripTodoView**
: 캘린더 스트립 제거(공용화), 섹션 태그 배경 `#F4F3F9`/radius 18, 체크 토글 시 위치 이동 버그 수정(ZStack + 고정 frame), 아이템 간격 축소
- **MyScheduleListView** 신규
: 개별 카드 분리(radius 16, gap 12), 썸네일 85x85 회색 placeholder + airplane 아이콘, 텍스트 간격 8

<br/>

### 기능 추가

- **내 일정 상세보기**
: Trip→TourSpotItem 변환(`Trip+SpotItem.swift`) → SpotDetailView 재활용
- **날짜별 필터링**
: `TripDataStore.trips(for:)` + `TripDetailViewModel.tripsForSelectedDate` — 선택 날짜에 해당하는 일정만 표시

<br/>

### 디자인 시스템

- `HiTripColor.sectionTagBackground` (#F4F3F9) 추가
- TripListView 캘린더 카드 radius 16→24 통일