### PR TITLE
feat: 서버 API 연동 + 커스텀 에러 시스템 + 데이터 플로우 개선

### DIFF
--- a/HiTrip.xcodeproj/project.pbxproj
+++ b/HiTrip.xcodeproj/project.pbxproj
@@ -27,9 +27,22 @@
 		917DC0572F67DDA500D5DAA8 /* HiTripTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HiTripTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		917736B82FD0370300DAF483 /* Exceptions for "HiTrip" folder in "HiTrip" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 917DBFCA2F557C9D00D5DAA8 /* HiTrip */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		917DBFCD2F557C9D00D5DAA8 /* HiTrip */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				917736B82FD0370300DAF483 /* Exceptions for "HiTrip" folder in "HiTrip" target */,
+			);
 			path = HiTrip;
 			sourceTree = "<group>";
 		};
@@ -355,6 +368,7 @@
 				DEVELOPMENT_TEAM = SDBJF5F47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = HiTrip/Info.plist;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "주변 관광지 검색을 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -392,6 +406,7 @@
 				DEVELOPMENT_TEAM = SDBJF5F47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = HiTrip/Info.plist;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "주변 관광지 검색을 위해 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -48,9 +48,13 @@ final class AppDIContainer {
         AuthRepository(networkService: networkService)
     }()
 
-    /// 일정 Repository — 현재 메모리 저장, 나중에 서버 연동으로 교체
+    /// 일정 Repository — 환경에 따라 Mock ↔ Remote 전환
     private lazy var scheduleRepository: ScheduleRepositoryProtocol = {
-        ScheduleRepository()
+        if APIEnvironment.current.useMock {
+            return ScheduleRepository()
+        } else {
+            return RemoteScheduleRepository(networkService: networkService)
+        }
     }()
 
     /// 채팅 Repository — 현재 메모리 저장, 나중에 WebSocket으로 교체
@@ -63,10 +67,14 @@ final class AppDIContainer {
         EmergencyRepository()
     }()
 
-    /// 여행(Trip/Todo/Event) Repository — 현재 Mock, 나중에 서버 연동으로 교체
+    /// 여행(Trip/Todo/Event) Repository — 환경에 따라 Mock ↔ Remote 전환
     /// TripDataStore.shared가 내부적으로 직접 참조하므로 DI 등록은 참조용
     private lazy var tripRepository: TripRepositoryProtocol = {
-        MockTripRepository()
+        if APIEnvironment.current.useMock {
+            return MockTripRepository()
+        } else {
+            return RemoteTripRepository(networkService: networkService)
+        }
     }()
 
     /// 관광지 Repository — TourAPI 실제 연동

--- a/HiTrip/Core/Extensions/RxSwift+ErrorHandling.swift
+++ b/HiTrip/Core/Extensions/RxSwift+ErrorHandling.swift
@@ -1,0 +1,179 @@
+import Foundation
+import RxSwift
+import RxRelay
+
+// MARK: - Single + HiTripError 편의 Operator
+/// ViewModel에서 반복되는 에러 처리 패턴을 간결하게 작성할 수 있는 확장
+///
+/// Before (반복 코드):
+/// ```swift
+/// useCase.fetchTrips()
+///     .observe(on: MainScheduler.instance)
+///     .subscribe(
+///         onSuccess: { trips in self.trips = trips },
+///         onFailure: { error in
+///             let htError = ErrorHandler.classify(error)
+///             self.errorHandler.handle(error)
+///             if htError.isRetryable { ... }
+///         }
+///     )
+/// ```
+///
+/// After (간결):
+/// ```swift
+/// useCase.fetchTrips()
+///     .withErrorHandling(errorHandler, context: "여행 목록 조회")
+///     .subscribe(onSuccess: { trips in self.trips = trips })
+/// ```
+
+extension PrimitiveSequence where Trait == SingleTrait {
+
+    // MARK: - 에러 핸들링 연결
+
+    /// ErrorHandler와 연결하여 에러 자동 처리
+    /// - Parameters:
+    ///   - handler: 에러를 처리할 ErrorHandler
+    ///   - context: 로그에 표시할 작업 이름 (예: "여행 목록 조회")
+    /// - Returns: 에러 발생 시 ErrorHandler에 전달하고 에러를 전파하는 Single
+    func withErrorHandling(
+        _ handler: ErrorHandler,
+        context: String? = nil
+    ) -> Single<Element> {
+        self.do(onError: { error in
+            handler.handle(error, context: context)
+        })
+        .observe(on: MainScheduler.instance)
+    }
+
+    /// 에러 발생 시 ErrorHandler에 전달하되, fallback 값으로 대체
+    /// - Parameters:
+    ///   - handler: 에러를 처리할 ErrorHandler
+    ///   - fallback: 에러 시 사용할 대체 값
+    ///   - context: 로그에 표시할 작업 이름
+    /// - Returns: 에러 발생 시 fallback 값을 방출하는 Single
+    func withErrorFallback(
+        _ handler: ErrorHandler,
+        fallback: Element,
+        context: String? = nil
+    ) -> Single<Element> {
+        self.do(onError: { error in
+            handler.handle(error, context: context)
+        })
+        .catch { _ in .just(fallback) }
+        .observe(on: MainScheduler.instance)
+    }
+
+    /// 에러 발생 시 조용히 로깅만 하고 fallback 값으로 대체
+    /// - 사용자에게 Alert를 표시하지 않는 경우 (백그라운드 로딩 등)
+    func withSilentFallback(
+        _ handler: ErrorHandler,
+        fallback: Element,
+        context: String? = nil
+    ) -> Single<Element> {
+        self.do(onError: { error in
+            handler.handleSilently(error, context: context)
+        })
+        .catch { _ in .just(fallback) }
+        .observe(on: MainScheduler.instance)
+    }
+
+    // MARK: - 자동 재시도
+
+    /// 재시도 가능한 에러에 대해 자동 재시도 (지수 백오프)
+    /// - Parameters:
+    ///   - maxRetries: 최대 재시도 횟수 (기본 2)
+    ///   - delay: 초기 지연 시간 (초, 기본 1.0 → 2회차 2.0 → 3회차 4.0)
+    /// - Returns: 재시도 로직이 적용된 Single
+    func retryOnNetworkError(
+        maxRetries: Int = 2,
+        delay: Double = 1.0
+    ) -> Single<Element> {
+        self.retry(when: { errors in
+            errors.enumerated().flatMap { attempt, error -> Observable<Void> in
+                // 최대 재시도 초과 시 에러 전파
+                guard attempt < maxRetries else {
+                    return .error(error)
+                }
+
+                // 재시도 가능한 에러만 재시도
+                let htError = ErrorHandler.classify(error)
+                guard htError.isRetryable else {
+                    return .error(error)
+                }
+
+                // 지수 백오프: 1초 → 2초 → 4초
+                let retryDelay = delay * pow(2.0, Double(attempt))
+                print("🔄 [Retry] \(attempt + 1)/\(maxRetries) — \(retryDelay)초 후 재시도 | \(htError.debugDescription)")
+
+                return Observable<Void>.just(())
+                    .delay(.milliseconds(Int(retryDelay * 1000)), scheduler: MainScheduler.instance)
+            }
+        })
+    }
+
+    // MARK: - isLoading 바인딩
+
+    /// 로딩 상태를 BehaviorRelay에 자동 바인딩
+    /// - Parameter relay: true/false를 방출할 로딩 Relay
+    /// - Returns: 구독 시작 시 true, 완료/에러 시 false를 방출하는 Single
+    func trackLoading(_ relay: BehaviorRelay<Bool>) -> Single<Element> {
+        self.do(
+            onSubscribe: { relay.accept(true) },
+            onDispose: { relay.accept(false) }
+        )
+    }
+}
+
+// MARK: - Observable + Error Handling
+
+extension ObservableType {
+
+    /// ErrorHandler와 연결하여 에러 자동 처리
+    func withErrorHandling(
+        _ handler: ErrorHandler,
+        context: String? = nil
+    ) -> Observable<Element> {
+        self.do(onError: { error in
+            handler.handle(error, context: context)
+        })
+        .observe(on: MainScheduler.instance)
+    }
+}
+
+// MARK: - DisposeBag + 편의 구독
+
+extension PrimitiveSequence where Trait == SingleTrait {
+
+    /// ErrorHandler 연결 + 성공 핸들러만 작성하는 간편 구독
+    ///
+    /// 사용법:
+    /// ```swift
+    /// useCase.fetchTrips()
+    ///     .handleAndSubscribe(
+    ///         errorHandler: errorHandler,
+    ///         disposeBag: disposeBag,
+    ///         context: "여행 목록",
+    ///         onSuccess: { [weak self] trips in
+    ///             self?.trips.accept(trips)
+    ///         }
+    ///     )
+    /// ```
+    @discardableResult
+    func handleAndSubscribe(
+        errorHandler: ErrorHandler,
+        disposeBag: DisposeBag,
+        context: String? = nil,
+        onSuccess: @escaping (Element) -> Void
+    ) -> Disposable {
+        let disposable = self
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: onSuccess,
+                onFailure: { error in
+                    errorHandler.handle(error, context: context)
+                }
+            )
+        disposable.disposed(by: disposeBag)
+        return disposable
+    }
+}

--- a/HiTrip/Core/Network/APIEndpoint+Places.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Places.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+// MARK: - Places Endpoints
+/// 장소 관련 API 엔드포인트
+///
+/// 백엔드: /api/places/, /api/recommendations/, /api/categories/
+
+extension APIEndpoint {
+
+    // MARK: - Places
+
+    /// 장소 목록 조회
+    /// - GET /api/places/
+    static func placesList() -> APIEndpoint {
+        APIEndpoint(path: "/api/places/")
+    }
+
+    /// 장소 상세 조회
+    /// - GET /api/places/:id/
+    static func placesRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(id)/")
+    }
+
+    /// 장소 생성
+    /// - POST /api/places/
+    static func placesCreate(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/", method: .post, body: body)
+    }
+
+    /// 장소 수정
+    /// - PUT /api/places/:id/
+    static func placesUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(id)/", method: .put, body: body)
+    }
+
+    /// 장소 부분 수정
+    /// - PATCH /api/places/:id/
+    static func placesPartialUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(id)/", method: .patch, body: body)
+    }
+
+    /// 장소 삭제
+    /// - DELETE /api/places/:id/
+    static func placesDestroy(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(id)/", method: .delete)
+    }
+
+    // MARK: - Place Coordinators
+
+    /// 장소 담당자 목록 조회
+    /// - GET /api/places/:place_pk/coordinators/
+    static func coordinatorsList(placePk: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/")
+    }
+
+    /// 장소 담당자 생성
+    /// - POST /api/places/:place_pk/coordinators/
+    static func coordinatorsCreate(placePk: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/", method: .post, body: body)
+    }
+
+    /// 장소 담당자 상세 조회
+    /// - GET /api/places/:place_pk/coordinators/:id/
+    static func coordinatorsRetrieve(placePk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/\(id)/")
+    }
+
+    /// 장소 담당자 수정
+    /// - PUT /api/places/:place_pk/coordinators/:id/
+    static func coordinatorsUpdate(placePk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/\(id)/", method: .put, body: body)
+    }
+
+    /// 장소 담당자 부분 수정
+    /// - PATCH /api/places/:place_pk/coordinators/:id/
+    static func coordinatorsPartialUpdate(placePk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/\(id)/", method: .patch, body: body)
+    }
+
+    /// 장소 담당자 삭제
+    /// - DELETE /api/places/:place_pk/coordinators/:id/
+    static func coordinatorsDestroy(placePk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/coordinators/\(id)/", method: .delete)
+    }
+
+    // MARK: - Place Expenses (선택 경비)
+
+    /// 선택 경비 목록 조회
+    /// - GET /api/places/:place_pk/expenses/
+    static func expensesList(placePk: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/")
+    }
+
+    /// 선택 경비 생성
+    /// - POST /api/places/:place_pk/expenses/
+    static func expensesCreate(placePk: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/", method: .post, body: body)
+    }
+
+    /// 선택 경비 상세 조회
+    /// - GET /api/places/:place_pk/expenses/:id/
+    static func expensesRetrieve(placePk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/\(id)/")
+    }
+
+    /// 선택 경비 수정
+    /// - PUT /api/places/:place_pk/expenses/:id/
+    static func expensesUpdate(placePk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/\(id)/", method: .put, body: body)
+    }
+
+    /// 선택 경비 부분 수정
+    /// - PATCH /api/places/:place_pk/expenses/:id/
+    static func expensesPartialUpdate(placePk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/\(id)/", method: .patch, body: body)
+    }
+
+    /// 선택 경비 삭제
+    /// - DELETE /api/places/:place_pk/expenses/:id/
+    static func expensesDestroy(placePk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/places/\(placePk)/expenses/\(id)/", method: .delete)
+    }
+
+    /// 선택 경비 합계 계산
+    /// - POST /api/places/:place_pk/expenses/calculate/
+    static func expensesCalculate(placePk: Int, selectedIds: [Int]) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/places/\(placePk)/expenses/calculate/",
+            method: .post,
+            body: ["selected_expense_ids": selectedIds]
+        )
+    }
+
+    // MARK: - Recommendations
+
+    /// AI 추천 장소 목록
+    /// - GET /api/recommendations/
+    static func recommendationsList() -> APIEndpoint {
+        APIEndpoint(path: "/api/recommendations/")
+    }
+
+    // MARK: - Categories
+
+    /// 카테고리 목록 조회
+    /// - GET /api/categories/
+    static func categoriesList() -> APIEndpoint {
+        APIEndpoint(path: "/api/categories/")
+    }
+
+    /// 카테고리 상세 조회
+    /// - GET /api/categories/:id/
+    static func categoriesRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/categories/\(id)/")
+    }
+
+    // MARK: - Locations
+
+    /// 장소 위치 데이터
+    /// - GET /api/locations/places/
+    static func locationPlaces() -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/")
+    }
+
+    /// 카테고리 위치 데이터
+    /// - GET /api/locations/categories/
+    static func locationCategories() -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/categories/")
+    }
+
+    // MARK: - Place Recommendations
+
+    /// 고정 카테고리 추천 장소
+    /// - POST /api/place-recommendations/fixed-top/
+    static func placeRecommendationsFixedTop(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/place-recommendations/fixed-top/", method: .post, body: body)
+    }
+
+    /// 대안 추천 장소
+    /// - POST /api/place-recommendations/alternatives/
+    static func placeRecommendationsAlternatives(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/place-recommendations/alternatives/", method: .post, body: body)
+    }
+
+    // MARK: - Locations CRUD
+
+    /// 위치 장소 생성
+    /// - POST /api/locations/places/
+    static func locationPlacesCreate(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/", method: .post, body: body)
+    }
+
+    /// 위치 장소 상세 조회
+    /// - GET /api/locations/places/:id/
+    static func locationPlacesRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/\(id)/")
+    }
+
+    /// 위치 장소 수정
+    /// - PUT /api/locations/places/:id/
+    static func locationPlacesUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/\(id)/", method: .put, body: body)
+    }
+
+    /// 위치 장소 부분 수정
+    /// - PATCH /api/locations/places/:id/
+    static func locationPlacesPartialUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/\(id)/", method: .patch, body: body)
+    }
+
+    /// 위치 장소 삭제
+    /// - DELETE /api/locations/places/:id/
+    static func locationPlacesDestroy(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/places/\(id)/", method: .delete)
+    }
+
+    /// 카테고리 위치 상세 조회
+    /// - GET /api/locations/categories/:id/
+    static func locationCategoriesRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/locations/categories/\(id)/")
+    }
+
+    // MARK: - Coordinator Roles
+
+    /// 담당자 역할 목록 조회
+    /// - GET /api/coordinator-roles/
+    static func coordinatorRolesList() -> APIEndpoint {
+        APIEndpoint(path: "/api/coordinator-roles/")
+    }
+
+    /// 담당자 역할 상세 조회
+    /// - GET /api/coordinator-roles/:id/
+    static func coordinatorRolesRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/coordinator-roles/\(id)/")
+    }
+
+    // MARK: - Monitoring
+
+    /// 모니터링 알림 (전체)
+    /// - GET /api/monitoring/alerts/
+    static func monitoringAlerts() -> APIEndpoint {
+        APIEndpoint(path: "/api/monitoring/alerts/")
+    }
+
+    /// 여행별 모니터링 알림
+    /// - GET /api/monitoring/trips/:id/alerts/
+    static func monitoringTripAlerts(tripId: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/monitoring/trips/\(tripId)/alerts/")
+    }
+
+    /// 데모 모니터링 데이터 생성
+    /// - POST /api/monitoring/trips/:id/generate-demo/
+    static func monitoringGenerateDemo(tripId: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/monitoring/trips/\(tripId)/generate-demo/", method: .post)
+    }
+
+    /// 최신 참가자 건강/위치 스냅샷
+    /// - GET /api/monitoring/trips/:id/latest/
+    static func monitoringLatest(tripId: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/monitoring/trips/\(tripId)/latest/")
+    }
+
+    /// 여행 모니터링 요약 (전체, 안전, 위험 카운트)
+    /// - GET /api/monitoring/trips/:id/summary/
+    static func monitoringSummary(tripId: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/monitoring/trips/\(tripId)/summary/")
+    }
+
+    // MARK: - Health Check
+
+    /// 서비스 헬스 체크
+    /// - GET /api/health/
+    static func healthCheck() -> APIEndpoint {
+        APIEndpoint(path: "/api/health/")
+    }
+}

