### PR TITLE
feat: 홈 대시보드 데이터 중앙관리 + 공지/일정 화면 + 디자인 시스템 정비

### DIFF
--- a/HiTrip/Core/Extensions/Color+Hex.swift
+++ b/HiTrip/Core/Extensions/Color+Hex.swift
@@ -112,8 +112,13 @@ enum HiTripColor {
     static let buttonDisabledText = gray400
     /// 로고 텍스트 컬러
     static let logoText = secondary700
-    /// 스크린 기본 배경
-    static let screenBackground = gray100
+    /// 강조 링크 / 이동 링크 (#0C46C0)
+    static let accentLink = primary800
+    /// 스크린 기본 배경 #F9F9F9
+    static let screenBackground = Color(hex: "F9F9F9")
+
+    /// 카드 드롭 섀도우 컬러 #B4BCC91F (12% opacity)
+    static let cardShadow = Color(hex: "B4BCC9").opacity(0.12)
     /// 인풋 필드 배경
     static let inputBackground = Color.white
     /// 에러 (빨간 테두리, 경고 텍스트)

--- a/HiTrip/Core/Extensions/View+CardStyle.swift
+++ b/HiTrip/Core/Extensions/View+CardStyle.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+// MARK: - HiTripCardStyle
+/// 공통 카드 스타일 ViewModifier
+///
+/// 디자인 스펙:
+/// - 배경: #FFFFFF (흰색)
+/// - Corner Radius: 16px
+/// - Drop Shadow: #B4BCC9, opacity 12%, radius 12 (spread 12% 근사)
+///
+/// 사용법:
+/// ```swift
+/// VStack { ... }
+///     .hiTripCard()
+/// ```
+///
+/// 패딩이 필요한 경우:
+/// ```swift
+/// VStack { ... }
+///     .hiTripCard(padding: 16)
+/// ```
+
+struct HiTripCardModifier: ViewModifier {
+    var padding: CGFloat?
+
+    func body(content: Content) -> some View {
+        Group {
+            if let padding = padding {
+                content.padding(padding)
+            } else {
+                content
+            }
+        }
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
+    }
+}
+
+extension View {
+    /// HiTrip 공통 카드 스타일 적용
+    /// - Parameter padding: 내부 패딩 (nil이면 패딩 없음, 직접 지정)
+    func hiTripCard(padding: CGFloat? = nil) -> some View {
+        modifier(HiTripCardModifier(padding: padding))
+    }
+}

--- a/HiTrip/Data/Repositories/TripRepository.swift
+++ b/HiTrip/Data/Repositories/TripRepository.swift
@@ -12,12 +12,26 @@ final class MockTripRepository: TripRepositoryProtocol {
 
     // MARK: - In-Memory Storage
 
+    private var currentPackage: TripPackage?
     private var trips: [Trip] = []
     private var todos: [TripTodo] = []
     private var events: [TripEvent] = []
 
     init() {
         loadMockData()
+    }
+
+    // MARK: - TripPackage
+
+    func fetchCurrentPackage() -> Single<TripPackage?> {
+        .just(currentPackage)
+    }
+
+    func fetchPackages() -> Single<[TripPackage]> {
+        if let pkg = currentPackage {
+            return .just([pkg])
+        }
+        return .just([])
     }
 
     // MARK: - Trip
@@ -93,6 +107,73 @@ final class MockTripRepository: TripRepositoryProtocol {
         let today = now
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) ?? now
         let dayAfter = calendar.date(byAdding: .day, value: 2, to: now) ?? now
+
+        // ── TripPackage (여행사 등록 데이터) ──────────────────
+
+        let packageStart = calendar.date(byAdding: .day, value: -2, to: now) ?? now
+        let packageEnd = calendar.date(byAdding: .day, value: 3, to: now) ?? now
+
+        currentPackage = TripPackage(
+            name: "제주 힐링여행",
+            startDate: packageStart,
+            endDate: packageEnd,
+            destination: "제주",
+            totalParticipants: 20,
+            currentParticipants: 18,
+            weatherDescription: "맑음 22°C",
+            notices: [
+                TripNotice(title: "집합 안내", content: "오전 9시 로비 집합 — 우산 꼭 챙겨주세요!", date: today, isImportant: true, isRepresentative: true),
+                TripNotice(title: "준비물 안내", content: "내일 해변 투어 준비물: 선크림, 모자, 수건 필수!", date: today),
+                TripNotice(title: "식사 안내", content: "점심은 12시 30분 한림 맛집에서 단체 식사입니다.", date: today),
+                TripNotice(title: "해변 투어", content: "내일 오전 9시 해변 투어 출발합니다. 편한 신발 착용해주세요.", date: tomorrow),
+                TripNotice(title: "귀국 안내", content: "마지막 날 체크아웃은 11시까지입니다.", date: dayAfter)
+            ],
+            missions: [
+                TripMission(content: "제주 명소 3곳 방문하기", date: today),
+                TripMission(content: "현지 맛집에서 사진 남기기", date: tomorrow)
+            ],
+            officialSchedules: [
+                TripOfficialSchedule(
+                    emoji: "🏠",
+                    title: "숙소로 이동",
+                    startTime: calendar.date(bySettingHour: 15, minute: 0, second: 0, of: today) ?? now,
+                    endTime: calendar.date(bySettingHour: 16, minute: 0, second: 0, of: today) ?? now,
+                    date: today
+                ),
+                TripOfficialSchedule(
+                    emoji: "🌅",
+                    title: "자유 시간",
+                    startTime: calendar.date(bySettingHour: 16, minute: 0, second: 0, of: today) ?? now,
+                    endTime: calendar.date(bySettingHour: 23, minute: 0, second: 0, of: today) ?? now,
+                    date: today
+                ),
+                TripOfficialSchedule(
+                    emoji: "🏖️",
+                    title: "해변 투어",
+                    startTime: calendar.date(bySettingHour: 9, minute: 0, second: 0, of: tomorrow) ?? now,
+                    endTime: calendar.date(bySettingHour: 12, minute: 0, second: 0, of: tomorrow) ?? now,
+                    date: tomorrow
+                ),
+                TripOfficialSchedule(
+                    emoji: "🍽️",
+                    title: "점심 식사",
+                    startTime: calendar.date(bySettingHour: 12, minute: 30, second: 0, of: tomorrow) ?? now,
+                    endTime: calendar.date(bySettingHour: 14, minute: 0, second: 0, of: tomorrow) ?? now,
+                    date: tomorrow
+                )
+            ],
+            nearbySpots: [
+                TripNearbySpot(name: "협재 해수욕장", distance: "도보 8분", category: "beach"),
+                TripNearbySpot(name: "한림공원", distance: "도보 11분", category: "leaf"),
+                TripNearbySpot(name: "금오름", distance: "차량 14분", category: "mountain"),
+                TripNearbySpot(name: "금능 해수욕장", distance: "도보 9분", category: "water")
+            ],
+            translations: [
+                TripTranslation(original: "화장실 어디예요?", translated: "Where is the restroom?", category: "기본"),
+                TripTranslation(original: "얼마예요?", translated: "How much is it?", category: "쇼핑"),
+                TripTranslation(original: "도와주세요", translated: "Please help me", category: "긴급")
+            ]
+        )
 
         // ── Trips ──────────────────────────────────
 

--- a/HiTrip/Domain/Repositories/TripRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/TripRepositoryProtocol.swift
@@ -13,6 +13,15 @@ import RxSwift
 
 protocol TripRepositoryProtocol {
 
+    // MARK: - TripPackage
+
+    /// 현재 사용자에게 배정된 여행 패키지 조회
+    /// (여행사가 등록 후 고객을 추가하면 해당 고객에게 노출)
+    func fetchCurrentPackage() -> Single<TripPackage?>
+
+    /// 전체 패키지 목록 (여행사 관리용)
+    func fetchPackages() -> Single<[TripPackage]>
+
     // MARK: - Trip
 
     /// 전체 여행 목록 조회

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -21,6 +21,8 @@ final class TripDataStore: ObservableObject {
 
     // MARK: - Published Data
 
+    /// 현재 사용자에게 배정된 여행 패키지 (여행사 등록 데이터)
+    @Published var currentPackage: TripPackage?
     @Published var trips: [Trip] = []
     @Published var todos: [TripTodo] = []
     @Published var events: [TripEvent] = []
@@ -47,6 +49,15 @@ final class TripDataStore: ObservableObject {
 
     /// Repository에서 초기 데이터 로드
     private func loadInitialData() {
+        // 여행 패키지 로드 (여행사 등록 데이터)
+        repository.fetchCurrentPackage()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] package in
+                self?.currentPackage = package
+            })
+            .disposed(by: disposeBag)
+
+        // 개인 일정 로드
         repository.fetchTrips()
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] trips in
@@ -81,6 +92,44 @@ final class TripDataStore: ObservableObject {
                 self?.events.append(contentsOf: fetchedEvents)
             })
             .disposed(by: disposeBag)
+    }
+
+    // MARK: - Package: Dashboard Helpers
+
+    /// 전체 공지사항 (최신순)
+    var allNotices: [TripNotice] {
+        guard let pkg = currentPackage else { return [] }
+        return pkg.notices.sorted { $0.date > $1.date }
+    }
+
+    /// 대표 공지사항 (홈 메인 노출용)
+    var representativeNotice: TripNotice? {
+        guard let pkg = currentPackage else { return nil }
+        return pkg.notices.first { $0.isRepresentative }
+            ?? pkg.notices.sorted(by: { $0.date > $1.date }).first
+    }
+
+    /// 오늘의 공지사항
+    func todayNotices(for date: Date = Date()) -> [TripNotice] {
+        guard let pkg = currentPackage else { return [] }
+        let cal = Calendar.current
+        return pkg.notices.filter { cal.isDate($0.date, inSameDayAs: date) }
+    }
+
+    /// 오늘의 미션
+    func todayMissions(for date: Date = Date()) -> [TripMission] {
+        guard let pkg = currentPackage else { return [] }
+        let cal = Calendar.current
+        return pkg.missions.filter { cal.isDate($0.date, inSameDayAs: date) }
+    }
+
+    /// 오늘의 공식 일정 (여행사 등록)
+    func todayOfficialSchedules(for date: Date = Date()) -> [TripOfficialSchedule] {
+        guard let pkg = currentPackage else { return [] }
+        let cal = Calendar.current
+        return pkg.officialSchedules
+            .filter { cal.isDate($0.date, inSameDayAs: date) }
+            .sorted { $0.startTime < $1.startTime }
     }
 
     // MARK: - Trip: Read

