### PR TITLE
feat: 버전정보(AppInfoView) 화면 추가 + 피그마 디자인 반영

### DIFF
--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -85,12 +85,13 @@ struct AppInfoView: View {
                 .foregroundColor(HiTripColor.gray500)
                 .lineSpacing(4)
 
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
                 featureRow("실시간 안전 모니터링 및 SOS 긴급 구조 연결")
                 featureRow("여행사·가이드·여행자 통합 일정 관리")
                 featureRow("경비 정산 및 참가자 납부 현황 관리")
                 featureRow("현지 맞춤 명소 AI 기반 콘텐츠 추천")
             }
+            .padding(.top, 8)
         }
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -103,13 +104,13 @@ struct AppInfoView: View {
     private func featureRow(_ text: String) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Circle()
-                .fill(HiTripColor.primary800)
-                .frame(width: 8, height: 8)
-                .padding(.top, 6)
+                .fill(HiTripColor.gray400)
+                .frame(width: 6, height: 6)
+                .padding(.top, 7)
 
             Text(text)
-                .font(.system(size: 15))
-                .foregroundColor(HiTripColor.textBlack)
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray500)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -95,6 +95,9 @@ struct AppInfoView: View {
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .padding(.horizontal, 20)
     }
 
     private func featureRow(_ text: String) -> some View {
@@ -133,6 +136,9 @@ struct AppInfoView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .padding(.horizontal, 20)
     }
 
     private func infoRow(label: String, value: String) -> some View {

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -12,19 +12,21 @@ struct AppInfoView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 16) {
+            VStack(spacing: 0) {
                 // 히어로 헤더 (풀너비, 마진 없음)
                 heroHeader
 
                 // 서비스 소개
                 serviceSection
+                    .padding(.top, 28)
 
                 // 앱 정보
                 appInfoSection
+                    .padding(.top, 28)
 
                 // 하단 링크
                 footerLinks
-                    .padding(.top, 8)
+                    .padding(.top, 36)
                     .padding(.bottom, 40)
             }
         }

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -155,7 +155,7 @@ struct AppInfoView: View {
                 .foregroundColor(HiTripColor.textBlack)
         }
         .padding(.horizontal, 20)
-        .padding(.vertical, 16)
+        .padding(.vertical, 10)
     }
 
     // MARK: - Footer Links

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -1,36 +1,32 @@
 import SwiftUI
 
 // MARK: - AppInfoView
-/// 버전정보 화면
+/// 버전정보 화면 — 피그마 디자인 반영
 ///
-/// 서비스 소개 · 앱 정보 · 하단 링크(이용약관, 개인정보처리방침, 고객센터)
+/// 구성: 히어로 헤더 (풀너비) → 서비스 소개 카드 → 앱 정보 카드 → 하단 링크
 
 struct AppInfoView: View {
 
-    private let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    private let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
     private let buildNumber: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
-                // 히어로 헤더
+            VStack(spacing: 16) {
+                // 히어로 헤더 (풀너비, 마진 없음)
                 heroHeader
 
                 // 서비스 소개
                 serviceSection
-                    .padding(.top, 28)
 
-                // 앱 정보 테이블
+                // 앱 정보
                 appInfoSection
-                    .padding(.top, 24)
 
                 // 하단 링크
                 footerLinks
-                    .padding(.top, 32)
-
-                Spacer().frame(height: 40)
+                    .padding(.top, 8)
+                    .padding(.bottom, 40)
             }
-            .padding(.horizontal, 24)
         }
         .background(HiTripColor.screenBackground)
         .navigationTitle("버전정보")