--- a/HiTrip/Core/Network/APIEndpoint+Schedules.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Schedules.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// MARK: - Schedule Endpoints
+/// 일정 관련 API 엔드포인트
+///
+/// 백엔드: /api/trips/:trip_pk/schedules/
+/// 여행사가 등록한 공식 일정(타임라인) CRUD
+
+extension APIEndpoint {
+
+    // MARK: - Schedules CRUD
+
+    /// 일정 목록 조회
+    /// - GET /api/trips/:trip_pk/schedules/
+    static func schedulesList(tripPk: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(tripPk)/schedules/")
+    }
+
+    /// 일정 생성
+    /// - POST /api/trips/:trip_pk/schedules/
+    static func schedulesCreate(tripPk: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/schedules/",
+            method: .post,
+            body: body
+        )
+    }
+
+    /// 일정 상세 조회
+    /// - GET /api/trips/:trip_pk/schedules/:id/
+    static func schedulesRetrieve(tripPk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(tripPk)/schedules/\(id)/")
+    }
+
+    /// 일정 수정 (전체)
+    /// - PUT /api/trips/:trip_pk/schedules/:id/
+    static func schedulesUpdate(tripPk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/schedules/\(id)/",
+            method: .put,
+            body: body
+        )
+    }
+
+    /// 일정 부분 수정
+    /// - PATCH /api/trips/:trip_pk/schedules/:id/
+    static func schedulesPartialUpdate(tripPk: Int, id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/schedules/\(id)/",
+            method: .patch,
+            body: body
+        )
+    }
+
+    /// 일정 삭제
+    /// - DELETE /api/trips/:trip_pk/schedules/:id/
+    static func schedulesDestroy(tripPk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(tripPk)/schedules/\(id)/", method: .delete)
+    }
+
+    /// 일정 재조정 (AI)
+    /// - POST /api/trips/:trip_pk/schedules/rebalance-day/
+    static func schedulesRebalanceDay(tripPk: Int, day: Int) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/schedules/rebalance-day/",
+            method: .post,
+            body: ["day": day]
+        )
+    }
+}

--- a/HiTrip/Core/Network/APIEndpoint+Traveler.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Traveler.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - Traveler Endpoints
+/// 여행객(참가자) 전용 API 엔드포인트
+///
+/// 백엔드: /api/traveler/
+/// 관광객이 초대코드로 로그인하여 자신의 여행/일정을 조회하는 API
+
+extension APIEndpoint {
+
+    // MARK: - Traveler Auth
+
+    /// 여행객 로그인 (초대코드 기반)
+    /// - POST /api/traveler/login/
+    static func travelerLogin(phone: String, birthDate: String, inviteCode: String) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/traveler/login/",
+            method: .post,
+            body: [
+                "phone": phone,
+                "birth_date": birthDate,
+                "invite_code": inviteCode
+            ]
+        )
+    }
+
+    /// 여행객 로그아웃
+    /// - POST /api/traveler/logout/
+    static func travelerLogout() -> APIEndpoint {
+        APIEndpoint(path: "/api/traveler/logout/", method: .post)
+    }
+
+    // MARK: - Traveler Profile
+
+    /// 현재 여행객 프로필 조회
+    /// - GET /api/traveler/me/
+    static func travelerMe() -> APIEndpoint {
+        APIEndpoint(path: "/api/traveler/me/")
+    }
+
+    // MARK: - Traveler Trip & Schedule
+
+    /// 현재 여행객의 여행 정보 조회
+    /// - GET /api/traveler/trip/
+    static func travelerTrip() -> APIEndpoint {
+        APIEndpoint(path: "/api/traveler/trip/")
+    }
+
+    /// 현재 여행객의 일정 목록 조회
+    /// - GET /api/traveler/schedules/
+    static func travelerSchedules() -> APIEndpoint {
+        APIEndpoint(path: "/api/traveler/schedules/")
+    }
+}

--- a/HiTrip/Core/Network/APIEndpoint+Trips.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Trips.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+// MARK: - Trip Endpoints
+/// 여행 관련 API 엔드포인트
+///
+/// 백엔드: /api/trips/
+/// Fern Docs 기준 request/response 매핑
+
+extension APIEndpoint {
+
+    // MARK: - Trips CRUD
+
+    /// 여행 목록 조회
+    /// - GET /api/trips/
+    static func tripsList() -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/")
+    }
+
+    /// 여행 생성
+    /// - POST /api/trips/
+    static func tripsCreate(
+        title: String,
+        startDate: String,
+        endDate: String,
+        destination: String,
+        participantCount: Int? = nil
+    ) -> APIEndpoint {
+        var body: [String: Any] = [
+            "title": title,
+            "start_date": startDate,
+            "end_date": endDate,
+            "destination": destination
+        ]
+        if let count = participantCount {
+            body["participant_count"] = count
+        }
+        return APIEndpoint(path: "/api/trips/", method: .post, body: body)
+    }
+
+    /// 여행 상세 조회
+    /// - GET /api/trips/:id/
+    static func tripsRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(id)/")
+    }
+
+    /// 여행 수정 (전체)
+    /// - PUT /api/trips/:id/
+    static func tripsUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(id)/", method: .put, body: body)
+    }
+
+    /// 여행 부분 수정
+    /// - PATCH /api/trips/:id/
+    static func tripsPartialUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(id)/", method: .patch, body: body)
+    }
+
+    /// 여행 삭제
+    /// - DELETE /api/trips/:id/
+    static func tripsDestroy(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(id)/", method: .delete)
+    }
+
+    /// 매니저 배정
+    /// - POST /api/trips/:id/assign-manager/
+    static func tripsAssignManager(tripId: Int, managerId: Int) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripId)/assign-manager/",
+            method: .post,
+            body: ["manager_id": managerId]
+        )
+    }
+
+    // MARK: - Participants
+
+    /// 참여자 목록 조회
+    /// - GET /api/trips/:trip_pk/participants/
+    static func participantsList(tripPk: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/trips/\(tripPk)/participants/")
+    }
+
+    /// 참여자 추가
+    /// - POST /api/trips/:trip_pk/participants/
+    static func participantsAdd(tripPk: Int, travelerId: Int) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/participants/",
+            method: .post,
+            body: ["traveler_id": travelerId]
+        )
+    }
+
+    /// 참여자 삭제
+    /// - DELETE /api/trips/:trip_pk/participants/:id/
+    static func participantsDestroy(tripPk: Int, id: Int) -> APIEndpoint {
+        APIEndpoint(
+            path: "/api/trips/\(tripPk)/participants/\(id)/",
+            method: .delete
+        )
+    }
+}

--- a/HiTrip/Core/Network/APIEndpoint.swift
+++ b/HiTrip/Core/Network/APIEndpoint.swift
@@ -26,6 +26,7 @@ struct APIEndpoint {
         case get    = "GET"
         case post   = "POST"
         case put    = "PUT"
+        case patch  = "PATCH"
         case delete = "DELETE"
     }
 
@@ -49,53 +50,125 @@ struct APIEndpoint {
 extension APIEndpoint {
 
     /// 로그인 API
-    /// - POST /auth/login
-    /// - Body: { "id": "...", "password": "..." }
-    static func login(id: String, password: String) -> APIEndpoint {
+    /// - POST /api/auth/login/
+    static func login(username: String, password: String) -> APIEndpoint {
         APIEndpoint(
-            path: "/auth/login",
+            path: "/api/auth/login/",
             method: .post,
-            body: ["id": id, "password": password]
+            body: ["username": username, "password": password]
         )
     }
 
-    /// 토큰 갱신 API
-    /// - POST /auth/refresh
-    /// - Body: { "refreshToken": "..." }
-    static func refreshToken(token: String) -> APIEndpoint {
-        APIEndpoint(
-            path: "/auth/refresh",
-            method: .post,
-            body: ["refreshToken": token]
-        )
+    /// 로그아웃 API
+    /// - POST /api/auth/logout/
+    static func logout() -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/logout/", method: .post)
     }
-}
 
-// MARK: - Sign Up Endpoints
+    /// 프로필 조회 API
+    /// - GET /api/auth/profile/
+    static func profile() -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/profile/")
+    }
 
-extension APIEndpoint {
+    /// 프로필 수정 API
+    /// - PUT /api/auth/profile/
+    static func profileUpdate(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/profile/", method: .put, body: body)
+    }
 
     /// 회원가입 API
-    /// - POST /auth/signup
-    static func signUp(nickname: String, userId: String, password: String) -> APIEndpoint {
+    /// - POST /api/auth/register/
+    static func register(username: String, password: String, email: String) -> APIEndpoint {
         APIEndpoint(
-            path: "/auth/signup",
+            path: "/api/auth/register/",
             method: .post,
             body: [
-                "nickname": nickname,
-                "userId": userId,
-                "password": password
+                "username": username,
+                "password": password,
+                "email": email
             ]
         )
     }
 
-    /// 닉네임 중복 확인 API
-    /// - GET /auth/check-nickname?nickname=...
-    static func checkNickname(_ nickname: String) -> APIEndpoint {
-        APIEndpoint(
-            path: "/auth/check-nickname",
-            queryItems: [URLQueryItem(name: "nickname", value: nickname)]
-        )
+    /// 여행객 목록 조회
+    /// - GET /api/auth/travelers/
+    static func travelersList() -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/")
+    }
+
+    /// 스태프 목록 조회
+    /// - GET /api/auth/staff/
+    static func staffList() -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/")
+    }
+
+    /// 스태프 계정 생성
+    /// - POST /api/auth/staff/
+    static func staffCreate(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/", method: .post, body: body)
+    }
+
+    /// 스태프 상세 조회
+    /// - GET /api/auth/staff/:id/
+    static func staffRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/\(id)/")
+    }
+
+    /// 스태프 정보 수정
+    /// - PUT /api/auth/staff/:id/
+    static func staffUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/\(id)/", method: .put, body: body)
+    }
+
+    /// 스태프 정보 부분 수정
+    /// - PATCH /api/auth/staff/:id/
+    static func staffPartialUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/\(id)/", method: .patch, body: body)
+    }
+
+    /// 스태프 삭제
+    /// - DELETE /api/auth/staff/:id/
+    static func staffDestroy(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/\(id)/", method: .delete)
+    }
+
+    /// 스태프 승인
+    /// - POST /api/auth/staff/:id/approve/
+    static func staffApprove(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/staff/\(id)/approve/", method: .post)
+    }
+
+    // MARK: - Travelers 관리
+
+    /// 여행객 생성
+    /// - POST /api/auth/travelers/
+    static func travelersCreate(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/", method: .post, body: body)
+    }
+
+    /// 여행객 상세 조회
+    /// - GET /api/auth/travelers/:id/
+    static func travelersRetrieve(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/\(id)/")
+    }
+
+    /// 여행객 정보 수정
+    /// - PUT /api/auth/travelers/:id/
+    static func travelersUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/\(id)/", method: .put, body: body)
+    }
+
+    /// 여행객 정보 부분 수정
+    /// - PATCH /api/auth/travelers/:id/
+    static func travelersPartialUpdate(id: Int, body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/\(id)/", method: .patch, body: body)
+    }
+
+    /// 여행객 삭제
+    /// - DELETE /api/auth/travelers/:id/
+    static func travelersDestroy(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/auth/travelers/\(id)/", method: .delete)
     }
 }
 

--- a/HiTrip/Core/Network/APIEnvironment.swift
+++ b/HiTrip/Core/Network/APIEnvironment.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+// MARK: - APIEnvironment
+/// API 환경 설정
+///
+/// Mock ↔ Remote 전환을 중앙에서 관리.
+/// 개발 중에는 .mock, 서버 연동 시 .remote로 전환.
+///
+/// 사용법:
+/// - AppDIContainer에서 현재 environment를 참조하여
+///   Mock 또는 Remote Repository를 주입
+/// - NetworkService는 baseURL을 여기서 가져감
+
+enum APIEnvironment {
+
+    /// Mock 데이터 사용 (서버 없이 앱 개발)
+    case mock
+
+    /// 실제 백엔드 API 연동
+    case remote
+
+    // MARK: - 현재 환경 (여기서 전환)
+
+    /// ⚠️ 서버 연동 시 .remote로 변경
+    static let current: APIEnvironment = .remote
+
+    // MARK: - Base URL
+
+    /// API 서버 기본 URL
+    var baseURL: String {
+        switch self {
+        case .mock:
+            return "https://api.hitrip.example.com"
+        case .remote:
+            // TODO: 실제 배포 서버 URL로 변경
+            return "http://100.124.191.47:18080"
+        }
+    }
+
+    /// Mock 데이터 사용 여부
+    var useMock: Bool {
+        self == .mock
+    }
+}