--- a/HiTrip/Features/Schedule/Models/TripPackage.swift
+++ b/HiTrip/Features/Schedule/Models/TripPackage.swift
@@ -1,0 +1,258 @@
+import Foundation
+
+// MARK: - TripPackage
+/// 여행사가 등록하는 여행 패키지 (홈 대시보드 데이터 원본)
+///
+/// 구조: 여행사 직원 → 그룹(여행객 그룹) 생성 → 일정/공지/장소 등록
+///       → 그룹에 속한 모든 여행객이 앱에서 수신
+///
+/// 역할 분담:
+/// - 여행사가 등록하는 것: 공지사항, 공식 일정, 추천 장소, 번역, 미션
+/// - 여행객 개인이 관리하는 것: 할 일(TripTodo), 개인 메모
+/// - 여행사 등록은 웹 SaaS에서 처리 → 앱은 수신/조회만 함
+///
+/// 하나의 TripPackage가 홈 화면의 모든 섹션 데이터를 제공:
+/// - 여행 기본 정보 (이름, 기간, 목적지)
+/// - 참여자 정보
+/// - 공지사항 (대표 공지 → 홈 노출, 전체 → 리스트 화면)
+/// - 오늘의 미션
+/// - 오늘의 일정 (여행사가 등록한 공식 타임라인)
+/// - 추천 장소
+/// - 번역 모음
+
+struct TripPackage: Identifiable, Codable, Equatable {
+
+    let id: UUID
+    var name: String               // "제주 힐링여행"
+    var startDate: Date            // 여행 시작일
+    var endDate: Date              // 여행 종료일
+    var destination: String        // "제주"
+
+    // 참여자
+    var totalParticipants: Int     // 정원
+    var currentParticipants: Int   // 현재 참여 인원
+
+    // 날씨 (서버에서 갱신하거나 여행사가 세팅)
+    var weatherDescription: String // "맑음 22°C"
+
+    // 공지사항 목록
+    var notices: [TripNotice]
+
+    // 미션 목록
+    var missions: [TripMission]
+
+    // 공식 일정 (여행사가 등록한 타임라인)
+    var officialSchedules: [TripOfficialSchedule]
+
+    // 추천 장소
+    var nearbySpots: [TripNearbySpot]
+
+    // 번역 모음
+    var translations: [TripTranslation]
+
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        startDate: Date,
+        endDate: Date,
+        destination: String,
+        totalParticipants: Int = 20,
+        currentParticipants: Int = 0,
+        weatherDescription: String = "",
+        notices: [TripNotice] = [],
+        missions: [TripMission] = [],
+        officialSchedules: [TripOfficialSchedule] = [],
+        nearbySpots: [TripNearbySpot] = [],
+        translations: [TripTranslation] = [],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.startDate = startDate
+        self.endDate = endDate
+        self.destination = destination
+        self.totalParticipants = totalParticipants
+        self.currentParticipants = currentParticipants
+        self.weatherDescription = weatherDescription
+        self.notices = notices
+        self.missions = missions
+        self.officialSchedules = officialSchedules
+        self.nearbySpots = nearbySpots
+        self.translations = translations
+        self.createdAt = createdAt
+    }
+
+    // MARK: - Computed
+
+    /// 현재 여행 일차 (1-based)
+    func currentDay(from today: Date = Date()) -> Int {
+        let cal = Calendar.current
+        let start = cal.startOfDay(for: startDate)
+        let now = cal.startOfDay(for: today)
+        let diff = cal.dateComponents([.day], from: start, to: now).day ?? 0
+        return max(1, diff + 1)
+    }
+
+    /// 총 여행 일수
+    var totalDays: Int {
+        let cal = Calendar.current
+        let diff = cal.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        return max(1, diff + 1)
+    }
+
+    /// 남은 일수
+    func daysRemaining(from today: Date = Date()) -> Int {
+        let cal = Calendar.current
+        let now = cal.startOfDay(for: today)
+        let end = cal.startOfDay(for: endDate)
+        let diff = cal.dateComponents([.day], from: now, to: end).day ?? 0
+        return max(0, diff)
+    }
+
+    /// 진행률 (0.0 ~ 1.0)
+    func progressRate(from today: Date = Date()) -> Double {
+        guard totalDays > 0 else { return 0 }
+        let day = currentDay(from: today)
+        return min(1.0, Double(day) / Double(totalDays))
+    }
+}
+
+// MARK: - TripNotice
+/// 여행사 공지사항
+///
+/// 여행사가 그룹(여행객 그룹)에 등록하는 공지.
+/// isRepresentative = true인 공지만 홈 메인에 노출되고,
+/// 공지 리스트 화면에서는 전체 목록을 볼 수 있다.
+
+struct TripNotice: Identifiable, Codable, Equatable {
+    let id: UUID
+    var title: String          // "집합 안내"
+    var content: String        // "오전 9시 로비 집합 — 우산 꼭 챙겨주세요!"
+    var date: Date             // 공지 등록 날짜
+    var isImportant: Bool      // 중요 표시
+    var isRepresentative: Bool // true면 홈 메인에 대표 공지로 노출
+
+    init(
+        id: UUID = UUID(),
+        title: String = "",
+        content: String,
+        date: Date,
+        isImportant: Bool = false,
+        isRepresentative: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.date = date
+        self.isImportant = isImportant
+        self.isRepresentative = isRepresentative
+    }
+}
+
+// MARK: - TripMission
+/// 오늘의 미션 (여행사가 날짜별로 등록)
+
+struct TripMission: Identifiable, Codable, Equatable {
+    let id: UUID
+    var content: String        // "제주 명소 3곳 방문하기"
+    var date: Date             // 미션 날짜
+    var isCompleted: Bool
+
+    init(
+        id: UUID = UUID(),
+        content: String,
+        date: Date,
+        isCompleted: Bool = false
+    ) {
+        self.id = id
+        self.content = content
+        self.date = date
+        self.isCompleted = isCompleted
+    }
+}
+
+// MARK: - TripOfficialSchedule
+/// 여행사 공식 일정 (홈 화면 "오늘의 일정" 섹션)
+///
+/// TripEvent(개인 일정)과 구분 — 이건 여행사가 등록한 공식 타임라인
+
+struct TripOfficialSchedule: Identifiable, Codable, Equatable {
+    let id: UUID
+    var emoji: String          // "🏠", "🌅"
+    var title: String          // "숙소로 이동"
+    var startTime: Date        // 시작 시간
+    var endTime: Date          // 종료 시간
+    var date: Date             // 해당 날짜
+
+    init(
+        id: UUID = UUID(),
+        emoji: String,
+        title: String,
+        startTime: Date,
+        endTime: Date,
+        date: Date
+    ) {
+        self.id = id
+        self.emoji = emoji
+        self.title = title
+        self.startTime = startTime
+        self.endTime = endTime
+        self.date = date
+    }
+
+    /// 표시용 시간 문자열 "15:00 – 16:00"
+    var timeText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: startTime)) – \(formatter.string(from: endTime))"
+    }
+}
+
+// MARK: - TripNearbySpot
+/// 추천 장소 (여행사가 등록)
+
+struct TripNearbySpot: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String           // "협재 해수욕장"
+    var distance: String       // "도보 8분"
+    var category: String       // "beach", "leaf", "mountain", "water"
+    var imageURL: String?      // 이미지 URL (nil이면 placeholder)
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        distance: String,
+        category: String,
+        imageURL: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.distance = distance
+        self.category = category
+        self.imageURL = imageURL
+    }
+}
+
+// MARK: - TripTranslation
+/// 여행 필수 번역 문장
+
+struct TripTranslation: Identifiable, Codable, Equatable {
+    let id: UUID
+    var original: String       // "화장실 어디예요?"
+    var translated: String     // "Where is the restroom?"
+    var category: String       // "기본", "식당", "교통" 등
+
+    init(
+        id: UUID = UUID(),
+        original: String,
+        translated: String,
+        category: String = "기본"
+    ) {
+        self.id = id
+        self.original = original
+        self.translated = translated
+        self.category = category
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
@@ -2,10 +2,16 @@ import Foundation
 import Combine
 
 // MARK: - TripListViewModel
-/// 화면1: 최근 일정 리스트 관리
+/// 홈 화면: 여행 대시보드 관리
 ///
-/// TripDataStore.shared를 참조하여 데이터 일관성 보장.
-/// Store에서 변경이 발생하면 자동으로 UI 갱신.
+/// TripDataStore.shared.currentPackage(여행사 등록 패키지)를 기반으로
+/// 대시보드 UI에 필요한 데이터를 계산하여 제공.
+///
+/// 데이터 흐름:
+/// 여행사 등록 → 서버 → Repository → TripDataStore.currentPackage → ViewModel → View
+///
+/// 하드코딩 없이 Store에서 모든 데이터를 가져오므로,
+/// API 연동 시 MockTripRepository → RemoteTripRepository 교체만 하면 된다.
 
 final class TripListViewModel: ObservableObject {
 
@@ -16,16 +22,12 @@ final class TripListViewModel: ObservableObject {
 
     // MARK: - Published State
 
-    /// 주간 캘린더에서 선택된 날짜
     @Published var selectedDate: Date = Date()
-
-    /// 로딩 상태
     @Published var isLoading: Bool = false
 
     // MARK: - Init
 
     init() {
-        // Store의 변경을 감지하여 View 갱신
         store.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
@@ -34,36 +36,125 @@ final class TripListViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    // MARK: - Trips
+    // MARK: - 패키지 존재 여부
 
-    /// 전체 여행 (최신순)
+    /// 현재 배정된 패키지가 있는지
+    var hasPackage: Bool {
+        store.currentPackage != nil
+    }
+
+    // MARK: - 현재 여행 정보 (Store 기반)
+
+    /// 현재 진행 중인 여행 이름
+    var currentTripName: String {
+        store.currentPackage?.name ?? "여행 없음"
+    }
+
+    /// 현재 여행 일차 텍스트
+    var currentDayText: String {
+        guard let pkg = store.currentPackage else { return "" }
+        return "\(pkg.currentDay())일차"
+    }
+
+    /// 여행 진행률 (0.0 ~ 1.0)
+    var progressRate: Double {
+        store.currentPackage?.progressRate() ?? 0
+    }
+
+    /// 진행률 텍스트
+    var progressText: String {
+        let percent = Int(progressRate * 100)
+        return "\(percent)% 완료"
+    }
+
+    /// 남은 일수 텍스트
+    var daysRemainingText: String {
+        guard let pkg = store.currentPackage else { return "" }
+        let remaining = pkg.daysRemaining()
+        return "여행 진행률 · \(remaining)일 남음"
+    }
+
+    // MARK: - 날씨 (Store 기반)
+
+    /// 현재 목적지
+    var weatherLocation: String {
+        store.currentPackage?.destination ?? ""
+    }
+
+    /// 날씨 설명
+    var weatherDescription: String {
+        store.currentPackage?.weatherDescription ?? ""
+    }
+
+    // MARK: - 참여자 (Store 기반)
+
+    var participantsText: String {
+        guard let pkg = store.currentPackage else { return "" }
+        return "참여자 \(pkg.currentParticipants) / \(pkg.totalParticipants)명"
+    }
+
+    // MARK: - 공지사항 (Store 기반 — 대표 공지)
+
+    /// 홈에 표시할 대표 공지 내용
+    var noticeText: String {
+        store.representativeNotice?.content ?? "등록된 공지사항이 없습니다"
+    }
+
+    /// 전체 공지사항 목록 (리스트 화면용)
+    var allNotices: [TripNotice] {
+        store.allNotices
+    }
+
+    // MARK: - 오늘의 미션 (Store 기반)
+
+    var missionText: String {
+        let missions = store.todayMissions()
+        return missions.first?.content ?? "등록된 미션이 없습니다"
+    }
+
+    // MARK: - 오늘의 일정 (Store 기반 — 여행사 공식 일정)
+
+    var todaySchedules: [TripOfficialSchedule] {
+        store.todayOfficialSchedules()
+    }
+
+    // MARK: - 지금 갈만한 곳 (Store 기반)
+
+    var nearbySpots: [TripNearbySpot] {
+        store.currentPackage?.nearbySpots ?? []
+    }
+
+    // MARK: - 여행 필수 번역 (Store 기반)
+
+    var translationPreview: String {
+        guard let pkg = store.currentPackage else { return "" }
+        let preview = pkg.translations.prefix(2).map { $0.original }
+        return preview.joined(separator: " / ")
+    }
+
+    // MARK: - Trips (기존 유지)
+
     var filteredTrips: [Trip] {
         store.sortedTrips
     }
 
-    /// tripId로 Trip 찾기
     func trip(for tripId: UUID) -> Trip? {
         store.trip(for: tripId)
     }
 
-    // MARK: - 선택된 날짜의 투두
+    // MARK: - Todo / Event (기존 유지)
 
     var todosForSelectedDate: [TripTodo] {
         store.todos(for: selectedDate)
     }
 
-    // MARK: - 선택된 날짜의 이벤트
-
     var eventsForSelectedDate: [TripEvent] {
         store.events(for: selectedDate)
     }
 
-    /// 선택된 날짜에 일정 또는 투두가 있는지
     var hasScheduleForSelectedDate: Bool {
         !todosForSelectedDate.isEmpty || !eventsForSelectedDate.isEmpty
     }
-
-    // MARK: - Todo Actions
 
     func toggleTodo(_ todoId: UUID) {
         store.toggleTodo(todoId)

--- a/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
+++ b/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
@@ -64,9 +64,7 @@ struct MyScheduleListView: View {
                     tripCardRow(trip)
                 }
                 .buttonStyle(.plain)
-                .background(Color.white)
-                .cornerRadius(16)
-                .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+                .hiTripCard()
             }
         }
     }

--- a/HiTrip/Features/Schedule/Views/NoticeListView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticeListView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+// MARK: - NoticeListView
+/// 공지사항 전체 리스트 화면
+///
+/// 여행사가 그룹에 등록한 모든 공지사항을 시간순으로 표시.
+/// 홈 화면의 공지 카드를 탭하면 이 화면으로 이동한다.
+///
+/// 디자인:
+/// - 상단: "공지사항" 타이틀 + 뒤로가기
+/// - 각 공지: 카드 형태 (제목, 내용, 날짜, 중요 뱃지)
+
+struct NoticeListView: View {
+
+    @ObservedObject var viewModel: TripListViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// 날짜 포맷
+    private var dateFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "M월 d일 (E)"
+        return f
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                if viewModel.allNotices.isEmpty {
+                    emptyState
+                        .padding(.top, 80)
+                } else {
+                    ForEach(viewModel.allNotices) { notice in
+                        noticeRow(notice)
+                    }
+                }
+
+                Spacer().frame(height: 40)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+        }
+        .background(HiTripColor.screenBackground)
+        .navigationTitle("공지사항")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+        }
+    }
+
+    // MARK: - Notice Row
+
+    private func noticeRow(_ notice: TripNotice) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // 상단: 제목 + 중요 뱃지
+            HStack(spacing: 8) {
+                if notice.isImportant {
+                    Text("중요")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.red.opacity(0.8))
+                        .cornerRadius(4)
+                }
+
+                Text(notice.title.isEmpty ? "공지" : notice.title)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Spacer()
+
+                if notice.isRepresentative {
+                    Text("대표")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(HiTripColor.secondary700)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(HiTripColor.secondary700, lineWidth: 1)
+                        )
+                }
+            }
+
+            // 내용
+            Text(notice.content)
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+                .lineLimit(3)
+
+            // 날짜
+            Text(dateFormatter.string(from: notice.date))
+                .font(.system(size: 12))
+                .foregroundColor(HiTripColor.gray400)
+        }
+        .hiTripCard(padding: 16)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "megaphone")
+                .font(.system(size: 40))
+                .foregroundColor(HiTripColor.gray300)
+
+            Text("등록된 공지사항이 없습니다")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("여행사에서 공지를 등록하면 여기에 표시됩니다")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TodayScheduleView.swift
+++ b/HiTrip/Features/Schedule/Views/TodayScheduleView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+// MARK: - TodayScheduleView
+/// 오늘의 일정 전체 보기 화면
+///
+/// 여행사가 그룹에 등록한 공식 일정(TripOfficialSchedule)을
+/// 타임라인 형태로 표시한다.
+///
+/// 홈 화면 "오늘의 일정" → "전체 보기 >" 탭 시 이동.
+///
+/// 디자인:
+/// - 타임라인 형태: 시간순 정렬
+/// - 각 일정: 이모지 + 제목 + 시간 + 연결선
+
+struct TodayScheduleView: View {
+
+    @ObservedObject var viewModel: TripListViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if viewModel.todaySchedules.isEmpty {
+                    emptyState
+                        .padding(.top, 80)
+                } else {
+                    timelineList
+                        .padding(.top, 20)
+                }
+
+                Spacer().frame(height: 40)
+            }
+            .padding(.horizontal, 20)
+        }
+        .background(HiTripColor.screenBackground)
+        .navigationTitle("오늘의 일정")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+        }
+    }
+
+    // MARK: - Timeline List
+
+    private var timelineList: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(viewModel.todaySchedules.enumerated()), id: \.element.id) { index, schedule in
+                timelineRow(schedule, isLast: index == viewModel.todaySchedules.count - 1)
+            }
+        }
+    }
+
+    // MARK: - Timeline Row
+
+    private func timelineRow(_ schedule: TripOfficialSchedule, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            // 왼쪽: 타임라인 도트 + 연결선
+            VStack(spacing: 0) {
+                // 도트
+                Circle()
+                    .fill(HiTripColor.primary800)
+                    .frame(width: 12, height: 12)
+
+                // 연결선
+                if !isLast {
+                    Rectangle()
+                        .fill(HiTripColor.gray200)
+                        .frame(width: 2)
+                        .frame(minHeight: 60)
+                }
+            }
+
+            // 오른쪽: 일정 카드
+            VStack(alignment: .leading, spacing: 8) {
+                // 시간
+                Text(schedule.timeText)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray500)
+
+                // 이모지 + 제목
+                HStack(spacing: 8) {
+                    Text(schedule.emoji)
+                        .font(.system(size: 24))
+
+                    Text(schedule.title)
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.white)
+            .cornerRadius(16)
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "calendar.badge.clock")
+                .font(.system(size: 40))
+                .foregroundColor(HiTripColor.gray300)
+
+            Text("오늘 등록된 일정이 없습니다")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("여행사에서 일정을 등록하면 여기에 표시됩니다")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -36,7 +36,7 @@ struct TripDetailView: View {
             // 탭 콘텐츠
             tabContent
         }