@@ -40,53 +36,56 @@ struct AppInfoView: View {
     // MARK: - Hero Header
 
     private var heroHeader: some View {
-        VStack(spacing: 12) {
-            Spacer().frame(height: 36)
-
-            Text("Hi Trip")
-                .font(.system(size: 34, weight: .bold))
-                .foregroundColor(.white)
-
-            Text("여행 중 안전·관리·콘텐츠 통합 SaaS\n여행사·가이드·여행자를 연결하는\n스마트 여행 플랫폼")
-                .font(.system(size: 15))
-                .foregroundColor(.white.opacity(0.9))
-                .multilineTextAlignment(.center)
-                .lineSpacing(4)
-
-            Text("v\(appVersion)")
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white.opacity(0.8))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 5)
-                .background(Color.white.opacity(0.2))
-                .cornerRadius(20)
-
-            Spacer().frame(height: 36)
-        }
-        .frame(maxWidth: .infinity)
-        .background(
+        ZStack {
             LinearGradient(
-                colors: [HiTripColor.primary800, HiTripColor.secondary600],
+                colors: [HiTripColor.primary800, Color(hex: "3A5BD9")],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-        )
-        .cornerRadius(20)
-        .padding(.top, 8)
+
+            VStack(spacing: 14) {
+                Spacer().frame(height: 12)
+
+                Text("Hi Trip")
+                    .font(.system(size: 36, weight: .bold))
+                    .foregroundColor(.white)
+
+                Text("여행 중 안전·관리·콘텐츠 통합 SaaS\n여행사·가이드·여행자를 연결하는\n스마트 여행 플랫폼")
+                    .font(.system(size: 15))
+                    .foregroundColor(.white.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+
+                Text("v\(appVersion)")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.25))
+                    .clipShape(Capsule())
+
+                Spacer().frame(height: 12)
+            }
+            .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 220)
     }
 
     // MARK: - Service Section
 
     private var serviceSection: some View {
         VStack(alignment: .leading, spacing: 16) {
-            sectionTitle("서비스 소개")
+            Text("서비스 소개")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
 
             Text("하이트립은 여행 중 발생하는 모든 상황을\n하나의 플랫폼에서 처리합니다.")
                 .font(.system(size: 15))
                 .foregroundColor(HiTripColor.gray500)
                 .lineSpacing(4)
 
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 14) {
                 featureRow("실시간 안전 모니터링 및 SOS 긴급 구조 연결")
                 featureRow("여행사·가이드·여행자 통합 일정 관리")
                 featureRow("경비 정산 및 참가자 납부 현황 관리")
@@ -94,20 +93,19 @@ struct AppInfoView: View {
             }
         }
         .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
     }
 
     private func featureRow(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: .top, spacing: 12) {
             Circle()
                 .fill(HiTripColor.primary800)
-                .frame(width: 6, height: 6)
-                .padding(.top, 7)
+                .frame(width: 8, height: 8)
+                .padding(.top, 6)
 
             Text(text)
-                .font(.system(size: 14))
+                .font(.system(size: 15))
                 .foregroundColor(HiTripColor.textBlack)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -116,25 +114,25 @@ struct AppInfoView: View {
     // MARK: - App Info Section
 
     private var appInfoSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            sectionTitle("앱 정보")
+        VStack(alignment: .leading, spacing: 0) {
+            Text("앱 정보")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
 
             VStack(spacing: 0) {
                 infoRow(label: "버전", value: "v\(appVersion) (2025.05)")
-                Divider().padding(.leading, 16)
+                Divider()
                 infoRow(label: "개발사", value: "하이트립 주식회사")
-                Divider().padding(.leading, 16)
+                Divider()
                 infoRow(label: "최소 지원", value: "iOS 16.0 이상")
-                Divider().padding(.leading, 16)
-                infoRow(label: "빌드 번호", value: buildNumber)
             }
-            .background(Color.white)
-            .cornerRadius(12)
+            .padding(.bottom, 4)
         }
-        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
     }
 
     private func infoRow(label: String, value: String) -> some View {
@@ -146,25 +144,24 @@ struct AppInfoView: View {
             Spacer()
 
             Text(value)
-                .font(.system(size: 15, weight: .medium))
+                .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(HiTripColor.textBlack)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
     }
 
     // MARK: - Footer Links
 
     private var footerLinks: some View {
-        VStack(spacing: 16) {
-            HStack(spacing: 0) {
-                linkButton("이용약관")
-                Text(" · ")
-                    .foregroundColor(HiTripColor.gray300)
-                linkButton("개인정보처리방침")
-                Text(" · ")
-                    .foregroundColor(HiTripColor.gray300)
-                linkButton("고객센터")
+        VStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Text("이용약관")
+                    .foregroundColor(HiTripColor.accentLink)
+                Text("개인정보처리방침")
+                    .foregroundColor(HiTripColor.accentLink)
+                Text("고객센터")
+                    .foregroundColor(HiTripColor.accentLink)
             }
             .font(.system(size: 13))
 
@@ -173,18 +170,5 @@ struct AppInfoView: View {
                 .foregroundColor(HiTripColor.gray400)
         }
         .frame(maxWidth: .infinity)
-    }
-
-    private func linkButton(_ title: String) -> some View {
-        Text(title)
-            .foregroundColor(HiTripColor.accentLink)
-    }
-
-    // MARK: - Section Title
-
-    private func sectionTitle(_ title: String) -> some View {
-        Text(title)
-            .font(.system(size: 17, weight: .bold))
-            .foregroundColor(HiTripColor.textBlack)
     }
 }

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+// MARK: - AppInfoView
+/// 버전정보 화면
+///
+/// 서비스 소개 · 앱 정보 · 하단 링크(이용약관, 개인정보처리방침, 고객센터)
+
+struct AppInfoView: View {
+
+    private let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    private let buildNumber: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                // 히어로 헤더
+                heroHeader
+
+                // 서비스 소개
+                serviceSection
+                    .padding(.top, 28)
+
+                // 앱 정보 테이블
+                appInfoSection
+                    .padding(.top, 24)
+
+                // 하단 링크
+                footerLinks
+                    .padding(.top, 32)
+
+                Spacer().frame(height: 40)
+            }
+            .padding(.horizontal, 24)
+        }
+        .background(HiTripColor.screenBackground)
+        .navigationTitle("버전정보")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Hero Header
+
+    private var heroHeader: some View {
+        VStack(spacing: 12) {
+            Spacer().frame(height: 36)
+
+            Text("Hi Trip")
+                .font(.system(size: 34, weight: .bold))
+                .foregroundColor(.white)
+
+            Text("여행 중 안전·관리·콘텐츠 통합 SaaS\n여행사·가이드·여행자를 연결하는\n스마트 여행 플랫폼")
+                .font(.system(size: 15))
+                .foregroundColor(.white.opacity(0.9))
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+
+            Text("v\(appVersion)")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white.opacity(0.8))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 5)
+                .background(Color.white.opacity(0.2))
+                .cornerRadius(20)
+
+            Spacer().frame(height: 36)
+        }
+        .frame(maxWidth: .infinity)
+        .background(
+            LinearGradient(
+                colors: [HiTripColor.primary800, HiTripColor.secondary600],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .cornerRadius(20)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Service Section
+
+    private var serviceSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionTitle("서비스 소개")
+
+            Text("하이트립은 여행 중 발생하는 모든 상황을\n하나의 플랫폼에서 처리합니다.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+                .lineSpacing(4)
+
+            VStack(alignment: .leading, spacing: 10) {
+                featureRow("실시간 안전 모니터링 및 SOS 긴급 구조 연결")
+                featureRow("여행사·가이드·여행자 통합 일정 관리")
+                featureRow("경비 정산 및 참가자 납부 현황 관리")
+                featureRow("현지 맞춤 명소 AI 기반 콘텐츠 추천")
+            }
+        }
+        .padding(20)
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+    }
+
+    private func featureRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Circle()
+                .fill(HiTripColor.primary800)
+                .frame(width: 6, height: 6)
+                .padding(.top, 7)
+
+            Text(text)
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.textBlack)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - App Info Section
+
+    private var appInfoSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionTitle("앱 정보")
+
+            VStack(spacing: 0) {
+                infoRow(label: "버전", value: "v\(appVersion) (2025.05)")
+                Divider().padding(.leading, 16)
+                infoRow(label: "개발사", value: "하이트립 주식회사")
+                Divider().padding(.leading, 16)
+                infoRow(label: "최소 지원", value: "iOS 16.0 이상")
+                Divider().padding(.leading, 16)
+                infoRow(label: "빌드 번호", value: buildNumber)
+            }
+            .background(Color.white)
+            .cornerRadius(12)
+        }
+        .padding(20)
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+    }
+
+    private func infoRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray500)
+
+            Spacer()
+
+            Text(value)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(HiTripColor.textBlack)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - Footer Links
+
+    private var footerLinks: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 0) {
+                linkButton("이용약관")
+                Text(" · ")
+                    .foregroundColor(HiTripColor.gray300)
+                linkButton("개인정보처리방침")
+                Text(" · ")
+                    .foregroundColor(HiTripColor.gray300)
+                linkButton("고객센터")
+            }
+            .font(.system(size: 13))
+
+            Text("© 2026 Hi Trip Inc. All rights reserved.")
+                .font(.system(size: 12))
+                .foregroundColor(HiTripColor.gray400)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func linkButton(_ title: String) -> some View {
+        Text(title)
+            .foregroundColor(HiTripColor.accentLink)
+    }
+
+    // MARK: - Section Title
+
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 17, weight: .bold))
+            .foregroundColor(HiTripColor.textBlack)
+    }
+}