--- a/HiTrip/Core/Network/DTOs/AuthDTO.swift
+++ b/HiTrip/Core/Network/DTOs/AuthDTO.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// MARK: - AuthLoginRequest
+/// POST /api/auth/login/ 요청 바디
+
+struct AuthLoginRequest: Encodable {
+    let username: String
+    let password: String
+}
+
+// MARK: - AuthLoginResponse
+/// POST /api/auth/login/ 응답
+///
+/// 서버는 UserDetail을 반환:
+/// { "id": 1, "username": "...", "email": "...", "full_name_kr": "...", "role": "...", ... }
+/// 세션 기반 인증이므로 토큰은 Set-Cookie 헤더로 전달됨
+///
+/// 하위 호환을 위해 token/key 필드도 유지 (다른 인증 방식 대응)
+
+struct AuthLoginResponse: Decodable {
+    // 토큰 기반 인증 (있는 경우)
+    let token: String?
+    let key: String?
+    let sessionid: String?
+
+    // UserDetail 필드 (서버 실제 응답)
+    let id: Int?
+    let username: String?
+    let email: String?
+    let phone: String?
+    let firstName: String?
+    let lastName: String?
+    let firstNameKr: String?
+    let lastNameKr: String?
+    let fullNameKr: String?
+    let fullNameEn: String?
+    let role: String?
+    let roleDisplay: String?
+    let isApproved: Bool?
+
+    /// 표시용 이름 (한글 이름 우선, 없으면 username)
+    var displayName: String {
+        if let kr = fullNameKr, !kr.isEmpty { return kr }
+        if let first = firstNameKr, let last = lastNameKr, !first.isEmpty {
+            return last + first
+        }
+        if let en = fullNameEn, !en.isEmpty { return en }
+        return username ?? "사용자"
+    }
+
+    /// 표시용 이메일
+    var displayEmail: String {
+        email ?? ""
+    }
+}
+
+// MARK: - AuthRegisterRequest
+/// POST /api/auth/register/ 요청 바디
+
+struct AuthRegisterRequest: Encodable {
+    let username: String
+    let password: String
+    let email: String?
+    let firstName: String?
+    let lastName: String?
+}
+
+// MARK: - StaffDTO
+/// GET /api/auth/staff/ 응답 모델
+
+struct StaffDTO: Decodable, Identifiable {
+    let id: Int
+    let role: String?               // "super_admin", "coordinator", etc.
+    let email: String?
+    let phone: String?
+    let username: String?
+    let lastName: String?
+    let firstName: String?
+    let isApproved: Bool?
+    let fullNameEn: String?
+    let fullNameKr: String?
+    let lastNameKr: String?
+    let firstNameKr: String?
+    let roleDisplay: String?
+}
+
+// MARK: - ProfileDTO
+/// GET /api/auth/profile/ 응답 모델
+
+struct ProfileDTO: Decodable {
+    let id: Int?
+    let username: String?
+    let email: String?
+    let firstName: String?
+    let lastName: String?
+    let phone: String?
+    let role: String?
+    let fullNameKr: String?
+    let firstNameKr: String?
+    let lastNameKr: String?
+}
+
+// MARK: - ProfileDTO → User 변환
+
+extension ProfileDTO {
+
+    func toUser() -> User {
+        User(
+            id: UUID(),
+            nickname: fullNameKr ?? username ?? "사용자",
+            email: email ?? "",
+            profileImageName: nil
+        )
+    }
+}
+
+// MARK: - TravelerDTO
+/// GET /api/auth/travelers/ 응답 모델
+
+struct TravelerDTO: Decodable, Identifiable {
+    let id: Int
+    let username: String?
+    let email: String?
+    let firstName: String?
+    let lastName: String?
+    let phone: String?
+}

--- a/HiTrip/Core/Network/DTOs/PlaceDTO.swift
+++ b/HiTrip/Core/Network/DTOs/PlaceDTO.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - PlaceDTO
+/// 백엔드 GET /api/places/ 응답 모델
+
+struct PlaceDTO: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let address: String?
+    let category: PlaceCategoryDTO?
+    let hasImage: Bool?
+    let createdAt: String?
+    let updatedAt: String?
+    let aiMeetingPoint: String?
+    let aiGeneratedInfo: String?
+}
+
+// MARK: - PlaceCategoryDTO
+
+struct PlaceCategoryDTO: Decodable {
+    let id: Int
+    let name: String
+    let order: Int?
+}
+
+// MARK: - PlaceDTO → TripNearbySpot 변환
+
+extension PlaceDTO {
+
+    func toNearbySpot() -> TripNearbySpot {
+        // 카테고리 → 앱 내부 카테고리 매핑
+        let categoryName: String
+        switch category?.name.lowercased() {
+        case "park", "garden":    categoryName = "leaf"
+        case "beach":             categoryName = "beach"
+        case "mountain", "hill":  categoryName = "mountain"
+        case "water", "lake":     categoryName = "water"
+        default:                  categoryName = "leaf"
+        }
+
+        return TripNearbySpot(
+            name: name,
+            distance: aiMeetingPoint ?? "",
+            category: categoryName
+        )
+    }
+}
+
+// MARK: - RecommendationDTO
+/// 백엔드 GET /api/recommendations/ 응답 모델
+
+struct RecommendationDTO: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let order: Int?
+    let reason: String?
+    let category: String?
+    let colorTheme: String?
+    let travelTimeMin: Int?
+    let transportMethod: String?    // "WALK", "BUS", "TAXI" 등
+}
+
+// MARK: - RecommendationDTO → TripNearbySpot 변환
+
+extension RecommendationDTO {
+
+    func toNearbySpot() -> TripNearbySpot {
+        // 이동 수단 + 시간 → 거리 텍스트
+        let methodText: String
+        switch transportMethod?.uppercased() {
+        case "WALK":  methodText = "도보"
+        case "BUS":   methodText = "버스"
+        case "TAXI":  methodText = "택시"
+        case "CAR":   methodText = "차량"
+        default:      methodText = "이동"
+        }
+        let distance = travelTimeMin.map { "\(methodText) \($0)분" } ?? ""
+
+        // 카테고리 매핑
+        let cat: String
+        switch category?.lowercased() {
+        case "landmark", "historical landmarks": cat = "mountain"
+        case "beach":                            cat = "beach"
+        case "park", "nature":                   cat = "leaf"
+        default:                                 cat = "leaf"
+        }
+
+        return TripNearbySpot(
+            name: name,
+            distance: distance,
+            category: cat
+        )
+    }
+}
+
+// MARK: - CategoryDTO
+/// 백엔드 GET /api/categories/ 응답 모델
+
+struct CategoryDTO: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let createdAt: String?
+    let description: String?
+}

--- a/HiTrip/Core/Network/DTOs/ScheduleDTO.swift
+++ b/HiTrip/Core/Network/DTOs/ScheduleDTO.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// MARK: - ScheduleDTO
+/// 백엔드 GET /api/trips/:trip_pk/schedules/ 응답 모델
+///
+/// 여행사가 등록한 공식 일정을 나타냄.
+/// 앱 내부에서는 TripOfficialSchedule 또는 Schedule로 변환하여 사용.
+
+struct ScheduleDTO: Decodable, Identifiable {
+    let id: Int
+    let trip: Int?
+    let place: Int?                 // place ID (FK)
+    let dayNumber: Int?             // 일차 (1, 2, 3...)
+    let startTime: String?          // "07:00:00"
+    let endTime: String?            // "09:00:00"
+    let durationMinutes: Int?       // 120
+    let transport: String?          // "자가용", "도보", "전용버스"
+    let mainContent: String?        // "탑승 수속 및 출국"
+    let meetingPoint: String?       // "T1 3층 출발홀"
+    let budget: Int?
+    let order: Int?
+    let placeName: String?          // "인천국제공항 T1"
+    let durationDisplay: String?    // "2시간"
+    let createdAt: String?
+    let updatedAt: String?
+
+    // 하위 호환용 (기존 코드에서 title/day/notes 참조)
+    var title: String { placeName ?? mainContent ?? "일정" }
+    var day: Int? { dayNumber }
+    var notes: String? { mainContent }
+    var timeBlock: String? {
+        guard let startTime, let hour = Int(startTime.prefix(2)) else { return nil }
+        if hour < 12 { return "morning" }
+        if hour < 18 { return "afternoon" }
+        return "evening"
+    }
+}
+
+// MARK: - ScheduleDTO → TripOfficialSchedule 변환
+
+extension ScheduleDTO {
+
+    /// DTO → 앱 내부 TripOfficialSchedule 변환
+    func toOfficialSchedule(for date: Date = Date()) -> TripOfficialSchedule {
+        let start = parseTime(startTime, on: date)
+        let end = parseTime(endTime, on: date)
+
+        // 이동수단 → emoji 매핑
+        let emoji: String
+        switch transport {
+        case "도보":     emoji = "🚶"
+        case "전용버스":  emoji = "🚌"
+        case "자가용":   emoji = "🚗"
+        case "공항버스":  emoji = "✈️"
+        case "택시":     emoji = "🚕"
+        default:
+            // timeBlock fallback
+            switch timeBlock {
+            case "morning":   emoji = "🌅"
+            case "afternoon": emoji = "☀️"
+            case "evening":   emoji = "🌙"
+            default:          emoji = "📍"
+            }
+        }
+
+        // 제목: 장소명 + 메인 콘텐츠
+        let displayTitle: String
+        if let placeName, let content = mainContent {
+            displayTitle = "\(placeName) — \(content)"
+        } else {
+            displayTitle = placeName ?? mainContent ?? title
+        }
+
+        return TripOfficialSchedule(
+            emoji: emoji,
+            title: displayTitle,
+            startTime: start,
+            endTime: end,
+            date: date
+        )
+    }
+
+    /// DTO → 앱 내부 Schedule 변환
+    func toSchedule() -> Schedule {
+        Schedule(
+            title: placeName ?? mainContent ?? title,
+            description: mainContent ?? "",
+            date: Date(),
+            location: meetingPoint ?? ""
+        )
+    }
+
+    // MARK: - Private
+
+    /// 시간 문자열을 특정 날짜에 결합
+    private func parseTime(_ timeString: String?, on date: Date) -> Date {
+        guard let timeString else { return date }
+        let calendar = Calendar.current
+
+        // "HH:mm:ss" 형태 시도
+        let parts = timeString.split(separator: ":").compactMap { Int($0) }
+        if parts.count >= 2 {
+            return calendar.date(bySettingHour: parts[0], minute: parts[1], second: 0, of: date) ?? date
+        }
+
+        // ISO 형태 시도
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+        if let parsed = iso.date(from: timeString) {
+            return parsed
+        }
+
+        return date
+    }
+}
+
+// MARK: - ScheduleCreateRequest
+/// POST /api/trips/:trip_pk/schedules/ 요청 바디
+
+struct ScheduleCreateRequest: Encodable {
+    let title: String
+    let day: Int
+    let timeBlock: String           // "morning", "afternoon", "evening"
+    let startTime: String           // "HH:mm:ss"
+    let endTime: String
+    let place: Int?
+    let notes: String?
+    let order: Int?
+}

--- a/HiTrip/Core/Network/DTOs/TripDTO.swift
+++ b/HiTrip/Core/Network/DTOs/TripDTO.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// MARK: - TripDTO
+/// 백엔드 GET /api/trips/ 응답 모델
+///
+/// snake_case → camelCase 변환은 JSONDecoder.keyDecodingStrategy로 자동 처리
+/// 이 DTO는 네트워크 레이어 전용이며, 앱 내부에서는 TripPackage/Trip 모델로 변환하여 사용
+
+struct TripDTO: Decodable, Identifiable {
+    let id: Int
+    let title: String
+    let status: String                  // "planning", "active", "completed"
+    let manager: Int?
+    let endDate: String?                // "2025-03-08" (Date only)
+    let spo2Min: String?
+    let createdAt: String?
+    let startDate: String?              // "2025-03-08"
+    let updatedAt: String?
+    let destination: String?
+    let inviteCode: String?
+    let managerName: String?
+    let heartRateMax: Int?
+    let heartRateMin: Int?
+    let participantCount: Int?
+    let geofenceRadiusKm: String?
+    let geofenceCenterLat: String?
+    let geofenceCenterLng: String?
+}
+
+// MARK: - TripDTO → TripPackage 변환
+
+extension TripDTO {
+
+    /// DTO → 앱 내부 TripPackage 모델 변환
+    func toTripPackage() -> TripPackage {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        let start = dateFormatter.date(from: startDate ?? "") ?? Date()
+        let end = dateFormatter.date(from: endDate ?? "") ?? Date()
+
+        return TripPackage(
+            id: UUID(),  // 서버 ID와 매핑 필요 시 별도 필드 추가
+            name: title,
+            startDate: start,
+            endDate: end,
+            destination: destination ?? "",
+            totalParticipants: participantCount ?? 0,
+            currentParticipants: participantCount ?? 0,
+            weatherDescription: ""
+        )
+    }
+
+    /// DTO → 앱 내부 Trip 모델 변환
+    func toTrip() -> Trip {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        let date = dateFormatter.date(from: startDate ?? "") ?? Date()
+
+        return Trip(
+            title: title,
+            date: date,
+            location: destination ?? "",
+            thumbnailName: "mappin.circle.fill",
+            memberAvatars: []
+        )
+    }
+}
+
+// MARK: - TripCreateRequest
+/// POST /api/trips/ 요청 바디
+
+struct TripCreateRequest: Encodable {
+    let title: String
+    let startDate: String          // "yyyy-MM-dd"
+    let endDate: String
+    let destination: String
+    let participantCount: Int?
+    let geofenceRadiusKm: String?
+    let geofenceCenterLat: String?
+    let geofenceCenterLng: String?
+}