-        .background(Color.white)
+        .background(HiTripColor.screenBackground)
         .onAppear { viewModel.selectedTab = initialTab }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -51,15 +51,16 @@ struct TripDetailView: View {
 
     // MARK: - Calendar Card (탭 공용)
 
-    /// 주간 캘린더 카드 — 흰색 배경, radius 24
+    /// 주간 캘린더 카드 — 흰색 배경, radius 16, 디자인 스펙 shadow
     private var calendarCard: some View {
         WeekCalendarStripView(
             selectedDate: $viewModel.selectedDate,
             style: .sundayStart
         )
+        .padding(16)
         .background(Color.white)
-        .cornerRadius(24)
-        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
+        .cornerRadius(16)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
     }
 
     // MARK: - Tab Selector

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -1,167 +1,385 @@
 import SwiftUI
 
 // MARK: - TripListView
-/// 홈 화면 — 피그마 디자인
+/// 홈 화면 — 여행 대시보드
 ///
-/// UI 구성:
-/// - 네비바: "Hi Trip" 로고 + 알림 아이콘
-/// - 주간 캘린더 스트립 (날짜 선택)
-/// - "내 일정" 섹션 + "View all" 링크
-/// - 여행 카드 리스트 (썸네일 + 날짜 + 제목 + 위치)
-/// - 긴급 연락망 바로가기 배너
+/// 피그마 디자인:
+/// - 헤더: "전체 일정 확인" + 여행 이름 pill
+/// - 진행률 카드 (파란 배경, 버스 아이콘, 날씨, 참여자)
+/// - 공지사항 카드
+/// - 오늘의 미션 카드
+/// - 오늘의 일정 (전체 보기 링크)
+/// - 지금 갈만한 곳 (가로 스크롤)
+/// - 여행 필수 번역 모음
+/// - 긴급 연락망 배너
 
 struct TripListView: View {
 
     @StateObject private var viewModel = TripListViewModel()
     @EnvironmentObject var router: AppRouter
 
-    /// "View all" 클릭 → AllTripsView로 이동
-    @State private var navigateToAllTrips: Bool = false
-
-    /// 내 일정 카드 클릭 → 상세보기 (SpotDetailView 스타일)
-    @State private var selectedTripForDetail: Trip?
-
     /// 긴급 연락 페이지 이동
     @State private var showEmergency: Bool = false
 
+    /// 공지사항 리스트 이동
+    @State private var showNoticeList: Bool = false
+
+    /// 오늘의 일정 전체 보기 이동
+    @State private var showTodaySchedule: Bool = false
+
     var body: some View {
         NavigationStack {
-            ZStack {
-                HiTripColor.screenBackground
-                    .ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 16) {
+                    // 헤더 (스크롤과 함께 이동)
+                    headerSection
 
-                ScrollView {
-                    VStack(spacing: 0) {
-                        // 주간 캘린더 스트립
-                        calendarCard
+                    // 진행률 카드
+                    progressCard
 
-                        // "내 일정" 헤더
-                        sectionHeader
-                            .padding(.top, 24)
+                    // 공지사항
+                    noticeCard
 
-                        // 여행 카드 리스트
-                        tripCardList
-                            .padding(.top, 12)
+                    // 오늘의 미션
+                    missionCard
 
-                        // 긴급 연락망 바로가기
-                        emergencyBanner
-                            .padding(.top, 24)
-                            .padding(.horizontal, 20)
+                    // 오늘의 일정
+                    todayScheduleSection
 
-                        Spacer().frame(height: 24)
-                    }
+                    // 지금 갈만한 곳
+                    nearbySpotSection
+
+                    // 여행 필수 번역 모음
+                    translationCard
+
+                    // 긴급 연락망
+                    emergencyBanner
+
+                    Spacer().frame(height: 24)
                 }
+                .padding(.horizontal, 20)
             }
-            // "View all" → 전체 일정 리스트
-            .navigationDestination(isPresented: $navigateToAllTrips) {
-                AllTripsView()
-            }
-            // 긴급 연락 → EmergencyView
+            .background(HiTripColor.screenBackground)
             .navigationDestination(isPresented: $showEmergency) {
                 EmergencyView(viewModel: AppDIContainer.shared.makeEmergencyViewModel())
             }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Text("Hi Trip")
-                        .font(.system(size: 20, weight: .bold))
-                        .foregroundColor(HiTripColor.primary800)
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button { } label: {
-                        Image(systemName: "bell")
-                            .foregroundColor(HiTripColor.textBlack)
-                    }
-                }
+            .navigationDestination(isPresented: $showNoticeList) {
+                NoticeListView(viewModel: viewModel)
             }
+            .navigationDestination(isPresented: $showTodaySchedule) {
+                TodayScheduleView(viewModel: viewModel)
+            }
+            .navigationBarHidden(true)
         }
     }
 
-    // MARK: - Calendar Card
+    // MARK: - Header Section
 
-    private var calendarCard: some View {
-        VStack(spacing: 0) {
-            WeekCalendarStripView(
-                selectedDate: $viewModel.selectedDate,
-                style: .sundayStart
-            )
-        }
-        .background(Color.white)
-        .cornerRadius(24)
-        .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
-        .padding(.horizontal, 20)
-        .padding(.top, 8)
-    }
-
-    // MARK: - Section Header
-
-    private var sectionHeader: some View {
+    /// 스크롤되는 헤더: "전체 일정 확인" + 여행 pill
+    private var headerSection: some View {
         HStack {
-            Text("내 일정")
-                .font(.system(size: 18, weight: .bold))
+            Text("전체 일정 확인")
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
 
             Spacer()
 
-            Button {
-                navigateToAllTrips = true
-            } label: {
-                HStack(spacing: 4) {
-                    Text("View all")
-                        .font(.system(size: 14))
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 11))
-                }
-                .foregroundColor(HiTripColor.secondary700)
-            }
+            tripDayPill
         }
-        .padding(.horizontal, 24)
+        .padding(.top, 12)
     }
 
