### PR TITLE
feat: 메시지 화면 피그마 UI 재구성 — 채팅 리스트 + 채팅방 + 할일 정렬 개선

### DIFF
--- a/HiTrip/Data/Repositories/ChatRepository.swift
+++ b/HiTrip/Data/Repositories/ChatRepository.swift
@@ -14,10 +14,10 @@ import RxSwift
 /// - chatRooms: [ChatRoom] — 채팅방 목록
 /// - messages: [UUID: [Message]] — 채팅방 ID별 메시지 배열 (Dictionary)
 ///
-/// Dictionary를 쓰는 이유:
-/// - 채팅방별로 메시지를 따로 관리해야 함
-/// - messages[chatRoomId]로 해당 방의 메시지만 빠르게 조회 가능
-/// - 배열 하나에 전부 넣으면 매번 filter해야 해서 비효율
+/// Mock 데이터 설계:
+/// - 여행사가 그룹 생성 시 자동으로 2개 채팅방 개설:
+///   1. 단체톡방 (해당 여행 그룹 전원)
+///   2. 담당 가이드 개인톡
 
 final class ChatRepository: ChatRepositoryProtocol {
 
@@ -27,8 +27,140 @@ final class ChatRepository: ChatRepositoryProtocol {
     private var chatRooms: [ChatRoom] = []
 
     /// 채팅방 ID → 메시지 배열 매핑
-    /// 예: [roomA의 UUID: [메시지1, 메시지2], roomB의 UUID: [메시지3]]
     private var messages: [UUID: [Message]] = [:]
+
+    // MARK: - Init (Mock 시드 데이터)
+
+    init() {
+        seedMockData()
+    }
+
+    /// Mock 채팅방 + 메시지 시드
+    private func seedMockData() {
+        let cal = Calendar.current
+        let now = Date()
+
+        // --- 1) 단체톡방 ---
+        let groupRoomId = UUID()
+        let groupRoom = ChatRoom(
+            id: groupRoomId,
+            participantName: "제주 힐링여행 단체톡방",
+            participantType: "group",
+            isGroupChat: true,
+            lastMessage: "내일 일정 변경 공지드립니다",
+            lastMessageDate: cal.date(byAdding: .minute, value: -15, to: now) ?? now,
+            unreadCount: 3,
+            isOnline: false,
+            createdAt: cal.date(byAdding: .day, value: -5, to: now) ?? now
+        )
+
+        let groupMessages: [Message] = [
+            Message(
+                chatRoomId: groupRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "안녕하세요! 제주 힐링여행 가이드 이연세입니다 😊",
+                sentAt: cal.date(byAdding: .hour, value: -3, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: groupRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "오늘 일정 안내드립니다. 9시 호텔 로비 집합입니다!",
+                sentAt: cal.date(byAdding: .hour, value: -2, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: groupRoomId,
+                senderId: "tourist_kim",
+                senderName: "김민수",
+                content: "네 알겠습니다!",
+                sentAt: cal.date(byAdding: .minute, value: -90, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: groupRoomId,
+                senderId: "guest",
+                senderName: "사용자",
+                content: "감사합니다 가이드님",
+                sentAt: cal.date(byAdding: .minute, value: -60, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: groupRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "내일 일정 변경 공지드립니다",
+                sentAt: cal.date(byAdding: .minute, value: -15, to: now) ?? now,
+                isRead: false
+            )
+        ]
+
+        // --- 2) 가이드 개인톡 ---
+        let guideRoomId = UUID()
+        let guideRoom = ChatRoom(
+            id: guideRoomId,
+            participantName: "이연세 가이드",
+            participantType: "guide",
+            isGroupChat: false,
+            lastMessage: "혹시 알레르기 있으신 음식 있으실까요?",
+            lastMessageDate: cal.date(byAdding: .minute, value: -30, to: now) ?? now,
+            unreadCount: 1,
+            isOnline: true,
+            createdAt: cal.date(byAdding: .day, value: -5, to: now) ?? now
+        )
+
+        let guideMessages: [Message] = [
+            Message(
+                chatRoomId: guideRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "안녕하세요! 담당 가이드 이연세입니다.",
+                sentAt: cal.date(byAdding: .hour, value: -4, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: guideRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "여행 중 궁금하신 점이나 불편한 사항이 있으시면 언제든 연락주세요 😊",
+                sentAt: cal.date(byAdding: .hour, value: -4, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: guideRoomId,
+                senderId: "guest",
+                senderName: "사용자",
+                content: "네 감사합니다! 내일 점심 장소는 어디인가요?",
+                sentAt: cal.date(byAdding: .hour, value: -1, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: guideRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "내일 점심은 제주 흑돼지 맛집으로 예약해두었습니다!",
+                sentAt: cal.date(byAdding: .minute, value: -45, to: now) ?? now,
+                isRead: true
+            ),
+            Message(
+                chatRoomId: guideRoomId,
+                senderId: "guide_lee",
+                senderName: "이연세 가이드",
+                content: "혹시 알레르기 있으신 음식 있으실까요?",
+                sentAt: cal.date(byAdding: .minute, value: -30, to: now) ?? now,
+                isRead: false
+            )
+        ]
+
+        // 저장
+        chatRooms = [groupRoom, guideRoom]
+        messages = [
+            groupRoomId: groupMessages,
+            guideRoomId: guideMessages
+        ]
+    }
 
     // MARK: - ChatRoom CRUD
 
@@ -36,7 +168,7 @@ final class ChatRepository: ChatRepositoryProtocol {
     func createRoom(room: ChatRoom) -> Single<ChatRoom> {
         return Single.create { [weak self] single in
             self?.chatRooms.append(room)
-            self?.messages[room.id] = []  // 빈 메시지 배열 초기화
+            self?.messages[room.id] = []
             single(.success(room))
             return Disposables.create()
         }
@@ -63,7 +195,7 @@ final class ChatRepository: ChatRepositoryProtocol {
 
             if let index = self.chatRooms.firstIndex(where: { $0.id == id }) {
                 self.chatRooms.remove(at: index)
-                self.messages.removeValue(forKey: id)  // 메시지도 함께 삭제
+                self.messages.removeValue(forKey: id)
                 single(.success(()))
             } else {
                 single(.failure(ChatError.roomNotFound))
@@ -75,8 +207,6 @@ final class ChatRepository: ChatRepositoryProtocol {
     // MARK: - Message CRUD
 
     /// 메시지 전송
-    /// 1. 메시지를 해당 채팅방 배열에 추가
-    /// 2. 채팅방의 lastMessage, lastMessageDate 갱신
     func sendMessage(message: Message) -> Single<Message> {
         return Single.create { [weak self] single in
             guard let self else {
@@ -120,7 +250,6 @@ final class ChatRepository: ChatRepositoryProtocol {
                 return Disposables.create()
             }
 
-            // 메시지 읽음 처리
             if var roomMessages = self.messages[chatRoomId] {
                 for i in 0..<roomMessages.count {
                     roomMessages[i].isRead = true
@@ -128,7 +257,6 @@ final class ChatRepository: ChatRepositoryProtocol {
                 self.messages[chatRoomId] = roomMessages
             }
 
-            // 채팅방 unreadCount 초기화
             if let roomIndex = self.chatRooms.firstIndex(where: { $0.id == chatRoomId }) {
                 self.chatRooms[roomIndex].unreadCount = 0
             }

--- a/HiTrip/Domain/Entities/ChatRoom.swift
+++ b/HiTrip/Domain/Entities/ChatRoom.swift
@@ -20,21 +20,21 @@ import Foundation
 /// Codable 채택 이유:
 /// - 추후 서버 JSON ↔ Swift 변환용
 
-struct ChatRoom: Identifiable, Codable, Equatable {
+struct ChatRoom: Identifiable, Codable, Equatable, Hashable {
 
     /// 고유 식별자
     let id: UUID
 
-    /// 상대방 이름 — 채팅 목록에 표시
-    /// 예: "김안내", "박관광"
+    /// 채팅방 이름 — 단체톡: "여행 단체톡방", 개인톡: 상대방 이름
     var participantName: String
 
-    /// 상대방 유형 — "guide" 또는 "tourist"
-    /// 목록에서 안내사/관광객 배지 표시에 사용
+    /// 채팅방 유형 — "guide"(가이드 개인톡) 또는 "group"(단체톡방)
     var participantType: String
 
+    /// 단체톡방 여부
+    var isGroupChat: Bool
+
     /// 마지막 메시지 내용 — 목록 미리보기
-    /// 예: "내일 9시에 만나요!"
     var lastMessage: String
 
     /// 마지막 메시지 시간 — 목록 정렬 기준
@@ -43,6 +43,9 @@ struct ChatRoom: Identifiable, Codable, Equatable {
     /// 읽지 않은 메시지 수 — 뱃지 숫자 표시
     var unreadCount: Int
 
+    /// 온라인 상태 (개인톡에서만 사용)
+    var isOnline: Bool
+
     /// 채팅방 생성 시간
     let createdAt: Date
 
@@ -50,18 +53,22 @@ struct ChatRoom: Identifiable, Codable, Equatable {
     init(
         id: UUID = UUID(),
         participantName: String,
-        participantType: String,
+        participantType: String = "guide",
+        isGroupChat: Bool = false,
         lastMessage: String = "",
         lastMessageDate: Date = Date(),
         unreadCount: Int = 0,
+        isOnline: Bool = false,
         createdAt: Date = Date()
     ) {
         self.id = id
         self.participantName = participantName
         self.participantType = participantType
+        self.isGroupChat = isGroupChat
         self.lastMessage = lastMessage
         self.lastMessageDate = lastMessageDate
         self.unreadCount = unreadCount
+        self.isOnline = isOnline
         self.createdAt = createdAt
     }
 }

--- a/HiTrip/Features/Chat/Views/ChatListView.swift
+++ b/HiTrip/Features/Chat/Views/ChatListView.swift
@@ -1,52 +1,71 @@
 import SwiftUI
 
 // MARK: - ChatListView
-/// 채팅방 목록 화면
+/// 메시지 목록 화면
 ///
-/// 카카오톡 채팅 목록과 유사한 구조:
-/// - 상대방 이름, 마지막 메시지, 시간, 읽지 않은 수 표시
-/// - 탭하면 ChatRoomView로 이동
-/// - 스와이프로 채팅방 삭제
-/// - 우상단 + 버튼으로 새 채팅방 생성
+/// 피그마 디자인:
+/// - 상단: ← "메시지" ... (네비게이션)
+/// - "메시지 및 문의" 헤더 + 새 메시지 아이콘
+/// - 검색바
+/// - 채팅방 리스트 (단체톡방 + 가이드 개인톡)
 ///
-/// ScheduleListView와 동일한 패턴:
-/// - @ObservedObject로 ViewModel 관찰
-/// - .onAppear에서 데이터 로드
-/// - .sheet로 생성 화면 표시
+/// 여행사가 그룹을 만들면 자동으로 단체톡방과 가이드 개인톡이 생성됨.
+/// 사용자가 직접 채팅방을 만들 수는 없음.
 
 struct ChatListView: View {
 
     @ObservedObject var viewModel: ChatViewModel
-    @State private var showCreateSheet = false
+    @State private var navigateToRoom: Bool = false
     @State private var selectedRoom: ChatRoom?
+    @State private var searchText: String = ""
+
+    /// 검색 필터 적용
+    private var filteredRooms: [ChatRoom] {
+        if searchText.isEmpty {
+            return viewModel.chatRooms
+        }
+        return viewModel.chatRooms.filter {
+            $0.participantName.localizedCaseInsensitiveContains(searchText) ||
+            $0.lastMessage.localizedCaseInsensitiveContains(searchText)
+        }
+    }
 
     var body: some View {
         NavigationStack {
-            Group {
-                if viewModel.chatRooms.isEmpty {
+            VStack(spacing: 0) {
+                // "메시지 및 문의" 헤더
+                sectionHeader
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+
+                // 검색바
+                searchBar
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+
+                // 채팅방 리스트
+                if filteredRooms.isEmpty {
                     emptyStateView
                 } else {
                     chatRoomList
                 }
+
+                Spacer()
             }
-            .navigationTitle("채팅")
+            .background(HiTripColor.screenBackground)
+            .navigationTitle("메시지")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        showCreateSheet = true
-                    } label: {
-                        Image(systemName: "plus")
+                    Button { } label: {
+                        Image(systemName: "ellipsis")
+                            .foregroundColor(HiTripColor.textBlack)
                     }
                 }
             }
-            .sheet(isPresented: $showCreateSheet) {
-                ChatCreateView(viewModel: viewModel)
-            }
-            .onChange(of: showCreateSheet) { isPresented in
-                // 시트가 닫힐 때 목록 새로고침
-                if !isPresented {
-                    viewModel.fetchChatRooms()
-                    viewModel.resetForm()
+            .navigationDestination(isPresented: $navigateToRoom) {
+                if let room = selectedRoom {
+                    ChatRoomView(viewModel: viewModel, chatRoom: room)
                 }
             }
             .onAppear {
@@ -55,82 +74,115 @@ struct ChatListView: View {
         }
     }
 
-    // MARK: - 채팅방 목록
+    // MARK: - Section Header
 
-    private var chatRoomList: some View {
-        List {
-            ForEach(viewModel.chatRooms) { room in
-                Button {
-                    selectedRoom = room
-                } label: {
-                    chatRoomRow(room)
-                }
-                .buttonStyle(.plain)
-            }
-            .onDelete { indexSet in
-                for index in indexSet {
-                    let room = viewModel.chatRooms[index]
-                    viewModel.deleteChatRoom(id: room.id)
-                }
-            }
-        }
-        .listStyle(.plain)
-        .sheet(item: $selectedRoom) { room in
-            ChatRoomView(viewModel: viewModel, chatRoom: room)
+    private var sectionHeader: some View {
+        HStack {
+            Text("메시지 및 문의")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Spacer()
+
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 18))
+                .foregroundColor(HiTripColor.textBlack)
         }
     }
 
-    // MARK: - 채팅방 행 (Row)
+    // MARK: - Search Bar
 
-    /// 각 채팅방의 한 줄 표시
-    /// - 왼쪽: 이니셜 아바타 + 이름 + 마지막 메시지
-    /// - 오른쪽: 시간 + 읽지 않은 수 뱃지
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray400)
+
+            TextField("채팅 및 메시지 검색", text: $searchText)
+                .font(.system(size: 14))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(HiTripColor.gray100)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Chat Room List
+
+    private var chatRoomList: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(filteredRooms) { room in
+                    Button {
+                        selectedRoom = room
+                        navigateToRoom = true
+                    } label: {
+                        chatRoomRow(room)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    // MARK: - Chat Room Row
+
     private func chatRoomRow(_ room: ChatRoom) -> some View {
-        HStack(spacing: 12) {
-            // 아바타 (이니셜)
-            Circle()
-                .fill(HiTripColor.primary800.opacity(0.15))
-                .frame(width: 48, height: 48)
-                .overlay(
-                    Text(String(room.participantName.prefix(1)))
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundColor(HiTripColor.primary800)
-                )
+        HStack(spacing: 14) {
+            // 아바타 + 온라인 표시
+            ZStack(alignment: .bottomLeading) {
+                Circle()
+                    .fill(HiTripColor.gray200)
+                    .frame(width: 52, height: 52)
+                    .overlay(
+                        Image(systemName: room.isGroupChat ? "person.3.fill" : "person.fill")
+                            .font(.system(size: room.isGroupChat ? 18 : 20))
+                            .foregroundColor(HiTripColor.gray400)
+                    )
+
+                // 온라인 도트
+                if room.isOnline {
+                    Circle()
+                        .fill(Color.yellow)
+                        .frame(width: 12, height: 12)
+                        .overlay(
+                            Circle().stroke(Color.white, lineWidth: 2)
+                        )
+                        .offset(x: 2, y: -2)
+                }
+            }
 
             // 이름 + 마지막 메시지
             VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(room.participantName)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(HiTripColor.textGrayA)
-
-                    // 안내사/관광객 배지
-                    Text(room.participantType == "guide" ? "안내사" : "관광객")
-                        .font(.system(size: 10))
-                        .foregroundColor(HiTripColor.primary800)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(HiTripColor.secondary100)
-                        .cornerRadius(4)
-                }
+                Text(room.participantName)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
 
                 Text(room.lastMessage.isEmpty ? "새로운 채팅방" : room.lastMessage)
-                    .font(.system(size: 14))
-                    .foregroundColor(HiTripColor.gray400)
+                    .font(.system(size: 13))
+                    .foregroundColor(HiTripColor.gray500)
                     .lineLimit(1)
             }
 
             Spacer()
 
-            // 시간 + 읽지 않은 수
-            VStack(alignment: .trailing, spacing: 6) {
-                Text(formatDate(room.lastMessageDate))
-                    .font(.system(size: 12))
-                    .foregroundColor(HiTripColor.gray400)
+            // 읽음 체크 + 시간
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 2) {
+                    // 읽음 체크마크
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(HiTripColor.gray400)
+
+                    Text(formatTime(room.lastMessageDate))
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray400)
+                }
 
                 if room.unreadCount > 0 {
                     Text("\(room.unreadCount)")
-                        .font(.system(size: 12, weight: .bold))
+                        .font(.system(size: 11, weight: .bold))
                         .foregroundColor(.white)
                         .frame(minWidth: 20, minHeight: 20)
                         .background(HiTripColor.error)
@@ -138,37 +190,39 @@ struct ChatListView: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
     }
 
-    // MARK: - 빈 상태
+    // MARK: - Empty State
 
     private var emptyStateView: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 12) {
             Spacer()
             Image(systemName: "bubble.left.and.bubble.right")
-                .font(.system(size: 48))
+                .font(.system(size: 40))
                 .foregroundColor(HiTripColor.gray300)
-            Text("채팅방이 없습니다")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(HiTripColor.textGrayA)
-            Text("+ 버튼을 눌러 새 채팅을 시작해보세요")
+
+            Text("메시지가 없습니다")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(HiTripColor.textBlack)
+
+            Text("여행사에서 채팅방을 개설하면\n여기에 표시됩니다")
                 .font(.system(size: 14))
-                .foregroundColor(HiTripColor.gray400)
+                .foregroundColor(HiTripColor.gray500)
+                .multilineTextAlignment(.center)
             Spacer()
         }
     }
 
-    // MARK: - 날짜 포맷
+    // MARK: - Time Format
 
-    /// 오늘이면 "오후 3:42", 아니면 "3/21"
-    private func formatDate(_ date: Date) -> String {
-        let calendar = Calendar.current
+    private func formatTime(_ date: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
-
+        let calendar = Calendar.current
         if calendar.isDateInToday(date) {
-            formatter.dateFormat = "a h:mm"
+            formatter.dateFormat = "HH:mm"
         } else {
             formatter.dateFormat = "M/d"
         }

--- a/HiTrip/Features/Chat/Views/ChatRoomView.swift
+++ b/HiTrip/Features/Chat/Views/ChatRoomView.swift
@@ -3,14 +3,14 @@ import SwiftUI
 // MARK: - ChatRoomView
 /// 채팅 메시지 화면 (대화창)
 ///
-/// 카카오톡 대화방과 유사한 구조:
-/// - 내 메시지: 오른쪽 (파란 말풍선)
-/// - 상대 메시지: 왼쪽 (회색 말풍선)
-/// - 하단 고정: 메시지 입력창 + 전송 버튼
-///
-/// 새로운 SwiftUI 패턴:
-/// - ScrollViewReader: 새 메시지 전송 시 자동 스크롤
-/// - safeAreaInset: 입력창을 하단에 고정
+/// 피그마 디자인:
+/// - 상단: ← "이름" (활동중 표시) 전화 아이콘
+/// - "오늘" 날짜 구분선
+/// - 메시지 말풍선:
+///   - 내 메시지: 연한 파란 배경 (#ECF2FE), 오른쪽 정렬
+///   - 상대 메시지: 회색 배경, 왼쪽 정렬 + 아바타
+/// - 읽음 표시: 초록 ✓✓
+/// - 하단: "메시지를 입력하세요" + 첨부 아이콘 + 파란 마이크 버튼
 
 struct ChatRoomView: View {
 
@@ -20,48 +20,98 @@ struct ChatRoomView: View {
     let chatRoom: ChatRoom
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 0) {
-                // MARK: - 메시지 목록
-                messageList
+        VStack(spacing: 0) {
+            // 커스텀 네비게이션 바
+            chatNavigationBar
 
-                // MARK: - 입력창
-                messageInputBar
-            }
-            .navigationTitle(chatRoom.participantName)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "chevron.left")
-                    }
-                }
-            }
-            .onAppear {
-                viewModel.fetchMessages(chatRoomId: chatRoom.id)
-                viewModel.markAsRead(chatRoomId: chatRoom.id)
-            }
+            Divider()
+
+            // 메시지 목록
+            messageList
+
+            // 입력창
+            messageInputBar
+        }
+        .background(HiTripColor.screenBackground)
+        .navigationBarHidden(true)
+        .onAppear {
+            viewModel.fetchMessages(chatRoomId: chatRoom.id)
+            viewModel.markAsRead(chatRoomId: chatRoom.id)
         }
     }
 
-    // MARK: - 메시지 목록
+    // MARK: - Custom Navigation Bar
+
+    private var chatNavigationBar: some View {
+        HStack(spacing: 12) {
+            // 뒤로가기
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(HiTripColor.textBlack)
+            }
+
+            // 이름 + 활동 상태
+            VStack(alignment: .leading, spacing: 2) {
+                Text(chatRoom.participantName)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                if chatRoom.isOnline && !chatRoom.isGroupChat {
+                    Text("활동중")
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.readCheck)
+                }
+            }
+
+            Spacer()
+
+            // 전화 아이콘 (개인톡만)
+            if !chatRoom.isGroupChat {
+                Button { } label: {
+                    Image(systemName: "phone")
+                        .font(.system(size: 18))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+
+            // 더보기
+            Button { } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 18))
+                    .foregroundColor(HiTripColor.textBlack)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.white)
+    }
+
+    // MARK: - Message List
 
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 8) {
-                    ForEach(viewModel.messages) { message in
-                        messageBubble(message)
+                LazyVStack(spacing: 0) {
+                    // 날짜 구분선
+                    dateSeparator
+
+                    ForEach(Array(viewModel.messages.enumerated()), id: \.element.id) { index, message in
+                        let isMe = viewModel.isMyMessage(message)
+                        let showAvatar = shouldShowAvatar(at: index)
+                        let showTime = shouldShowTime(at: index)
+
+                        messageBubble(message, isMe: isMe, showAvatar: showAvatar, showTime: showTime)
                             .id(message.id)
+                            .padding(.top, showAvatar ? 12 : 4)
                     }
                 }
                 .padding(.horizontal, 16)
-                .padding(.vertical, 8)
+                .padding(.bottom, 12)
             }
             .onChange(of: viewModel.messages.count) { _ in
-                // 새 메시지가 추가되면 자동으로 맨 아래로 스크롤
                 if let lastMessage = viewModel.messages.last {
                     withAnimation(.easeOut(duration: 0.3)) {
                         proxy.scrollTo(lastMessage.id, anchor: .bottom)
@@ -71,90 +121,191 @@ struct ChatRoomView: View {
         }
     }
 
-    // MARK: - 말풍선
+    // MARK: - Date Separator
 
-    /// 내 메시지 / 상대 메시지에 따라 좌우 배치 + 색상 변경
-    private func messageBubble(_ message: Message) -> some View {
-        let isMe = viewModel.isMyMessage(message)
+    private var dateSeparator: some View {
+        HStack {
+            line
+            Text(dateSeparatorText)
+                .font(.system(size: 12))
+                .foregroundColor(HiTripColor.gray400)
+                .padding(.horizontal, 12)
+            line
+        }
+        .padding(.vertical, 16)
+    }
 
-        return HStack(alignment: .bottom, spacing: 8) {
+    private var line: some View {
+        Rectangle()
+            .fill(HiTripColor.gray200)
+            .frame(height: 0.5)
+    }
+
+    /// 날짜 구분 텍스트 ("오늘", "어제", "5월 3일" 등)
+    private var dateSeparatorText: String {
+        guard let firstMessage = viewModel.messages.first else { return "오늘" }
+        let cal = Calendar.current
+        if cal.isDateInToday(firstMessage.sentAt) {
+            return "오늘"
+        } else if cal.isDateInYesterday(firstMessage.sentAt) {
+            return "어제"
+        } else {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "ko_KR")
+            formatter.dateFormat = "M월 d일"
+            return formatter.string(from: firstMessage.sentAt)
+        }
+    }
+
+    // MARK: - Message Bubble
+
+    private func messageBubble(_ message: Message, isMe: Bool, showAvatar: Bool, showTime: Bool) -> some View {
+        HStack(alignment: .bottom, spacing: 6) {
             if isMe {
                 Spacer(minLength: 60)
 
-                // 시간 (왼쪽)
-                messageTime(message.sentAt)
+                // 읽음 표시 + 시간 (왼쪽)
+                VStack(alignment: .trailing, spacing: 2) {
+                    if showTime {
+                        // 읽음 체크 (✓✓)
+                        if message.isRead {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundColor(HiTripColor.readCheck)
+                        }
 
-                // 내 말풍선 (오른쪽, 파란색)
+                        Text(formatTime(message.sentAt))
+                            .font(.system(size: 11))
+                            .foregroundColor(HiTripColor.gray400)
+                    }
+                }
+
+                // 내 말풍선 (연한 파란 배경)
                 Text(message.content)
                     .font(.system(size: 15))
-                    .foregroundColor(.white)
+                    .foregroundColor(HiTripColor.textBlack)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
-                    .background(HiTripColor.primary800)
+                    .background(HiTripColor.secondary100)
                     .cornerRadius(16)
                     .cornerRadius(4, corners: .bottomRight)
+
             } else {
-                // 상대 말풍선 (왼쪽, 회색)
-                Text(message.content)
-                    .font(.system(size: 15))
-                    .foregroundColor(HiTripColor.textGrayA)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
-                    .background(HiTripColor.gray100)
-                    .cornerRadius(16)
-                    .cornerRadius(4, corners: .bottomLeft)
+                // 아바타 (첫 메시지 or 발신자 변경 시)
+                if showAvatar {
+                    Circle()
+                        .fill(HiTripColor.gray200)
+                        .frame(width: 36, height: 36)
+                        .overlay(
+                            Image(systemName: chatRoom.isGroupChat ? "person.fill" : "person.fill")
+                                .font(.system(size: 14))
+                                .foregroundColor(HiTripColor.gray400)
+                        )
+                } else {
+                    Spacer().frame(width: 36)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    // 이름 (아바타 표시 시에만)
+                    if showAvatar && chatRoom.isGroupChat {
+                        Text(message.senderName)
+                            .font(.system(size: 12))
+                            .foregroundColor(HiTripColor.gray500)
+                    }
+
+                    // 상대 말풍선 (회색 배경)
+                    Text(message.content)
+                        .font(.system(size: 15))
+                        .foregroundColor(HiTripColor.textGrayA)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(HiTripColor.gray100)
+                        .cornerRadius(16)
+                        .cornerRadius(4, corners: .bottomLeft)
+                }
 
                 // 시간 (오른쪽)
-                messageTime(message.sentAt)
+                if showTime {
+                    Text(formatTime(message.sentAt))
+                        .font(.system(size: 11))
+                        .foregroundColor(HiTripColor.gray400)
+                }
 
                 Spacer(minLength: 60)
             }
         }
     }
 
-    /// 시간 표시 ("오후 3:42")
-    private func messageTime(_ date: Date) -> some View {
-        Text(formatTime(date))
-            .font(.system(size: 11))
-            .foregroundColor(HiTripColor.gray400)
-    }
+    // MARK: - Input Bar
 
-    // MARK: - 입력창
-
-    /// 하단 고정 메시지 입력 바
     private var messageInputBar: some View {
         VStack(spacing: 0) {
             Divider()
 
-            HStack(spacing: 12) {
+            HStack(spacing: 10) {
+                // 첨부 버튼
+                Button { } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(HiTripColor.gray400)
+                }
+
+                // 텍스트 입력
                 TextField("메시지를 입력하세요", text: $viewModel.messageText)
                     .font(.system(size: 15))
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                     .background(HiTripColor.gray100)
                     .cornerRadius(20)
 
-                // 전송 버튼
-                Button {
-                    viewModel.sendMessage(chatRoomId: chatRoom.id)
-                } label: {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 32))
-                        .foregroundColor(
-                            viewModel.isMessageValid
-                                ? HiTripColor.primary800
-                                : HiTripColor.gray300
-                        )
+                // 전송/마이크 버튼
+                if viewModel.isMessageValid {
+                    Button {
+                        viewModel.sendMessage(chatRoomId: chatRoom.id)
+                    } label: {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 32))
+                            .foregroundColor(HiTripColor.primary800)
+                    }
+                } else {
+                    Button { } label: {
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 18))
+                            .foregroundColor(.white)
+                            .frame(width: 36, height: 36)
+                            .background(HiTripColor.primary800)
+                            .clipShape(Circle())
+                    }
                 }
-                .disabled(!viewModel.isMessageValid)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
         }
-        .background(Color(UIColor.systemBackground))
+        .background(Color.white)
     }
 
-    // MARK: - 시간 포맷
+    // MARK: - Helpers
+
+    /// 아바타 표시 여부: 첫 메시지거나 이전 메시지의 발신자가 다를 때
+    private func shouldShowAvatar(at index: Int) -> Bool {
+        let message = viewModel.messages[index]
+        if viewModel.isMyMessage(message) { return false }
+        if index == 0 { return true }
+        let prev = viewModel.messages[index - 1]
+        return prev.senderId != message.senderId
+    }
+
+    /// 시간 표시 여부: 마지막 메시지거나 다음 메시지와 시간이 다를 때
+    private func shouldShowTime(at index: Int) -> Bool {
+        if index == viewModel.messages.count - 1 { return true }
+        let current = viewModel.messages[index]
+        let next = viewModel.messages[index + 1]
+        // 발신자가 다르면 항상 표시
+        if current.senderId != next.senderId { return true }
+        // 같은 발신자라도 분이 다르면 표시
+        let cal = Calendar.current
+        return cal.component(.minute, from: current.sentAt) != cal.component(.minute, from: next.sentAt)
+    }
 
     private func formatTime(_ date: Date) -> String {
         let formatter = DateFormatter()
@@ -166,9 +317,6 @@ struct ChatRoomView: View {
 
 // MARK: - 특정 모서리만 둥글게 하는 Extension
 /// .cornerRadius(4, corners: .bottomRight) 같은 사용을 위한 헬퍼
-///
-/// SwiftUI 기본 .cornerRadius()는 4개 모서리 전부 둥글게 함
-/// 카톡 말풍선은 한쪽 모서리만 뾰족해야 하므로 이 Extension 필요
 
 extension View {
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -162,6 +162,7 @@ final class TripDataStore: ObservableObject {
             $0.section == section &&
             cal.isDate($0.date, inSameDayAs: date)
         }
+        .sorted { !$0.isCompleted && $1.isCompleted }
     }
 
     /// 특정 날짜의 전체 투두 (모든 Trip)


### PR DESCRIPTION
채팅 UI를 피그마 디자인에 맞춰 전면 재작성하고, 여행사→그룹→여행객 채팅 구조를 반영합니다.

- ChatListView: 검색바, "메시지 및 문의" 헤더, 아바타/온라인 상태/읽음 표시 적용
- ChatRoomView: 커스텀 네비바(활동중 상태, 전화 아이콘), 날짜 구분선, 연한 파란 내 말풍선(#ECF2FE), 읽음 체크, 마이크/전송 전환 입력바
- ChatRepository: 단체톡방 + 가이드 개인톡 Mock 시드 데이터 추가
- ChatRoom: Hashable 채택, isGroupChat/isOnline 필드 활용
- TripDataStore: 완료된 할일 카테고리 내 하단 이동 정렬