--- a/HiTrip/Core/Network/HiTripAPIService.swift
+++ b/HiTrip/Core/Network/HiTripAPIService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import RxSwift
+
+// MARK: - HiTripAPIService
+/// Hi Trip 자체 백엔드 API 호출 서비스
+///
+/// NetworkService를 래핑하여 도메인별 편의 메서드를 제공.
+/// ViewModel이나 UseCase에서 직접 사용하거나,
+/// Repository에서 호출할 수 있다.
+///
+/// TourAPIService가 한국관광공사 API 전용이라면,
+/// 이 서비스는 Hi Trip 자체 백엔드 전용.
+
+final class HiTripAPIService {
+
+    // MARK: - Singleton
+
+    static let shared = HiTripAPIService()
+
+    private let network: NetworkService
+
+    private init() {
+        self.network = .shared
+    }
+
+    /// 테스트용
+    init(networkService: NetworkService) {
+        self.network = networkService
+    }
+
+    // MARK: - Trips
+
+    /// 여행 목록 조회
+    func fetchTrips() -> Single<[TripDTO]> {
+        network.request(.tripsList(), type: [TripDTO].self)
+            .catch { error in
+                print("❌ [HiTrip API] fetchTrips 실패: \(error.localizedDescription)")
+                return .just([])
+            }
+    }
+
+    /// 여행 상세 조회
+    func fetchTrip(id: Int) -> Single<TripDTO> {
+        network.request(.tripsRetrieve(id: id), type: TripDTO.self)
+    }
+
+    // MARK: - Schedules
+
+    /// 특정 여행의 일정 목록 조회
+    func fetchSchedules(tripPk: Int) -> Single<[ScheduleDTO]> {
+        network.request(.schedulesList(tripPk: tripPk), type: [ScheduleDTO].self)
+            .catch { error in
+                print("❌ [HiTrip API] fetchSchedules 실패: \(error.localizedDescription)")
+                return .just([])
+            }
+    }
+
+    // MARK: - Places
+
+    /// 장소 목록 조회
+    func fetchPlaces() -> Single<[PlaceDTO]> {
+        network.request(.placesList(), type: [PlaceDTO].self)
+            .catch { error in
+                print("❌ [HiTrip API] fetchPlaces 실패: \(error.localizedDescription)")
+                return .just([])
+            }
+    }
+
+    /// 장소 상세 조회
+    func fetchPlace(id: Int) -> Single<PlaceDTO> {
+        network.request(.placesRetrieve(id: id), type: PlaceDTO.self)
+    }
+
+    // MARK: - Recommendations
+
+    /// AI 추천 장소 목록
+    func fetchRecommendations() -> Single<[RecommendationDTO]> {
+        network.request(.recommendationsList(), type: [RecommendationDTO].self)
+            .catch { error in
+                print("❌ [HiTrip API] fetchRecommendations 실패: \(error.localizedDescription)")
+                return .just([])
+            }
+    }
+
+    // MARK: - Categories
+
+    /// 카테고리 목록 조회
+    func fetchCategories() -> Single<[CategoryDTO]> {
+        network.request(.categoriesList(), type: [CategoryDTO].self)
+            .catch { error in
+                print("❌ [HiTrip API] fetchCategories 실패: \(error.localizedDescription)")
+                return .just([])
+            }
+    }
+
+    // MARK: - Auth
+
+    /// 로그인
+    func login(username: String, password: String) -> Single<AuthLoginResponse> {
+        network.request(.login(username: username, password: password), type: AuthLoginResponse.self)
+    }
+
+    /// 프로필 조회
+    func fetchProfile() -> Single<ProfileDTO> {
+        network.request(.profile(), type: ProfileDTO.self)
+    }
+
+    /// 회원가입
+    func register(username: String, password: String, email: String) -> Single<ProfileDTO> {
+        network.request(.register(username: username, password: password, email: email), type: ProfileDTO.self)
+    }
+
+    // MARK: - Health
+
+    /// 서버 상태 확인
+    func healthCheck() -> Single<[String: String]> {
+        network.request(
+            APIEndpoint(path: "/api/health/"),
+            type: [String: String].self
+        )
+        .catch { _ in .just(["status": "unreachable"]) }
+    }
+}

--- a/HiTrip/Core/Network/HiTripError.swift
+++ b/HiTrip/Core/Network/HiTripError.swift
@@ -1,0 +1,442 @@
+import Foundation
+
+// MARK: - HiTripError
+/// 앱 전체에서 사용하는 통합 에러 타입
+///
+/// 설계 의도:
+/// - Network/Domain/Presentation 모든 레이어에서 일관된 에러 처리
+/// - 서버 에러 응답(body)을 파싱하여 구체적인 정보 보존
+/// - HTTP 상태코드별 분류로 자동 로그인 만료, 권한 에러 등 대응
+/// - 사용자에게 보여줄 한글 메시지와 개발자 디버그 정보 분리
+///
+/// 면접 포인트:
+/// "에러 처리를 어떻게 설계하셨나요?"
+/// → "계층적 에러 enum으로 네트워크/서버/클라이언트 에러를 분류하고,
+///    서버 응답 body를 파싱하여 필드별 Validation 에러까지 전달합니다.
+///    ViewModel에서는 ErrorHandler를 통해 사용자 친화적 메시지로 변환합니다."
+
+enum HiTripError: Error, Equatable {
+
+    // MARK: - Network (연결 자체의 문제)
+
+    /// URL 조합 실패 (개발자 실수)
+    case invalidURL
+
+    /// 인터넷 연결 없음
+    case noConnection
+
+    /// 요청 타임아웃
+    case timeout
+
+    /// 기타 네트워크 에러 (URLSession 레벨)
+    case networkFailure(String)
+
+    // MARK: - Server (HTTP 응답은 왔으나 실패)
+
+    /// 401 — 인증 실패 또는 토큰 만료
+    case unauthorized(ServerErrorDetail)
+
+    /// 403 — 권한 없음
+    case forbidden(ServerErrorDetail)
+
+    /// 404 — 리소스 없음
+    case notFound(ServerErrorDetail)
+
+    /// 409 — 충돌 (이미 존재하는 리소스 등)
+    case conflict(ServerErrorDetail)
+
+    /// 422 / 400 — Validation 실패 (필드별 에러 포함)
+    case validationFailed(ServerErrorDetail)
+
+    /// 429 — Too Many Requests
+    case rateLimited
+
+    /// 500+ — 서버 내부 오류
+    case serverError(Int, ServerErrorDetail)
+
+    /// 기타 HTTP 에러
+    case httpError(Int, ServerErrorDetail)
+
+    // MARK: - Client (앱 내부 문제)
+
+    /// JSON 디코딩 실패
+    case decodingFailed(String)
+
+    /// 응답 데이터 없음
+    case noData
+
+    /// HTTPURLResponse 캐스팅 실패
+    case invalidResponse
+
+    // MARK: - Equatable
+
+    static func == (lhs: HiTripError, rhs: HiTripError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidURL, .invalidURL),
+             (.noConnection, .noConnection),
+             (.timeout, .timeout),
+             (.rateLimited, .rateLimited),
+             (.noData, .noData),
+             (.invalidResponse, .invalidResponse):
+            return true
+        case (.networkFailure(let a), .networkFailure(let b)):
+            return a == b
+        case (.decodingFailed(let a), .decodingFailed(let b)):
+            return a == b
+        case (.unauthorized(let a), .unauthorized(let b)),
+             (.forbidden(let a), .forbidden(let b)),
+             (.notFound(let a), .notFound(let b)),
+             (.conflict(let a), .conflict(let b)),
+             (.validationFailed(let a), .validationFailed(let b)):
+            return a == b
+        case (.serverError(let c1, let d1), .serverError(let c2, let d2)),
+             (.httpError(let c1, let d1), .httpError(let c2, let d2)):
+            return c1 == c2 && d1 == d2
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - LocalizedError
+
+extension HiTripError: LocalizedError {
+
+    /// 사용자에게 표시할 한글 메시지
+    var errorDescription: String? {
+        switch self {
+        // Network
+        case .invalidURL:
+            return "잘못된 요청입니다."
+        case .noConnection:
+            return "인터넷 연결을 확인해주세요."
+        case .timeout:
+            return "서버 응답이 지연되고 있어요. 잠시 후 다시 시도해주세요."
+        case .networkFailure:
+            return "네트워크 오류가 발생했습니다. 다시 시도해주세요."
+
+        // Server — 사용자 메시지
+        case .unauthorized(let detail):
+            return detail.userMessage ?? "로그인이 만료되었습니다. 다시 로그인해주세요."
+        case .forbidden(let detail):
+            return detail.userMessage ?? "접근 권한이 없습니다."
+        case .notFound(let detail):
+            return detail.userMessage ?? "요청한 정보를 찾을 수 없습니다."
+        case .conflict(let detail):
+            return detail.userMessage ?? "이미 존재하는 데이터입니다."
+        case .validationFailed(let detail):
+            return detail.userMessage ?? "입력 정보를 확인해주세요."
+        case .rateLimited:
+            return "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+        case .serverError(_, let detail):
+            return detail.userMessage ?? "서버에 일시적인 문제가 발생했습니다."
+        case .httpError(_, let detail):
+            return detail.userMessage ?? "요청 처리 중 오류가 발생했습니다."
+
+        // Client
+        case .decodingFailed:
+            return "데이터를 처리하는 중 오류가 발생했습니다."
+        case .noData:
+            return "서버에서 데이터를 받지 못했습니다."
+        case .invalidResponse:
+            return "서버 응답이 올바르지 않습니다."
+        }
+    }
+}
+
+// MARK: - 편의 프로퍼티
+
+extension HiTripError {
+
+    /// 토큰 만료로 재로그인이 필요한지 여부
+    var requiresReauth: Bool {
+        if case .unauthorized = self { return true }
+        return false
+    }
+
+    /// 재시도 가능한 에러인지 여부
+    var isRetryable: Bool {
+        switch self {
+        case .noConnection, .timeout, .rateLimited:
+            return true
+        case .serverError(let code, _):
+            return code >= 500
+        case .networkFailure:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// HTTP 상태 코드 (있는 경우)
+    var statusCode: Int? {
+        switch self {
+        case .unauthorized: return 401
+        case .forbidden: return 403
+        case .notFound: return 404
+        case .conflict: return 409
+        case .validationFailed: return 400
+        case .rateLimited: return 429
+        case .serverError(let code, _): return code
+        case .httpError(let code, _): return code
+        default: return nil
+        }
+    }
+
+    /// 디버그용 상세 정보 (콘솔 로깅용)
+    var debugDescription: String {
+        switch self {
+        case .invalidURL:
+            return "[HiTripError] invalidURL"
+        case .noConnection:
+            return "[HiTripError] noConnection"
+        case .timeout:
+            return "[HiTripError] timeout"
+        case .networkFailure(let msg):
+            return "[HiTripError] networkFailure: \(msg)"
+        case .unauthorized(let d):
+            return "[HiTripError] 401 unauthorized: \(d)"
+        case .forbidden(let d):
+            return "[HiTripError] 403 forbidden: \(d)"
+        case .notFound(let d):
+            return "[HiTripError] 404 notFound: \(d)"
+        case .conflict(let d):
+            return "[HiTripError] 409 conflict: \(d)"
+        case .validationFailed(let d):
+            return "[HiTripError] 400/422 validation: \(d)"
+        case .rateLimited:
+            return "[HiTripError] 429 rateLimited"
+        case .serverError(let code, let d):
+            return "[HiTripError] \(code) serverError: \(d)"
+        case .httpError(let code, let d):
+            return "[HiTripError] \(code) httpError: \(d)"
+        case .decodingFailed(let msg):
+            return "[HiTripError] decodingFailed: \(msg)"
+        case .noData:
+            return "[HiTripError] noData"
+        case .invalidResponse:
+            return "[HiTripError] invalidResponse"
+        }
+    }
+}
+
+// MARK: - ServerErrorDetail
+/// 서버 에러 응답의 파싱 결과
+///
+/// Django REST Framework 에러 포맷:
+/// - 단일 메시지: {"detail": "Authentication credentials were not provided."}
+/// - 필드 에러:   {"username": ["This field is required."], "password": ["Too short."]}
+/// - 복합:        {"detail": "Validation failed", "errors": {...}}
+
+struct ServerErrorDetail: Equatable, CustomStringConvertible {
+
+    /// 서버가 보낸 대표 메시지 (detail 필드)
+    let message: String?
+
+    /// 필드별 에러 메시지 (Validation 에러 시)
+    let fieldErrors: [String: [String]]
+
+    /// 원본 응답 body (디버깅용)
+    let rawBody: String?
+
+    /// HTTP 상태 코드
+    let statusCode: Int
+
+    // MARK: - 사용자 표시용 메시지
+
+    /// 사용자에게 보여줄 메시지 (우선순위: 필드에러 요약 → detail → nil)
+    var userMessage: String? {
+        // 필드별 에러가 있으면 첫 번째 에러를 보여줌
+        if !fieldErrors.isEmpty {
+            let firstField = fieldErrors.first
+            if let fieldName = firstField?.key,
+               let messages = firstField?.value,
+               let firstMessage = messages.first {
+                return fieldDisplayName(fieldName) + ": " + firstMessage
+            }
+        }
+        return message
+    }
+
+    /// 모든 필드 에러를 줄바꿈으로 연결 (Alert에서 표시)
+    var allFieldErrorMessages: String? {
+        guard !fieldErrors.isEmpty else { return nil }
+        return fieldErrors.map { field, messages in
+            let name = fieldDisplayName(field)
+            return messages.map { "\(name): \($0)" }.joined(separator: "\n")
+        }.joined(separator: "\n")
+    }
+
+    var description: String {
+        var parts: [String] = []
+        if let message { parts.append("message=\(message)") }
+        if !fieldErrors.isEmpty { parts.append("fields=\(fieldErrors)") }
+        return "ServerErrorDetail(\(parts.joined(separator: ", ")))"
+    }
+
+    // MARK: - Private
+
+    /// 서버 필드명 → 한글 표시명 변환
+    private func fieldDisplayName(_ field: String) -> String {
+        let map: [String: String] = [
+            "username": "아이디",
+            "password": "비밀번호",
+            "email": "이메일",
+            "phone": "전화번호",
+            "title": "제목",
+            "destination": "목적지",
+            "start_date": "시작일",
+            "end_date": "종료일",
+            "birth_date": "생년월일",
+            "invite_code": "초대코드",
+            "name": "이름",
+            "nickname": "닉네임",
+            "non_field_errors": "입력 오류",
+            "detail": "상세",
+        ]
+        return map[field] ?? field
+    }
+}
+
+// MARK: - ServerErrorDetail 파싱
+
+extension ServerErrorDetail {
+
+    /// 서버 응답 Data를 파싱하여 ServerErrorDetail 생성
+    ///
+    /// Django REST Framework 에러 형식을 처리:
+    /// 1. {"detail": "string"} — 단일 메시지
+    /// 2. {"field": ["error1", "error2"]} — 필드별 Validation
+    /// 3. {"detail": "msg", "field": [...]} — 혼합
+    static func parse(data: Data?, statusCode: Int) -> ServerErrorDetail {
+        let rawBody = data.flatMap { String(data: $0, encoding: .utf8) }
+
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return ServerErrorDetail(
+                message: nil,
+                fieldErrors: [:],
+                rawBody: rawBody,
+                statusCode: statusCode
+            )
+        }
+
+        // detail 필드 추출
+        var message: String?
+        if let detail = json["detail"] as? String {
+            message = detail
+        } else if let detailArray = json["detail"] as? [String] {
+            message = detailArray.joined(separator: " ")
+        }
+
+        // 필드별 에러 추출
+        var fieldErrors: [String: [String]] = [:]
+        for (key, value) in json {
+            if key == "detail" { continue }
+            if let messages = value as? [String] {
+                fieldErrors[key] = messages
+            } else if let singleMessage = value as? String {
+                fieldErrors[key] = [singleMessage]
+            }
+        }
+
+        // non_field_errors 처리
+        if let nonFieldErrors = json["non_field_errors"] as? [String] {
+            fieldErrors["non_field_errors"] = nonFieldErrors
+            if message == nil {
+                message = nonFieldErrors.first
+            }
+        }
+
+        return ServerErrorDetail(
+            message: message,
+            fieldErrors: fieldErrors,
+            rawBody: rawBody,
+            statusCode: statusCode
+        )
+    }
+
+    /// 빈 에러 디테일 생성 (서버 응답이 없을 때)
+    static func empty(statusCode: Int) -> ServerErrorDetail {
+        ServerErrorDetail(message: nil, fieldErrors: [:], rawBody: nil, statusCode: statusCode)
+    }
+}
+
+// MARK: - HiTripError 팩토리
+
+extension HiTripError {
+
+    /// HTTP 상태코드 + 응답 Data로 적절한 HiTripError 생성
+    static func from(statusCode: Int, data: Data?) -> HiTripError {
+        let detail = ServerErrorDetail.parse(data: data, statusCode: statusCode)
+
+        switch statusCode {
+        case 400, 422:
+            return .validationFailed(detail)
+        case 401:
+            return .unauthorized(detail)
+        case 403:
+            return .forbidden(detail)
+        case 404:
+            return .notFound(detail)
+        case 409:
+            return .conflict(detail)
+        case 429:
+            return .rateLimited
+        case 500...599:
+            return .serverError(statusCode, detail)
+        default:
+            return .httpError(statusCode, detail)
+        }
+    }
+
+    /// URLSession 에러를 HiTripError로 변환
+    static func from(urlError: Error) -> HiTripError {
+        let nsError = urlError as NSError
+
+        switch nsError.code {
+        case NSURLErrorNotConnectedToInternet,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorDataNotAllowed:
+            return .noConnection
+
+        case NSURLErrorTimedOut:
+            return .timeout
+
+        case NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorDNSLookupFailed:
+            return .networkFailure("서버에 연결할 수 없습니다.")
+
+        case NSURLErrorSecureConnectionFailed,
+             NSURLErrorServerCertificateUntrusted:
+            return .networkFailure("보안 연결에 실패했습니다.")
+
+        default:
+            return .networkFailure(urlError.localizedDescription)
+        }
+    }
+}
+
+// MARK: - 기존 NetworkError → HiTripError 변환 (마이그레이션용)
+
+extension NetworkError {
+
+    /// 기존 NetworkError를 HiTripError로 변환
+    var toHiTripError: HiTripError {
+        switch self {
+        case .invalidURL:
+            return .invalidURL
+        case .requestFailed(let msg):
+            return .networkFailure(msg)
+        case .invalidResponse:
+            return .invalidResponse
+        case .httpError(let code):
+            return .from(statusCode: code, data: nil)
+        case .noData:
+            return .noData
+        case .decodingFailed(let msg):
+            return .decodingFailed(msg)
+        }
+    }
+}

--- a/HiTrip/Core/Network/NetworkService.swift
+++ b/HiTrip/Core/Network/NetworkService.swift
@@ -30,8 +30,7 @@ final class NetworkService {
     /// 프로덕션 전용 싱글턴 초기화
     /// - private으로 외부에서 직접 생성 방지
     private init() {
-        // TODO: 실제 서버 배포 후 URL 변경
-        self.baseURL = "https://api.hitrip.example.com/v1"
+        self.baseURL = APIEnvironment.current.baseURL
         self.session = .shared
     }
 
@@ -66,41 +65,75 @@ final class NetworkService {
         return Single.create { [weak self] single in
             guard let self,
                   let request = self.buildRequest(endpoint) else {
-                single(.failure(NetworkError.invalidURL))
+                print("❌ [Network] URL 생성 실패 | path: \(endpoint.path)")
+                single(.failure(HiTripError.invalidURL))
                 return Disposables.create()
+            }
+
+            // 디버그: 모든 API 요청 로깅
+            let method = endpoint.method.rawValue
+            let url = request.url?.absoluteString ?? ""
+            print("🌐 [Network] \(method) \(url)")
+            if let body = endpoint.body {
+                print("   📦 Body: \(body)")
             }
 
             let task = self.session.dataTask(with: request) { data, response, error in
                 // 1) 네트워크 에러 (인터넷 끊김, 타임아웃 등)
                 if let error {
-                    single(.failure(NetworkError.requestFailed(error.localizedDescription)))
+                    let hiTripError = HiTripError.from(urlError: error)
+                    print("❌ [Network] \(hiTripError.debugDescription) | \(url)")
+                    single(.failure(hiTripError))
                     return
                 }
 
                 // 2) HTTPURLResponse 캐스팅 확인
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    single(.failure(NetworkError.invalidResponse))
+                    single(.failure(HiTripError.invalidResponse))
                     return
                 }
 
-                // 3) HTTP 상태코드 검증
+                // 3) HTTP 상태코드 검증 — 서버 에러 body를 파싱하여 구체적인 에러 생성
                 guard (200...299).contains(httpResponse.statusCode) else {
-                    single(.failure(NetworkError.httpError(httpResponse.statusCode)))
+                    let hiTripError = HiTripError.from(statusCode: httpResponse.statusCode, data: data)
+                    print("❌ [Network] \(hiTripError.debugDescription) | URL: \(url)")
+
+                    // 401 토큰 만료 시 자동 로그아웃 알림 (NotificationCenter)
+                    if hiTripError.requiresReauth {
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(
+                                name: .hiTripTokenExpired,
+                                object: nil,
+                                userInfo: ["error": hiTripError]
+                            )
+                        }
+                    }
+
+                    single(.failure(hiTripError))
                     return
                 }
 
                 // 4) 데이터 존재 확인
                 guard let data else {
-                    single(.failure(NetworkError.noData))
+                    single(.failure(HiTripError.noData))
                     return
+                }
+
+                // 디버그: 성공 응답 본문 출력
+                if let body = String(data: data, encoding: .utf8) {
+                    print("✅ [Network] HTTP \(httpResponse.statusCode) | URL: \(url) | Body: \(body.prefix(500))")
                 }
 
                 // 5) JSON 디코딩
                 do {
-                    let decoded = try JSONDecoder().decode(T.self, from: data)
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .custom(NetworkService.flexibleDateDecoder)
+                    decoder.keyDecodingStrategy = .convertFromSnakeCase
+                    let decoded = try decoder.decode(T.self, from: data)
                     single(.success(decoded))
                 } catch {
-                    single(.failure(NetworkError.decodingFailed(error.localizedDescription)))
+                    print("❌ [Network] 디코딩 실패 | Type: \(T.self) | Error: \(error)")
+                    single(.failure(HiTripError.decodingFailed(error.localizedDescription)))
                 }
             }
 
@@ -121,20 +154,75 @@ final class NetworkService {
         type: T.Type
     ) async throws -> T {
         guard let request = buildRequest(endpoint) else {
-            throw NetworkError.invalidURL
+            throw HiTripError.invalidURL
         }
 
-        let (data, response) = try await session.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw HiTripError.from(urlError: error)
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.invalidResponse
+            throw HiTripError.invalidResponse
         }
 
         guard (200...299).contains(httpResponse.statusCode) else {
-            throw NetworkError.httpError(httpResponse.statusCode)
+            let hiTripError = HiTripError.from(statusCode: httpResponse.statusCode, data: data)
+            if hiTripError.requiresReauth {
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .hiTripTokenExpired, object: nil)
+                }
+            }
+            throw hiTripError
         }
 
-        return try JSONDecoder().decode(T.self, from: data)
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .custom(NetworkService.flexibleDateDecoder)
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw HiTripError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Date Decoder
+
+    /// 백엔드에서 오는 다양한 날짜 포맷을 유연하게 파싱
+    /// - ISO 8601 datetime: "2025-03-08T02:46:56.037Z"
+    /// - Date only: "2025-03-08"
+    static func flexibleDateDecoder(_ decoder: Decoder) throws -> Date {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+
+        // ISO 8601 with fractional seconds
+        let iso8601Formatter = ISO8601DateFormatter()
+        iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso8601Formatter.date(from: dateString) {
+            return date
+        }
+
+        // ISO 8601 without fractional seconds
+        iso8601Formatter.formatOptions = [.withInternetDateTime]
+        if let date = iso8601Formatter.date(from: dateString) {
+            return date
+        }
+
+        // Date only (yyyy-MM-dd)
+        let dateOnly = DateFormatter()
+        dateOnly.dateFormat = "yyyy-MM-dd"
+        dateOnly.locale = Locale(identifier: "en_US_POSIX")
+        if let date = dateOnly.date(from: dateString) {
+            return date
+        }
+
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Cannot decode date: \(dateString)"
+        )
     }
 
     // MARK: - Private: URLRequest 빌드