-    // MARK: - Trip Card List
+    // MARK: - Trip Day Pill
 
-    private var tripCardList: some View {
-        LazyVStack(spacing: 12) {
-            ForEach(viewModel.filteredTrips) { trip in
-                Button {
-                    selectedTripForDetail = trip
-                } label: {
-                    TripCardRow(trip: trip)
+    /// "제주 힐링여행 · 2일차" 알약 배지
+    private var tripDayPill: some View {
+        Text("\(viewModel.currentTripName) · \(viewModel.currentDayText)")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(HiTripColor.accentLink)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(HiTripColor.accentLink, lineWidth: 1)
+            )
+    }
+
+    // MARK: - Progress Card
+
+    /// 여행 진행률 카드 (파란 배경)
+    private var progressCard: some View {
+        HStack(spacing: 0) {
+            // 왼쪽: 버스 아이콘 + 진행률
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 10) {
+                    // 버스 이모지
+                    Text("🚌")
+                        .font(.system(size: 36))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(viewModel.daysRemainingText)
+                            .font(.system(size: 13))
+                            .foregroundColor(.white.opacity(0.85))
+
+                        // 프로그레스 바
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.white.opacity(0.3))
+                                    .frame(height: 6)
+
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.white)
+                                    .frame(width: geo.size.width * viewModel.progressRate, height: 6)
+                            }
+                        }
+                        .frame(height: 6)
+                    }
                 }