--- a/HiTrip/Features/Profile/Views/ProfileView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileView.swift
@@ -22,6 +22,9 @@ struct ProfileView: View {
     /// 프로필 수정 화면 이동
     @State private var showEditProfile = false
 
+    /// 버전정보 화면 이동
+    @State private var showAppInfo = false
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -80,6 +83,9 @@ struct ProfileView: View {
             }
             .navigationDestination(isPresented: $showEditProfile) {
                 ProfileEditView(viewModel: viewModel)
+            }
+            .navigationDestination(isPresented: $showAppInfo) {
+                AppInfoView()
             }
             .onAppear {
                 viewModel.loadProfile()
@@ -189,7 +195,9 @@ struct ProfileView: View {
 
             menuDivider
 
-            menuRow(icon: "info.circle", title: "버전정보") { }
+            menuRow(icon: "info.circle", title: "버전정보") {
+                showAppInfo = true
+            }
         }
         .background(Color.white)
         .cornerRadius(16)


### PR DESCRIPTION
## 📋 개요

프로필 메뉴의 **버전정보** 항목을 실제 화면으로 연결합니다.  
피그마 디자인을 기반으로 `AppInfoView`를 신규 구현하고, 디자인 디테일을 단계적으로 조정했습니다.

---

## ✨ 추가된 화면 — AppInfoView

### 구성 요소

| 섹션 | 내용 |
|------|------|
| **히어로 헤더** | 풀너비 그라데이션 배경 · 앱명 · 슬로건 · 버전 뱃지 |
| **서비스 소개** | 서비스 설명 텍스트 + 주요 기능 4가지 bullet 리스트 |
| **앱 정보** | 버전 / 개발사 / 최소 지원 iOS 버전 |
| **하단 링크** | 이용약관 · 개인정보처리방침 · 고객센터 · 저작권 문구 |

### 디자인 스펙

- **히어로**: 좌우 마진 없이 풀너비, 220pt 고정 높이, 파란 그라데이션
- **서비스 소개 / 앱 정보 카드**: 좌우 20pt 마진, cornerRadius 16, 그림자
- **bullet 리스트**: 회색 점(6pt) + 회색 텍스트(`gray400` / `gray500`), 간격 8pt
- **섹션 간격**: 카드 사이 28pt, 카드↔하단링크 36pt

---

## 🔗 진입점 연결

`ProfileView` 버전정보 메뉴 → `navigationDestination` → `AppInfoView`

```swift
// ProfileView.swift
menuRow(icon: "info.circle", title: "버전정보") {
    showAppInfo = true
}
.navigationDestination(isPresented: $showAppInfo) {
    AppInfoView()
}
```

---

## ✅ 체크리스트

- [x] 프로필 → 버전정보 탭 시 화면 전환 확인
- [x] 히어로 헤더 풀너비 레이아웃 확인
- [x] 서비스 소개 / 앱 정보 카드 마진·radius 확인
- [x] 버전 정보 (`CFBundleShortVersionString`) 동적 바인딩 확인