@@ -173,10 +261,17 @@ final class NetworkService {
     }
 }
 
-// MARK: - NetworkError
+// MARK: - Notification Names
 
-/// 네트워크 에러 타입 정의
-/// LocalizedError 채택으로 .localizedDescription에서 한글 메시지 반환
+extension Notification.Name {
+    /// 토큰 만료 시 발송 — AppDelegate/SceneDelegate에서 수신하여 로그인 화면으로 전환
+    static let hiTripTokenExpired = Notification.Name("hiTripTokenExpired")
+}
+
+// MARK: - NetworkError (Deprecated — 호환용)
+
+/// 기존 네트워크 에러 타입 (HiTripError로 마이그레이션 권장)
+/// @available(*, deprecated, message: "Use HiTripError instead")
 enum NetworkError: LocalizedError {
     /// URL 조합 실패
     case invalidURL

--- a/HiTrip/Core/Utils/ErrorHandler.swift
+++ b/HiTrip/Core/Utils/ErrorHandler.swift
@@ -1,0 +1,182 @@
+import Foundation
+import RxSwift
+import RxRelay
+
+// MARK: - ErrorHandler
+/// ViewModel에서 공통으로 사용하는 에러 핸들링 유틸리티
+///
+/// 설계 의도:
+/// - 모든 ViewModel이 동일한 방식으로 에러를 처리하도록 중앙화
+/// - HiTripError → 사용자 Alert 메시지 자동 변환
+/// - 재시도 가능 여부 판단 + 자동 재시도 지원
+/// - 토큰 만료 시 로그인 화면 전환 트리거
+///
+/// 사용법:
+/// ```swift
+/// class TripViewModel {
+///     let errorHandler = ErrorHandler()
+///
+///     func loadTrips() {
+///         useCase.fetchTrips()
+///             .subscribe(
+///                 onSuccess: { [weak self] trips in ... },
+///                 onFailure: { [weak self] error in
+///                     self?.errorHandler.handle(error)
+///                 }
+///             )
+///     }
+/// }
+/// ```
+///
+/// SwiftUI View에서:
+/// ```swift
+/// .alert(item: $viewModel.errorHandler.alertItem) { item in
+///     Alert(title: Text(item.title), message: Text(item.message), ...)
+/// }
+/// ```
+
+final class ErrorHandler: ObservableObject {
+
+    // MARK: - Published (SwiftUI 바인딩용)
+
+    /// 현재 표시할 에러 Alert 정보
+    @Published var alertItem: AlertItem?
+
+    /// 에러 발생 여부 (로딩 상태 전환 등에 활용)
+    @Published var hasError: Bool = false
+
+    // MARK: - RxSwift (MVVM 바인딩용)
+
+    /// 에러 메시지를 방출하는 Relay (ViewModel → View 바인딩)
+    let errorMessage = PublishRelay<String>()
+
+    /// 에러 상세를 방출하는 Relay (디버깅/로깅용)
+    let errorDetail = PublishRelay<HiTripError>()
+
+    /// 재시도 트리거 Relay
+    let retryTrigger = PublishRelay<Void>()
+
+    // MARK: - Handle
+
+    /// 에러를 처리하여 사용자 메시지로 변환
+    ///
+    /// 동작:
+    /// 1. HiTripError로 변환 (아니면 래핑)
+    /// 2. 토큰 만료면 Notification 발송 (로그인 화면 전환)
+    /// 3. 사용자 메시지를 alertItem + errorMessage Relay로 방출
+    /// 4. 재시도 가능 에러면 Alert에 재시도 버튼 포함
+    func handle(_ error: Error, context: String? = nil) {
+        let hiTripError = Self.classify(error)
+        let message = hiTripError.localizedDescription
+
+        // 콘솔 로깅
+        if let context {
+            print("⚠️ [ErrorHandler] \(context): \(hiTripError.debugDescription)")
+        } else {
+            print("⚠️ [ErrorHandler] \(hiTripError.debugDescription)")
+        }
+
+        // Rx Relay 방출
+        errorMessage.accept(message)
+        errorDetail.accept(hiTripError)
+
+        // SwiftUI 바인딩
+        hasError = true
+        alertItem = AlertItem(
+            title: Self.alertTitle(for: hiTripError),
+            message: message,
+            isRetryable: hiTripError.isRetryable
+        )
+    }
+
+    /// 에러를 조용히 처리 (사용자에게 표시하지 않음, 로깅만)
+    func handleSilently(_ error: Error, context: String? = nil) {
+        let hiTripError = Self.classify(error)
+        if let context {
+            print("🔇 [ErrorHandler] \(context): \(hiTripError.debugDescription)")
+        } else {
+            print("🔇 [ErrorHandler] \(hiTripError.debugDescription)")
+        }
+        errorDetail.accept(hiTripError)
+    }
+
+    /// Alert 닫기
+    func dismissAlert() {
+        alertItem = nil
+        hasError = false
+    }
+
+    // MARK: - Static Helpers
+
+    /// 임의의 Error를 HiTripError로 분류
+    static func classify(_ error: Error) -> HiTripError {
+        // 이미 HiTripError인 경우
+        if let htError = error as? HiTripError {
+            return htError
+        }
+
+        // 기존 NetworkError인 경우 (마이그레이션)
+        if let networkError = error as? NetworkError {
+            return networkError.toHiTripError
+        }
+
+        // 기존 도메인 에러들은 그대로 전파
+        // (LoginError, SignUpError 등은 LocalizedError이므로 메시지가 있음)
+
+        // URLError인 경우
+        if let urlError = error as? URLError {
+            return HiTripError.from(urlError: urlError)
+        }
+
+        // 기타 — networkFailure로 래핑
+        return .networkFailure(error.localizedDescription)
+    }
+
+    /// 에러 유형별 Alert 제목
+    static func alertTitle(for error: HiTripError) -> String {
+        switch error {
+        case .noConnection, .timeout:
+            return "연결 오류"
+        case .unauthorized:
+            return "인증 만료"
+        case .forbidden:
+            return "접근 제한"
+        case .validationFailed:
+            return "입력 오류"
+        case .notFound:
+            return "찾을 수 없음"
+        case .rateLimited:
+            return "요청 제한"
+        case .serverError:
+            return "서버 오류"
+        default:
+            return "오류"
+        }
+    }
+
+    /// 재시도 가능 여부 확인
+    static func isRetryable(_ error: Error) -> Bool {
+        classify(error).isRetryable
+    }
+
+    /// 토큰 만료 에러인지 확인
+    static func requiresReauth(_ error: Error) -> Bool {
+        classify(error).requiresReauth
+    }
+}
+
+// MARK: - AlertItem
+/// Alert 표시에 필요한 정보를 담는 모델
+
+struct AlertItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+    let isRetryable: Bool
+
+    init(title: String = "오류", message: String, isRetryable: Bool = false) {
+        self.title = title
+        self.message = message
+        self.isRetryable = isRetryable
+    }
+}