-                .buttonStyle(.plain)
+
+                Text(viewModel.progressText)
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            Spacer()
+
+            // 오른쪽: 날씨 + 참여자
+            VStack(alignment: .trailing, spacing: 6) {
+                Text(viewModel.weatherLocation)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+
+                Text(viewModel.weatherDescription)
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.85))
+
+                Spacer().frame(height: 4)
+
+                Text(viewModel.participantsText)
+                    .font(.system(size: 12))
+                    .foregroundColor(.white.opacity(0.8))
             }
         }
-        .padding(.horizontal, 20)
-        .sheet(item: $selectedTripForDetail) { trip in
-            TripScheduleDetailView(trip: trip)
+        .padding(20)
+        .background(
+            LinearGradient(
+                colors: [HiTripColor.primary800, HiTripColor.secondary600],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        )
+        .cornerRadius(16)
+    }
+
+    // MARK: - Notice Card
+
+    /// 공지사항 카드 (탭 → 공지 리스트)
+    private var noticeCard: some View {
+        Button {
+            showNoticeList = true
+        } label: {
+            infoCard(emoji: "📢", title: "공지사항", content: viewModel.noticeText)
         }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Mission Card
+
+    /// 오늘의 미션 카드
+    private var missionCard: some View {
+        infoCard(emoji: "🎯", title: "오늘의 미션", content: viewModel.missionText)
+    }
+
+    /// 공통 정보 카드 (공지, 미션 등)
+    private func infoCard(emoji: String, title: String, content: String) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 4) {
+                    Text(emoji)
+                        .font(.system(size: 14))
+                    Text(title)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+
+                Text(content)
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray500)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .hiTripCard(padding: 16)
+    }
+
+    // MARK: - Today Schedule Section
+
+    /// 오늘의 일정 섹션
+    private var todayScheduleSection: some View {
+        VStack(spacing: 0) {
+            // 헤더: "오늘의 일정" + "전체 보기 >"
+            HStack {
+                Text("오늘의 일정")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Spacer()
+
+                Button {
+                    showTodaySchedule = true
+                } label: {
+                    Text("전체 보기 >")
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.accentLink)
+                }
+            }
+            .padding(.bottom, 12)
+
+            // 일정 리스트
+            VStack(spacing: 0) {
+                ForEach(Array(viewModel.todaySchedules.enumerated()), id: \.element.id) { index, schedule in
+                    HStack {
+                        HStack(spacing: 6) {
+                            Text(schedule.emoji)
+                                .font(.system(size: 16))
+                            Text(schedule.title)
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundColor(HiTripColor.textBlack)
+                        }
+
+                        Spacer()
+
+                        Text(schedule.timeText)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(HiTripColor.gray500)
+                    }
+                    .padding(.vertical, 14)
+
+                    if index < viewModel.todaySchedules.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Nearby Spot Section
+
+    /// 지금 갈만한 곳 (가로 스크롤)
+    private var nearbySpotSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // 헤더
+            HStack {
+                HStack(spacing: 4) {
+                    Text("📍")
+                        .font(.system(size: 14))
+                    Text("지금 갈만한 곳")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+
+                Spacer()
+
+                Text("가이드 추천 더보기 >")
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.accentLink)
+            }
+
+            // 가로 스크롤 카드
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(viewModel.nearbySpots) { spot in
+                        nearbySpotCard(spot)
+                    }
+                }
+                .padding(.leading, 4)
+            }
+        }
+        .hiTripCard(padding: 16)
+    }
+
+    /// 추천 ���소 개별 카드
+    private func nearbySpotCard(_ spot: TripNearbySpot) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 썸네일 placeholder
+            RoundedRectangle(cornerRadius: 12)
+                .fill(HiTripColor.gray200)
+                .frame(height: 80)
+                .overlay(
+                    Image(systemName: spotIcon(spot.category))
+                        .font(.system(size: 20))
+                        .foregroundColor(HiTripColor.gray400)
+                )
+
+            Spacer().frame(height: 8)
+
+            // 거리
+            Text(spot.distance)
+                .font(.system(size: 11))
+                .foregroundColor(HiTripColor.gray500)
+
+            Spacer().frame(height: 2)
+
+            // 장소 이름
+            Text(spot.name)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(HiTripColor.textBlack)
+                .lineLimit(1)
+        }
+        .frame(width: 100)
+    }
+
+    /// 장소 타입별 아이콘
+    private func spotIcon(_ imageName: String) -> String {
+        switch imageName {
+        case "beach":    return "water.waves"
+        case "leaf":     return "leaf.fill"
+        case "mountain": return "mountain.2.fill"
+        case "water":    return "water.waves"
+        default:         return "mappin.circle.fill"
+        }
+    }
+
+    // MARK: - Translation Card
+
+    /// 여행 필수 번역 모음
+    private var translationCard: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("여행 필수 번역 모음")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                Text(viewModel.translationPreview)
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray500)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray300)
+        }
+        .hiTripCard(padding: 16)
     }
 
     // MARK: - Emergency Banner
 