--- a/HiTrip/Data/Repositories/AuthRepository.swift
+++ b/HiTrip/Data/Repositories/AuthRepository.swift
@@ -18,11 +18,13 @@ import RxSwift
 /// - 로그인 성공 시 Keychain에 토큰/유저 정보 자동 저장
 /// - UseCase는 이 구현체를 모르고, Protocol만 알고 호출
 ///
-/// 면접 포인트:
-/// "Repository 패턴의 장점은 무엇인가요?"
-/// → "데이터 소스(네트워크, 로컬DB, 캐시)를 추상화하여
-///    UseCase가 구체적인 구현에 의존하지 않게 합니다.
-///    나중에 CoreData 캐싱을 추가해도 UseCase 코드는 변경 불필요합니다."
+/// API 연동 현황:
+/// - login: POST /api/auth/login/ → AuthLoginResponse (token/key 기반)
+/// - register: POST /api/auth/register/ → ProfileDTO
+/// - profile: GET /api/auth/profile/ → ProfileDTO
+/// - logout: POST /api/auth/logout/
+/// - refreshToken: 서버 미지원 → 기존 토큰 재사용 fallback
+/// - checkNickname: 서버 미지원 → 항상 사용 가능 반환
 
 final class AuthRepository: AuthRepositoryProtocol {
 
@@ -41,45 +43,85 @@ final class AuthRepository: AuthRepositoryProtocol {
 
     /// 로그인 API 호출 + 토큰 자동 저장
     ///
-    /// .do(onSuccess:) 사용 이유:
-    /// - .map은 값을 변환할 때, .do는 부수효과(side effect)를 실행할 때 사용
-    /// - 토큰 저장은 값 변환이 아닌 부수효과이므로 .do가 적합
-    /// - [weak self]로 메모리 누수 방지
+    /// 실제 API: POST /api/auth/login/
+    /// 응답: AuthLoginResponse { token, key, sessionid }
+    /// → 기존 LoginResponse로 변환하여 UseCase/ViewModel 코드 변경 최소화
     func login(request: LoginRequest) -> Single<LoginResponse> {
         let endpoint = APIEndpoint.login(
-            id: request.id,
+            username: request.id,
             password: request.password
         )
 
-        return networkService.request(endpoint, type: LoginResponse.self)
-            .do(onSuccess: { [weak self] response in
-                // 로그인 성공 시 Keychain에 토큰 + 유저 정보 저장
-                self?.keychain.saveToken(response.accessToken)
-                self?.keychain.saveRefreshToken(response.refreshToken)
-                self?.keychain.saveUserId(response.user.id)
-                self?.keychain.saveUserType(response.user.userType.rawValue)
-            })
+        return networkService.request(endpoint, type: AuthLoginResponse.self)
+            .map { [weak self] authResponse in
+                guard let self else { throw HiTripError.invalidResponse }
+
+                // 1) 토큰 저장 (토큰 기반 인증인 경우)
+                let token = authResponse.token ?? authResponse.key ?? "session-auth"
+                self.keychain.saveToken(token)
+
+                // 2) ✅ 서버 UserDetail 정보를 Keychain에 저장
+                let displayName = authResponse.displayName
+                let displayEmail = authResponse.displayEmail
+
+                self.keychain.saveUserName(displayName)
+                self.keychain.saveUserEmail(displayEmail)
+
+                if let userId = authResponse.id {
+                    self.keychain.saveUserId(String(userId))
+                }
+                if let role = authResponse.role {
+                    self.keychain.saveUserType(role)
+                }
+
+                print("✅ [Auth] 유저 정보 저장: name=\(displayName), email=\(displayEmail), role=\(authResponse.role ?? "none")")
+
+                // 3) 기존 LoginResponse 형태로 변환 (UseCase/ViewModel 호환)
+                let userType: UserType = (authResponse.role == "super_admin" || authResponse.role == "coordinator") ? .guide : .tourist
+
+                let userInfo = UserInfo(
+                    id: authResponse.id.map(String.init) ?? "0",
+                    name: displayName,
+                    userType: userType,
+                    phone: authResponse.phone,
+                    country: nil
+                )
+                return LoginResponse(
+                    accessToken: token,
+                    refreshToken: token,
+                    user: userInfo
+                )
+            }
     }
 
     // MARK: - 토큰 갱신
 
-    /// Refresh Token으로 새 Access Token 발급
-    ///
-    /// 호출 시점: Access Token 만료 시 (HTTP 401 응답)
-    /// 동작: Keychain의 Refresh Token → 서버에 갱신 요청 → 새 토큰 저장
+    /// Refresh Token 갱신
+    /// 현재 서버에 refresh 엔드포인트가 없으므로,
+    /// 기존 토큰이 있으면 그대로 반환 (세션 기반 인증)
     func refreshToken() -> Single<LoginResponse> {
-        guard let token = keychain.getRefreshToken() else {
-            return .error(LoginError.invalidCredentials)
+        guard let token = keychain.getToken() else {
+            return .error(HiTripError.unauthorized(
+                ServerErrorDetail(message: "저장된 인증 정보가 없습니다.", fieldErrors: [:], rawBody: nil, statusCode: 401)
+            ))
         }
 
-        return networkService.request(
-            APIEndpoint.refreshToken(token: token),
-            type: LoginResponse.self
-        )
-        .do(onSuccess: { [weak self] response in
-            self?.keychain.saveToken(response.accessToken)
-            self?.keychain.saveRefreshToken(response.refreshToken)
-        })
+        // 서버에 refresh API가 없으므로 기존 토큰으로 프로필 조회하여 유효성 확인
+        return networkService.request(APIEndpoint.profile(), type: ProfileDTO.self)
+            .map { profileDTO in
+                let user = profileDTO.toUser()
+                return LoginResponse(
+                    accessToken: token,
+                    refreshToken: token,
+                    user: UserInfo(
+                        id: user.id.uuidString,
+                        name: user.nickname,
+                        userType: .tourist,
+                        phone: nil,
+                        country: nil
+                    )
+                )
+            }
     }
 
     // MARK: - 토큰 조회
@@ -92,26 +134,61 @@ final class AuthRepository: AuthRepositoryProtocol {
 
     // MARK: - 로그아웃
 
-    /// Keychain의 모든 인증 데이터 삭제
+    /// 서버 로그아웃 호출 + Keychain 데이터 삭제
     func logout() {
+        // 서버에 로그아웃 알림 (실패해도 로컬은 삭제)
+        _ = networkService.request(APIEndpoint.logout(), type: EmptyResponse.self)
+            .subscribe()
         keychain.clearAll()
     }
 
     // MARK: - 닉네임 중복 확인
 
+    /// 현재 서버에 닉네임 중복 확인 API가 없음
+    /// → 항상 사용 가능으로 반환 (서버 추가 시 연동 예정)
     func checkNickname(_ nickname: String) -> Single<NicknameCheckResponse> {
-        let endpoint = APIEndpoint.checkNickname(nickname)
-        return networkService.request(endpoint, type: NicknameCheckResponse.self)
+        return .just(NicknameCheckResponse(isAvailable: true, message: nil))
     }
 
     // MARK: - 회원가입
 
+    /// 회원가입 API: POST /api/auth/register/
+    /// 서버 응답(ProfileDTO)을 기존 SignUpResponse로 변환
     func signUp(request: SignUpRequest) -> Single<SignUpResponse> {
-        let endpoint = APIEndpoint.signUp(
-            nickname: request.nickname,
-            userId: request.userId,
-            password: request.password
+        let endpoint = APIEndpoint.register(
+            username: request.userId,
+            password: request.password,
+            email: "\(request.userId)@hitrip.app"  // 이메일 필수 → userId 기반 자동 생성
         )
-        return networkService.request(endpoint, type: SignUpResponse.self)
+
+        print("📤 [Auth] 회원가입 요청: username=\(request.userId), email=\(request.userId)@hitrip.app")
+
+        return networkService.request(endpoint, type: ProfileDTO.self)
+            .do(onSuccess: { dto in
+                print("✅ [Auth] 회원가입 성공: \(dto)")
+            }, onError: { error in
+                print("❌ [Auth] 회원가입 실패: \(error)")
+            })
+            .map { [weak self] profileDTO in
+                let user = profileDTO.toUser()
+
+                // ✅ 회원가입 후에도 유저 정보를 Keychain에 저장
+                self?.keychain.saveUserName(user.nickname)
+                self?.keychain.saveUserEmail(user.email)
+                if let id = profileDTO.id {
+                    self?.keychain.saveUserId(String(id))
+                }
+
+                return SignUpResponse(
+                    message: "회원가입이 완료되었습니다.",
+                    user: UserInfo(
+                        id: profileDTO.id.map(String.init) ?? user.id.uuidString,
+                        name: user.nickname,
+                        userType: .tourist,
+                        phone: profileDTO.phone,
+                        country: nil
+                    )
+                )
+            }
     }
 }

--- a/HiTrip/Data/Repositories/RemoteScheduleRepository.swift
+++ b/HiTrip/Data/Repositories/RemoteScheduleRepository.swift
@@ -1,0 +1,118 @@
+import Foundation
+import RxSwift
+
+// MARK: - RemoteScheduleRepository
+/// 실제 백엔드 API를 호출하는 Schedule Repository
+///
+/// API: /api/trips/:trip_pk/schedules/
+/// 여행사가 등록한 공식 일정을 서버에서 가져오거나 수정
+
+final class RemoteScheduleRepository: ScheduleRepositoryProtocol {
+
+    // MARK: - Properties
+
+    private let networkService: NetworkService
+    /// 현재 활성 여행의 서버 ID (trip_pk)
+    /// TripDataStore에서 설정하거나, 첫 trips 조회 시 자동 설정
+    var activeTripPk: Int?
+
+    // MARK: - Init
+
+    init(networkService: NetworkService = .shared) {
+        self.networkService = networkService
+    }
+
+    // MARK: - CRUD
+
+    func create(schedule: Schedule) -> Single<Schedule> {
+        guard let tripPk = activeTripPk else {
+            return .error(HiTripError.validationFailed(
+                ServerErrorDetail(message: "활성 여행이 없습니다.", fieldErrors: [:], rawBody: nil, statusCode: 400)
+            ))
+        }
+
+        let body: [String: Any] = [
+            "title": schedule.title,
+            "day": 1,
+            "time_block": "morning",
+            "start_time": formatTime(schedule.date),
+            "end_time": formatTime(schedule.date),
+            "notes": schedule.description
+        ]
+
+        return networkService.request(
+            .schedulesCreate(tripPk: tripPk, body: body),
+            type: ScheduleDTO.self
+        )
+        .map { $0.toSchedule() }
+    }
+
+    func fetchAll() -> Single<[Schedule]> {
+        guard let tripPk = activeTripPk else {
+            return .just([])
+        }
+
+        return networkService.request(
+            .schedulesList(tripPk: tripPk),
+            type: [ScheduleDTO].self
+        )
+        .map { dtos in dtos.map { $0.toSchedule() } }
+        .catch { error in
+            print("⚠️ [ScheduleRepo] fetchAll 실패: \(error)")
+            if let htError = error as? HiTripError, htError.isRetryable {
+                return .just([])
+            }
+            return .error(error)
+        }
+    }
+
+    func fetchById(id: UUID) -> Single<Schedule> {
+        return .error(HiTripError.notFound(.empty(statusCode: 404)))
+    }
+
+    func update(schedule: Schedule) -> Single<Schedule> {
+        // TODO: UUID → Int 매핑 구현 후 서버 호출 연결
+        return .just(schedule)
+    }
+
+    func delete(id: UUID) -> Single<Void> {
+        // TODO: UUID → Int 매핑 구현 후 서버 호출 연결
+        return .just(())
+    }
+
+    // MARK: - 공식 일정 전용 API
+
+    /// 여행의 공식 일정(TripOfficialSchedule) 목록을 서버에서 가져와 변환
+    func fetchOfficialSchedules(tripPk: Int) -> Single<[TripOfficialSchedule]> {
+        networkService.request(
+            .schedulesList(tripPk: tripPk),
+            type: [ScheduleDTO].self
+        )
+        .map { dtos in
+            dtos.map { $0.toOfficialSchedule() }
+        }
+        .catch { error in
+            print("⚠️ [ScheduleRepo] fetchOfficialSchedules 실패: \(error)")
+            if let htError = error as? HiTripError, htError.isRetryable {
+                return .just([])
+            }
+            return .error(error)
+        }
+    }
+
+    /// AI 일정 재조정 요청
+    func rebalanceDay(tripPk: Int, day: Int) -> Single<[ScheduleDTO]> {
+        networkService.request(
+            .schedulesRebalanceDay(tripPk: tripPk, day: day),
+            type: [ScheduleDTO].self
+        )
+    }
+
+    // MARK: - Private
+
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+}

--- a/HiTrip/Data/Repositories/RemoteTripRepository.swift
+++ b/HiTrip/Data/Repositories/RemoteTripRepository.swift
@@ -1,0 +1,162 @@
+import Foundation
+import RxSwift
+
+// MARK: - RemoteTripRepository
+/// 실제 백엔드 API를 호출하는 Trip Repository
+///
+/// MockTripRepository와 동일한 TripRepositoryProtocol을 구현하므로,
+/// AppDIContainer에서 환경에 따라 교체 가능.
+///
+/// API 연동 흐름:
+/// 1. NetworkService로 API 호출
+/// 2. TripDTO 응답 수신
+/// 3. DTO → 앱 내부 모델(TripPackage, Trip 등)로 변환
+/// 4. 변환된 모델 반환
+
+final class RemoteTripRepository: TripRepositoryProtocol {
+
+    // MARK: - Properties
+
+    private let networkService: NetworkService
+    /// 서버에서 받은 여행 ID를 캐싱 (UUID ↔ Int 매핑용)
+    private var tripIdMap: [UUID: Int] = [:]
+
+    // MARK: - Init
+
+    init(networkService: NetworkService = .shared) {
+        self.networkService = networkService
+    }
+
+    // MARK: - TripPackage
+
+    func fetchCurrentPackage() -> Single<TripPackage?> {
+        networkService.request(.tripsList(), type: [TripDTO].self)
+            .map { [weak self] dtos in
+                guard let first = dtos.first(where: { $0.status == "active" || $0.status == "ongoing" }) ?? dtos.first else {
+                    return nil
+                }
+                let pkg = first.toTripPackage()
+                self?.tripIdMap[pkg.id] = first.id
+                return pkg
+            }
+            .catch { error in
+                print("⚠️ [TripRepo] fetchCurrentPackage 실패: \(error)")
+                // 네트워크 에러는 nil 반환 (오프라인 대응), 그 외는 전파
+                if let htError = error as? HiTripError, htError.isRetryable {
+                    return .just(nil)
+                }
+                return .error(error)
+            }
+    }
+
+    func fetchPackages() -> Single<[TripPackage]> {
+        networkService.request(.tripsList(), type: [TripDTO].self)
+            .map { [weak self] dtos in
+                dtos.map { dto in
+                    let pkg = dto.toTripPackage()
+                    self?.tripIdMap[pkg.id] = dto.id
+                    return pkg
+                }
+            }
+            .catch { error in
+                print("⚠️ [TripRepo] fetchPackages 실패: \(error)")
+                if let htError = error as? HiTripError, htError.isRetryable {
+                    return .just([])
+                }
+                return .error(error)
+            }
+    }
+
+    // MARK: - Trip
+
+    func fetchTrips() -> Single<[Trip]> {
+        networkService.request(.tripsList(), type: [TripDTO].self)
+            .map { dtos in dtos.map { $0.toTrip() } }
+            .catch { error in
+                print("⚠️ [TripRepo] fetchTrips 실패: \(error)")
+                if let htError = error as? HiTripError, htError.isRetryable {
+                    return .just([])
+                }
+                return .error(error)
+            }
+    }
+
+    func createTrip(_ trip: Trip) -> Single<Trip> {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        return networkService.request(
+            .tripsCreate(
+                title: trip.title,
+                startDate: dateFormatter.string(from: trip.date),
+                endDate: dateFormatter.string(from: trip.date),
+                destination: trip.location
+            ),
+            type: TripDTO.self
+        )
+        .map { $0.toTrip() }
+    }
+
+    func deleteTrip(id: UUID) -> Single<Void> {
+        guard let serverId = tripIdMap[id] else {
+            return .error(HiTripError.notFound(.empty(statusCode: 404)))
+        }
+        return networkService.request(.tripsDestroy(id: serverId), type: EmptyResponse.self)
+            .map { _ in () }
+    }
+
+    // MARK: - Todo (로컬 저장 — 서버 API 없음)
+
+    private var localTodos: [TripTodo] = []
+
+    func fetchTodos(tripId: UUID) -> Single<[TripTodo]> {
+        .just(localTodos.filter { $0.tripId == tripId })
+    }
+
+    func createTodo(_ todo: TripTodo) -> Single<TripTodo> {
+        localTodos.append(todo)
+        return .just(todo)
+    }
+
+    func updateTodo(_ todo: TripTodo) -> Single<TripTodo> {
+        if let i = localTodos.firstIndex(where: { $0.id == todo.id }) {
+            localTodos[i] = todo
+        }
+        return .just(todo)
+    }
+
+    func deleteTodo(id: UUID) -> Single<Void> {
+        localTodos.removeAll { $0.id == id }
+        return .just(())
+    }
+
+    // MARK: - Event (로컬 저장 — 서버 API 없음)
+
+    private var localEvents: [TripEvent] = []
+
+    func fetchEvents(tripId: UUID) -> Single<[TripEvent]> {
+        .just(localEvents.filter { $0.tripId == tripId })
+    }
+
+    func createEvent(_ event: TripEvent) -> Single<TripEvent> {
+        localEvents.append(event)
+        return .just(event)
+    }
+
+    func updateEvent(_ event: TripEvent) -> Single<TripEvent> {
+        if let i = localEvents.firstIndex(where: { $0.id == event.id }) {
+            localEvents[i] = event
+        }
+        return .just(event)
+    }
+
+    func deleteEvent(id: UUID) -> Single<Void> {
+        localEvents.removeAll { $0.id == id }
+        return .just(())
+    }
+}
+
+// MARK: - EmptyResponse
+/// DELETE 등 빈 응답용
+
+struct EmptyResponse: Decodable {}

--- a/HiTrip/Domain/Entities/User.swift
+++ b/HiTrip/Domain/Entities/User.swift
@@ -55,3 +55,13 @@ struct NicknameCheckResponse: Codable {
     let isAvailable: Bool
     let message: String?
 }
+
+// MARK: - User (프로필 도메인 모델)
+/// 앱 내부에서 사용하는 사용자 프로필 모델
+/// ProfileDTO.toUser()에서 서버 응답을 이 모델로 변환
+struct User: Identifiable {
+    let id: UUID
+    let nickname: String
+    let email: String
+    let profileImageName: String?
+}

--- a/HiTrip/Domain/UseCases/LoginUseCase.swift
+++ b/HiTrip/Domain/UseCases/LoginUseCase.swift
@@ -42,12 +42,18 @@ final class LoginUseCase {
     ///   - password: 사용자 입력 비밀번호 (생년월일)
     /// - Returns: 로그인 성공 시 UserInfo
     func execute(id: String, password: String) -> Single<UserInfo> {
-        // 입력 검증 — 빈 값이면 즉시 에러 반환 (네트워크 호출 불필요)
+        // 입력 검증 — 조건 미충족 시 즉시 에러 반환 (네트워크 호출 불필요)
         guard !id.trimmed.isEmpty else {
             return .error(LoginError.emptyId)
         }
+        guard id.trimmed.count >= 4 else {
+            return .error(LoginError.idTooShort)
+        }
         guard !password.trimmed.isEmpty else {
             return .error(LoginError.emptyPassword)
+        }
+        guard password.count >= 8 else {
+            return .error(LoginError.passwordTooShort)
         }
 
         // Repository에 API 호출 위임
@@ -74,10 +80,14 @@ final class LoginUseCase {
 /// 로그인 관련 에러 정의
 /// LocalizedError 채택 → .localizedDescription으로 한글 메시지 바로 사용 가능
 enum LoginError: LocalizedError, Equatable {
-    /// ID(성함) 미입력
+    /// 아이디 미입력
     case emptyId
-    /// 비밀번호(생년월일) 미입력
+    /// 아이디 4자 미만
+    case idTooShort
+    /// 비밀번호 미입력
     case emptyPassword
+    /// 비밀번호 8자 미만
+    case passwordTooShort
     /// 서버에서 인증 실패 (401)
     case invalidCredentials
     /// 서버 에러 (기타)
@@ -86,11 +96,15 @@ enum LoginError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .emptyId:
-            return "이름을 입력해주세요."
+            return "아이디를 입력해주세요."
+        case .idTooShort:
+            return "아이디는 4자 이상이어야 합니다."
         case .emptyPassword:
-            return "생년월일을 입력해주세요."
+            return "비밀번호를 입력해주세요."
+        case .passwordTooShort:
+            return "비밀번호는 8자 이상이어야 합니다."
         case .invalidCredentials:
-            return "이름 또는 생년월일이 올바르지 않습니다."
+            return "아이디 또는 비밀번호가 올바르지 않습니다."
         case .serverError(let msg):
             return msg
         }

--- a/HiTrip/Domain/UseCases/SignUpUseCase.swift
+++ b/HiTrip/Domain/UseCases/SignUpUseCase.swift
@@ -74,7 +74,7 @@ final class SignUpUseCase {
         guard !password.isEmpty else {
             return .error(SignUpError.emptyPassword)
         }
-        guard password.count >= 6 else {
+        guard password.count >= 8 else {
             return .error(SignUpError.passwordTooShort)
         }
 
@@ -114,7 +114,7 @@ enum SignUpError: LocalizedError, Equatable {
         case .emptyUserId:       return "아이디를 입력해주세요."
         case .userIdTooShort:    return "아이디는 4자 이상이어야 합니다."
         case .emptyPassword:     return "비밀번호를 입력해주세요."
-        case .passwordTooShort:  return "비밀번호는 6자 이상이어야 합니다."
+        case .passwordTooShort:  return "비밀번호는 8자 이상이어야 합니다."
         case .passwordMismatch:  return "비밀번호가 일치하지 않습니다."
         case .serverError(let msg): return msg
         }

--- a/HiTrip/Features/Auth/ViewModels/LoginViewModel.swift
+++ b/HiTrip/Features/Auth/ViewModels/LoginViewModel.swift
@@ -42,6 +42,23 @@ final class LoginViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var loginSuccess: Bool = false
 
+    // MARK: - Validation (회원가입 조건과 동일)
+
+    /// 아이디 유효성: 4자 이상
+    var isIdValid: Bool {
+        id.trimmed.count >= 4
+    }
+
+    /// 비밀번호 유효성: 8자 이상
+    var isPasswordValid: Bool {
+        password.count >= 8
+    }
+
+    /// 폼 전체 유효성: 아이디 4자+ & 비밀번호 8자+
+    var isFormValid: Bool {
+        isIdValid && isPasswordValid
+    }
+
     // MARK: - Dependencies
 
     private let loginUseCase: LoginUseCase

--- a/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
+++ b/HiTrip/Features/Auth/ViewModels/SignUpViewModel.swift
@@ -124,37 +124,27 @@ final class SignUpViewModel: ObservableObject {
         isLoading = true
         errorMessage = nil
 
-        // TODO: 백엔드 연동 시 실제 닉네임 중복 확인 API 호출
-        // 현재는 Mock으로 항상 사용 가능 처리 (UI 확인용)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.isLoading = false
-            self?.isNicknameChecked = true
-            self?.isNicknameAvailable = true
-            self?.nicknameMessage = "사용 가능한 닉네임입니다."
-        }
-
-        // ── 원본 API 호출 코드 (백엔드 연동 시 위 Mock 삭제 후 아래 주석 해제) ──
-        // signUpUseCase.checkNickname(nickname)
-        //     .observe(on: MainScheduler.instance)
-        //     .subscribe(
-        //         onSuccess: { [weak self] response in
-        //             self?.isLoading = false
-        //             self?.isNicknameChecked = true
-        //             self?.isNicknameAvailable = response.isAvailable
-        //             if response.isAvailable {
-        //                 self?.nicknameMessage = "사용 가능한 닉네임입니다."
-        //             } else {
-        //                 self?.nicknameMessage = "이미 사용 중인 닉네임입니다."
-        //             }
-        //         },
-        //         onFailure: { [weak self] error in
-        //             self?.isLoading = false
-        //             self?.isNicknameChecked = false
-        //             self?.isNicknameAvailable = false
-        //             self?.nicknameMessage = error.localizedDescription
-        //         }
-        //     )
-        //     .disposed(by: disposeBag)
+        signUpUseCase.checkNickname(nickname)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] response in
+                    self?.isLoading = false
+                    self?.isNicknameChecked = true
+                    self?.isNicknameAvailable = response.isAvailable
+                    if response.isAvailable {
+                        self?.nicknameMessage = "사용 가능한 닉네임입니다."
+                    } else {
+                        self?.nicknameMessage = "이미 사용 중인 닉네임입니다."
+                    }
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.isNicknameChecked = false
+                    self?.isNicknameAvailable = false
+                    self?.nicknameMessage = error.localizedDescription
+                }
+            )
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Step 2: 아이디 중복 확인
@@ -230,33 +220,24 @@ final class SignUpViewModel: ObservableObject {
         isLoading = true
         errorMessage = nil
 
-        // TODO: 백엔드 연동 시 실제 회원가입 API 호출
-        // 현재는 Mock으로 항상 성공 처리 (UI 확인용)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.isLoading = false
-            self?.signUpCompleted = true
-            self?.currentStep = .complete
-        }
-
-        // ── 원본 API 호출 코드 (백엔드 연동 시 위 Mock 삭제 후 아래 주석 해제) ──
-        // signUpUseCase.execute(
-        //     nickname: nickname,
-        //     userId: userId,
-        //     password: password,
-        //     passwordConfirm: passwordConfirm
-        // )
-        // .observe(on: MainScheduler.instance)
-        // .subscribe(
-        //     onSuccess: { [weak self] _ in
-        //         self?.isLoading = false
-        //         self?.signUpCompleted = true
-        //         self?.currentStep = .complete
-        //     },
-        //     onFailure: { [weak self] error in
-        //         self?.isLoading = false
-        //         self?.errorMessage = error.localizedDescription
-        //     }
-        // )
-        // .disposed(by: disposeBag)
+        signUpUseCase.execute(
+            nickname: nickname,
+            userId: userId,
+            password: password,
+            passwordConfirm: passwordConfirm
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] _ in
+                self?.isLoading = false
+                self?.signUpCompleted = true
+                self?.currentStep = .complete
+            },
+            onFailure: { [weak self] error in
+                self?.isLoading = false
+                self?.errorMessage = error.localizedDescription
+            }
+        )
+        .disposed(by: disposeBag)
     }
 }

--- a/HiTrip/Features/Auth/Views/LoginView.swift
+++ b/HiTrip/Features/Auth/Views/LoginView.swift
@@ -69,25 +69,64 @@ struct LoginView: View {
     // MARK: - Input Fields
 
     /// ID, Password 입력 필드
-    /// - submitLabel(.next): 키보드 리턴키를 "다음"으로 표시
-    /// - onSubmit: ID 입력 후 자동으로 Password 필드로 포커스 이동
+    /// - 회원가입과 동일 조건: 아이디 4자+, 비밀번호 8자+
+    /// - 조건 미충족 시 실시간 피드백 표시
     private var inputSection: some View {
-        VStack(spacing: 12) {
-            TextField("ID (성함)", text: $viewModel.id)
-                .padding(14)
-                .background(HiTripColor.inputBackground)
-                .cornerRadius(10)
-                .focused($focusedField, equals: .id)
-                .submitLabel(.next)
-                .onSubmit { focusedField = .password }
+        VStack(spacing: 16) {
+            // 아이디 입력
+            VStack(alignment: .leading, spacing: 6) {
+                TextField("아이디를 입력해주세요 (4자 이상)", text: $viewModel.id)
+                    .padding(14)
+                    .background(HiTripColor.inputBackground)
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(idBorderColor, lineWidth: 1)
+                    )
+                    .focused($focusedField, equals: .id)
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    .submitLabel(.next)
+                    .onSubmit { focusedField = .password }
 
-            SecureField("password (생년월일)", text: $viewModel.password)
-                .padding(14)
-                .background(HiTripColor.inputBackground)
-                .cornerRadius(10)
-                .keyboardType(.numberPad)
-                .focused($focusedField, equals: .password)
+                if !viewModel.id.isEmpty && !viewModel.isIdValid {
+                    Text("아이디는 4자 이상이어야 합니다.")
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.error)
+                }
+            }
+
+            // 비밀번호 입력
+            VStack(alignment: .leading, spacing: 6) {
+                SecureField("비밀번호를 입력해주세요 (8자 이상)", text: $viewModel.password)
+                    .padding(14)
+                    .background(HiTripColor.inputBackground)
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(passwordBorderColor, lineWidth: 1)
+                    )
+                    .focused($focusedField, equals: .password)
+
+                if !viewModel.password.isEmpty && !viewModel.isPasswordValid {
+                    Text("비밀번호는 8자 이상이어야 합니다.")
+                        .font(.system(size: 13))
+                        .foregroundColor(HiTripColor.error)
+                }
+            }
         }
+    }
+
+    // MARK: - Border Colors
+
+    private var idBorderColor: Color {
+        guard !viewModel.id.isEmpty else { return .clear }
+        return viewModel.isIdValid ? HiTripColor.readCheck : HiTripColor.error
+    }
+
+    private var passwordBorderColor: Color {
+        guard !viewModel.password.isEmpty else { return .clear }
+        return viewModel.isPasswordValid ? HiTripColor.readCheck : HiTripColor.error
     }
 
     // MARK: - Error Message
@@ -141,17 +180,19 @@ struct LoginView: View {
         } label: {
             Text("로그인")
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(
+                    viewModel.isFormValid ? .white : HiTripColor.buttonDisabledText
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(
-                    isFormValid
+                    viewModel.isFormValid
                         ? HiTripColor.buttonPrimary
                         : HiTripColor.buttonDisabled
                 )
                 .cornerRadius(10)
         }
-        .disabled(!isFormValid)
+        .disabled(!viewModel.isFormValid)
     }
 
     // MARK: - Sign Up Button
@@ -181,9 +222,5 @@ struct LoginView: View {
     }
 
     // MARK: - Validation
-
-    /// 폼 유효성: ID + PW 모두 비어있지 않아야 버튼 활성화
-    private var isFormValid: Bool {
-        !viewModel.id.trimmed.isEmpty && !viewModel.password.trimmed.isEmpty
-    }
+    // → viewModel.isFormValid로 이동 (아이디 4자+, 비밀번호 8자+)
 }

--- a/HiTrip/Features/Auth/Views/SplashView.swift
+++ b/HiTrip/Features/Auth/Views/SplashView.swift
@@ -36,13 +36,9 @@ struct SplashView: View {
 
             // 1.5초 후 자동 로그인 판단
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                // TODO: 서버 연동 후 아래 주석 해제하고 디버그 코드 삭제
-                // router.handleAutoLogin(
-                //     isLoggedIn: KeychainManager.shared.isLoggedIn
-                // )
-
-                // [DEBUG] 로그인 없이 바로 홈 화면으로 이동 (CRUD 테스트용)
-                router.navigateToHome()
+                router.handleAutoLogin(
+                    isLoggedIn: KeychainManager.shared.isLoggedIn
+                )
             }
         }
     }

--- a/HiTrip/Features/Profile/ViewModels/ProfileViewModel.swift
+++ b/HiTrip/Features/Profile/ViewModels/ProfileViewModel.swift
@@ -1,15 +1,13 @@
 import Foundation
 import Combine
+import RxSwift
 
 // MARK: - ProfileViewModel
 /// 프로필 화면의 ViewModel
 ///
-/// 유저 정보(이름, 이메일)와 통계 수치를 중앙 관리.
-/// KeychainManager에서 유저 기본 정보를 읽고,
-/// 프로필 수정 시 저장까지 담당한다.
-///
-/// 추후 API 연동 시 UserRepository를 주입받아
-/// 서버에서 프로필 데이터를 fetch/update하도록 확장한다.
+/// 1차: Keychain에서 로그인 시 저장한 유저 정보를 즉시 표시
+/// 2차: 서버 GET /api/auth/profile/ 호출하여 최신 정보로 갱신
+/// 프로필 수정 시 서버 PUT /api/auth/profile/ + Keychain 동기화
 
 final class ProfileViewModel: ObservableObject {
 
@@ -17,8 +15,10 @@ final class ProfileViewModel: ObservableObject {
 
     @Published var userName: String = ""
     @Published var userEmail: String = ""
+    @Published var userPhone: String = ""
+    @Published var userRole: String = ""
 
-    // MARK: - Published: 통계 (추후 API로 대체)
+    // MARK: - Published: 통계
 
     @Published var points: Int = 0
     @Published var tripCount: Int = 0
@@ -39,6 +39,8 @@ final class ProfileViewModel: ObservableObject {
     // MARK: - Dependencies
 
     private let keychain = KeychainManager.shared
+    private let networkService = NetworkService.shared
+    private let disposeBag = DisposeBag()
 
     // MARK: - Init
 
@@ -48,40 +50,96 @@ final class ProfileViewModel: ObservableObject {
 
     // MARK: - Load Profile
 
-    /// Keychain + Mock 통계 데이터 로드
-    /// 추후 API 연동 시 이 메서드 내부를 서버 호출로 교체
+    /// 1) Keychain 캐시에서 즉시 로드 (빠른 표시)
+    /// 2) 서버에서 최신 프로필 가져와서 갱신
     func loadProfile() {
-        // 유저 기본 정보 (Keychain에서 읽기)
-        userName = keychain.getUserName() ?? keychain.getUserId() ?? "사용자"
+        // 1차: Keychain 캐시 (즉시 표시)
+        userName = keychain.getUserName() ?? "사용자"
         userEmail = keychain.getUserEmail() ?? "이메일 없음"
+        userRole = keychain.getUserType() ?? ""
 
-        // 통계 데이터 (추후 API 응답으로 대체)
-        // TODO: UserRepository.fetchStats() → points, tripCount, bucketListCount
+        // 통계 데이터
         points = 50
         tripCount = TripDataStore.shared.trips.count
         bucketListCount = 200
 
-        // 편집 폼 초기값 세팅
+        // 편집 폼 초기값
         editNickname = userName
+
+        // 2차: 서버에서 최신 프로필 갱신
+        fetchProfileFromServer()
+    }
+
+    /// 서버 GET /api/auth/profile/ 호출하여 최신 유저 정보로 갱신
+    private func fetchProfileFromServer() {
+        networkService.request(.profile(), type: ProfileDTO.self)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] dto in
+                    guard let self else { return }
+                    let name = dto.fullNameKr ?? dto.username ?? self.userName
+                    let email = dto.email ?? self.userEmail
+
+                    // UI 갱신
+                    self.userName = name
+                    self.userEmail = email
+                    self.userPhone = dto.phone ?? ""
+                    self.userRole = dto.role ?? ""
+                    self.editNickname = name
+                    self.editPhoneNumber = dto.phone ?? ""
+
+                    // Keychain 동기화 (다른 화면에서도 최신 정보 사용)
+                    self.keychain.saveUserName(name)
+                    self.keychain.saveUserEmail(email)
+                    if let role = dto.role {
+                        self.keychain.saveUserType(role)
+                    }
+
+                    print("✅ [Profile] 서버 프로필 갱신: \(name), \(email)")
+                },
+                onFailure: { error in
+                    // 서버 실패 시 Keychain 캐시 데이터 유지 (오프라인 대응)
+                    print("⚠️ [Profile] 서버 프로필 조회 실패, 캐시 사용: \(error.localizedDescription)")
+                }
+            )
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Save Profile
 
-    /// 프로필 수정 저장
-    /// 추후 API 연동 시 UserRepository.updateProfile()로 교체
+    /// 프로필 수정 저장 — 서버 + Keychain 동기화
     func saveProfile() {
-        // Keychain에 업데이트
-        if !editNickname.trimmed.isEmpty {
-            keychain.saveUserName(editNickname.trimmed)
-        }
+        let newName = editNickname.trimmed.isEmpty ? userName : editNickname.trimmed
 
-        // 로컬 상태 반영
-        userName = editNickname.trimmed.isEmpty ? userName : editNickname.trimmed
+        // 서버에 프로필 업데이트
+        let body: [String: Any] = [
+            "first_name_kr": newName,
+            "phone": editPhoneNumber
+        ]
 
-        // TODO: API 연동 시 서버에도 저장
-        // userRepository.updateProfile(nickname: editNickname, birthday: editBirthday, ...)
-
-        showSaveAlert = true
+        networkService.request(.profileUpdate(body: body), type: ProfileDTO.self)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] dto in
+                    guard let self else { return }
+                    let updatedName = dto.fullNameKr ?? dto.username ?? newName
+                    self.userName = updatedName
+                    self.keychain.saveUserName(updatedName)
+                    if let email = dto.email {
+                        self.keychain.saveUserEmail(email)
+                    }
+                    self.showSaveAlert = true
+                    print("✅ [Profile] 프로필 수정 완료: \(updatedName)")
+                },
+                onFailure: { [weak self] error in
+                    // 서버 실패 시 로컬만 업데이트
+                    print("⚠️ [Profile] 서버 프로필 수정 실패, 로컬 저장: \(error.localizedDescription)")
+                    self?.userName = newName
+                    self?.keychain.saveUserName(newName)
+                    self?.showSaveAlert = true
+                }
+            )
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Computed

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -35,17 +35,31 @@ final class TripDataStore: ObservableObject {
 
     // MARK: - Init
 
-    /// 프로덕션 (Mock Repository)
+    /// 프로덕션 — APIEnvironment에 따라 Mock/Remote 자동 전환
     private init() {
-        self.repository = MockTripRepository()
+        self.networkService = .shared
+        self.scheduleRepository = RemoteScheduleRepository(networkService: .shared)
+        if APIEnvironment.current.useMock {
+            self.repository = MockTripRepository()
+        } else {
+            self.repository = RemoteTripRepository(networkService: .shared)
+        }
         loadInitialData()
     }
 
     /// 테스트용 — 커스텀 Repository 주입
     init(repository: TripRepositoryProtocol) {
+        self.networkService = .shared
+        self.scheduleRepository = RemoteScheduleRepository(networkService: .shared)
         self.repository = repository
         loadInitialData()
     }
+
+    /// 스케줄 Repository (서버 공식 일정 조회용)
+    private let scheduleRepository: RemoteScheduleRepository
+
+    /// NetworkService (추천 장소 등 직접 호출용)
+    private let networkService: NetworkService
 
     /// Repository에서 초기 데이터 로드
     private func loadInitialData() {
@@ -54,6 +68,12 @@ final class TripDataStore: ObservableObject {
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] package in
                 self?.currentPackage = package
+
+                // 패키지 로드 후 서버 스케줄 + 추천 장소도 가져오기
+                if let pkg = package {
+                    self?.loadServerSchedules()
+                    self?.loadServerRecommendations()
+                }
             })
             .disposed(by: disposeBag)
 