+    /// 긴급 연락망 바로가기
     private var emergencyBanner: some View {
         Button {
             showEmergency = true
         } label: {
             HStack(spacing: 14) {
-                // 아이콘 영역
-                ZStack {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(
-                            LinearGradient(
-                                colors: [Color.red.opacity(0.8), Color.orange.opacity(0.7)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 52, height: 52)
-
-                    Image(systemName: "phone.fill")
-                        .font(.system(size: 22))
-                        .foregroundColor(.white)
-                }
-
-                // 텍스트 영역
                 VStack(alignment: .leading, spacing: 4) {
                     Text("긴급 연락망")
                         .font(.system(size: 16, weight: .semibold))
@@ -178,91 +396,8 @@ struct TripListView: View {
                     .font(.system(size: 14))
                     .foregroundColor(HiTripColor.gray300)
             }
-            .padding(16)
-            .background(Color.white)
-            .cornerRadius(14)
-            .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+            .hiTripCard(padding: 16)
         }
         .buttonStyle(.plain)
-    }
-}
-
-// MARK: - TripCardRow
-
-struct TripCardRow: View {
-
-    let trip: Trip
-
-    var body: some View {
-        HStack(spacing: 14) {
-            thumbnailView
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 4) {
-                    Image(systemName: "calendar")
-                        .font(.system(size: 12))
-                    Text(formattedDate)
-                        .font(.system(size: 13))
-                }
-                .foregroundColor(HiTripColor.gray500)
-
-                Text(trip.title)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(HiTripColor.textBlack)
-
-                if !trip.location.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "mappin.circle.fill")
-                            .font(.system(size: 12))
-                        Text("위치: \(trip.location)")
-                            .font(.system(size: 13))
-                    }
-                    .foregroundColor(HiTripColor.gray400)
-                }
-            }
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: 14))
-                .foregroundColor(HiTripColor.gray300)
-        }
-        .padding(16)
-        .background(Color.white)
-        .cornerRadius(14)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
-    }
-
-    private var thumbnailView: some View {
-        RoundedRectangle(cornerRadius: 12)
-            .fill(
-                LinearGradient(
-                    colors: [HiTripColor.primary800.opacity(0.3), HiTripColor.secondary300],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .frame(width: 80, height: 80)
-            .overlay(
-                Image(systemName: thumbnailIcon)
-                    .font(.system(size: 24))
-                    .foregroundColor(.white)
-            )
-    }
-
-    private var thumbnailIcon: String {
-        switch trip.thumbnailName {
-        case "mountain": return "mountain.2.fill"
-        case "building": return "building.2.fill"
-        case "beach":    return "water.waves"
-        default:         return "photo.fill"
-        }
-    }
-
-    private var formattedDate: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy년 M월 d일"
-        return formatter.string(from: trip.date)
     }
 }


### PR DESCRIPTION
## Summary
- TripPackage 모델 생성 (여행사→그룹→여행객 데이터 구조)
- 홈 대시보드 하드코딩 제거 → TripDataStore 기반 중앙 관리
- 공지사항 리스트(NoticeListView) + 대표 공지 홈 노출
- 오늘의 일정 전체보기(TodayScheduleView) 타임라인 화면
- 전체 배경색 #F9F9F9 + 카드 컴포넌트(hiTripCard) 통일
- 강조 링크 컬러 #0C46C0(accentLink) 시스템 등록
- 홈 헤더 스크롤 영역 내부로 이동 (고정 해제)