@@ -62,11 +82,65 @@ final class TripDataStore: ObservableObject {
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] trips in
                 self?.trips = trips
-                // 각 Trip의 Todo/Event도 로드
                 for trip in trips {
                     self?.loadTodos(for: trip.id)
                     self?.loadEvents(for: trip.id)
                 }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Server Schedule 로드
+
+    /// 서버에서 공식 일정 가져와서 currentPackage.officialSchedules에 반영
+    func loadServerSchedules() {
+        // 서버 Trip 목록에서 첫 번째(활성) Trip의 ID를 사용
+        networkService.request(.tripsList(), type: [TripDTO].self)
+            .observe(on: MainScheduler.instance)
+            .flatMap { [weak self] dtos -> Single<[ScheduleDTO]> in
+                guard let self,
+                      let activeTripId = dtos.first(where: { $0.status == "ongoing" })?.id ?? dtos.first?.id else {
+                    return .just([])
+                }
+                // activeTripPk 설정 (ScheduleViewModel에서도 사용)
+                self.scheduleRepository.activeTripPk = activeTripId
+                return self.networkService.request(.schedulesList(tripPk: activeTripId), type: [ScheduleDTO].self)
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] scheduleDTOs in
+                guard let self, var pkg = self.currentPackage else { return }
+
+                // 일차별로 그룹화하여 날짜 계산
+                let schedules = scheduleDTOs.compactMap { dto -> TripOfficialSchedule? in
+                    let dayOffset = (dto.dayNumber ?? 1) - 1
+                    let scheduleDate = Calendar.current.date(byAdding: .day, value: dayOffset, to: pkg.startDate) ?? pkg.startDate
+                    return dto.toOfficialSchedule(for: scheduleDate)
+                }
+
+                pkg.officialSchedules = schedules
+                self.currentPackage = pkg
+                print("✅ [TripDataStore] 서버 스케줄 \(schedules.count)개 로드 완료")
+            }, onFailure: { error in
+                print("⚠️ [TripDataStore] 서버 스케줄 로드 실패: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Server Recommendations 로드
+
+    /// 서버에서 AI 추천 장소 가져와서 currentPackage.nearbySpots에 반영
+    func loadServerRecommendations() {
+        networkService.request(.recommendationsList(), type: [RecommendationDTO].self)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] dtos in
+                guard let self, var pkg = self.currentPackage else { return }
+
+                let spots = dtos.map { $0.toNearbySpot() }
+                pkg.nearbySpots = spots
+                self.currentPackage = pkg
+                print("✅ [TripDataStore] 추천 장소 \(spots.count)개 로드 완료")
+            }, onFailure: { error in
+                print("⚠️ [TripDataStore] 추천 장소 로드 실패: \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }

--- a/HiTrip/Info.plist
+++ b/HiTrip/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>100.124.191.47</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## API 연동
- baseURL을 새 서버(100.124.191.47:18080)로 변경
- 서버 79개 API 전체 endpoint 정의 (80개 static func)
- APIEndpoint+Traveler.swift 신규: 여행객 전용 API 5개
- Staff CRUD/approve, Travelers CRUD, Places CRUD, Coordinators CRUD, Expenses CRUD, Monitoring 상세, coordinator-roles, health check 등 누락 endpoint 보완
- Info.plist에 ATS 예외 추가 (HTTP 허용)

</br>

## 커스텀 에러 시스템
- HiTripError: 14가지 에러 케이스 (네트워크/서버/클라이언트 분류)
- ServerErrorDetail: Django REST Framework 에러 body 파싱
- 401 토큰 만료 시 NotificationCenter 자동 알림
- ErrorHandler: ViewModel용 에러 처리 유틸리티
- RxSwift+ErrorHandling: 6개 편의 operator (withErrorHandling, retryOnNetworkError, trackLoading 등)
- Repository에서 retryable 에러만 fallback, 나머지는 전파

</br>

## 로그인 → 프로필 연계
- AuthLoginResponse에 UserDetail 필드 추가 (서버 실제 응답 파싱)
- 로그인/회원가입 시 Keychain에 userName, userEmail, userId, role 저장
- ProfileViewModel: Keychain 즉시 로드 + 서버 프로필 API 갱신

</br>

## 스케줄 & 추천 장소 서버 연동
- ScheduleDTO: 서버 실제 필드(placeName, mainContent, transport 등) 반영
- TripDataStore: loadServerSchedules() + loadServerRecommendations() 추가
- 패키지 로드 후 서버 공식 일정/AI 추천 장소 자동 로드