### PR TITLE
feat: 지도 탭 신규 구현 + KakaoMap 렌더링 수정

### DIFF
--- a/HiTrip/Core/Network/KakaoLocalAPIService.swift
+++ b/HiTrip/Core/Network/KakaoLocalAPIService.swift
@@ -1,0 +1,116 @@
+import Foundation
+import RxSwift
+
+// MARK: - Kakao Local API DTOs
+
+struct KakaoLocalPlace: Decodable, Identifiable {
+    let id: String
+    let placeName: String
+    let categoryName: String
+    let addressName: String
+    let roadAddressName: String
+    let x: String   // longitude
+    let y: String   // latitude
+    let placeUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case placeName        = "place_name"
+        case categoryName     = "category_name"
+        case addressName      = "address_name"
+        case roadAddressName  = "road_address_name"
+        case x, y
+        case placeUrl         = "place_url"
+    }
+}
+
+private struct KakaoLocalResponse: Decodable {
+    let documents: [KakaoLocalPlace]
+}
+
+// MARK: - KakaoLocalAPIService
+
+final class KakaoLocalAPIService {
+
+    private let baseURL = "https://dapi.kakao.com/v2/local/search"
+    private var authHeader: String { "KakaoAK \(APIKeys.kakaoRestAPIKey)" }
+
+    /// 카테고리 코드 기반 검색 (편의점·마트·음식점 등)
+    func searchByCategory(
+        code: String,
+        longitude: Double,
+        latitude: Double,
+        radiusMeters: Int = 1000
+    ) -> Single<[KakaoLocalPlace]> {
+        request(
+            path: "category.json",
+            params: [
+                "category_group_code": code,
+                "x": "\(longitude)",
+                "y": "\(latitude)",
+                "radius": "\(radiusMeters)",
+                "size": "15"
+            ]
+        )
+    }
+
+    /// 키워드 기반 검색 (무장애·반려동물·할랄 등)
+    func searchByKeyword(
+        keyword: String,
+        longitude: Double,
+        latitude: Double,
+        radiusMeters: Int = 1000
+    ) -> Single<[KakaoLocalPlace]> {
+        request(
+            path: "keyword.json",
+            params: [
+                "query": keyword,
+                "x": "\(longitude)",
+                "y": "\(latitude)",
+                "radius": "\(radiusMeters)",
+                "size": "15"
+            ]
+        )
+    }
+
+    // MARK: - Private
+
+    private func request(path: String, params: [String: String]) -> Single<[KakaoLocalPlace]> {
+        Single.create { [weak self] single in
+            guard let self else {
+                single(.failure(NSError(domain: "KakaoLocal", code: -1)))
+                return Disposables.create()
+            }
+
+            var components = URLComponents(string: "\(self.baseURL)/\(path)")!
+            components.queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
+
+            guard let url = components.url else {
+                single(.failure(NSError(domain: "KakaoLocal", code: -2, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
+                return Disposables.create()
+            }
+
+            var req = URLRequest(url: url)
+            req.setValue(self.authHeader, forHTTPHeaderField: "Authorization")
+
+            let task = URLSession.shared.dataTask(with: req) { data, _, error in
+                if let error = error {
+                    single(.failure(error))
+                    return
+                }
+                guard let data = data else {
+                    single(.failure(NSError(domain: "KakaoLocal", code: -3)))
+                    return
+                }
+                do {
+                    let res = try JSONDecoder().decode(KakaoLocalResponse.self, from: data)
+                    single(.success(res.documents))
+                } catch {
+                    single(.failure(error))
+                }
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
+        }
+    }
+}

--- a/HiTrip/Features/Auth/Views/HomeView.swift
+++ b/HiTrip/Features/Auth/Views/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
     enum Tab: String, CaseIterable {
         case home      = "홈"
         case calendar  = "캘린더"
-        case search    = "검색"
+        case search    = "지도"
         case message   = "메시지"
         case mypage    = "마이페이지"
 
@@ -30,7 +30,7 @@ struct HomeView: View {
             switch self {
             case .home:     return "house.fill"
             case .calendar: return "calendar"
-            case .search:   return "magnifyingglass"
+            case .search:   return "map"
             case .message:  return "bubble.left.and.bubble.right"
             case .mypage:   return "person.fill"
             }
@@ -49,9 +49,7 @@ struct HomeView: View {
                 .tabItem { Label(Tab.calendar.rawValue, systemImage: Tab.calendar.icon) }
                 .tag(Tab.calendar)
 
-            SpotListView(
-                    viewModel: AppDIContainer.shared.makeSpotViewModel()
-                )
+            NearbyMapView()
                 .tabItem { Label(Tab.search.rawValue, systemImage: Tab.search.icon) }
                 .tag(Tab.search)
 

--- a/HiTrip/Features/Map/Models/MapPlaceItem.swift
+++ b/HiTrip/Features/Map/Models/MapPlaceItem.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+// MARK: - MapCategory
+
+enum MapCategory: String, CaseIterable, Identifiable {
+    case accessible  = "무장애"
+    case petFriendly = "반려동물"
+    case halal       = "할랄"
+    case convenience = "편의점"
+    case mart        = "마트"
+    case restaurant  = "음식점"
+
+    var id: String { rawValue }
+
+    var emoji: String {
+        switch self {
+        case .accessible:  return "♿"
+        case .petFriendly: return "🐾"
+        case .halal:       return "🌙"
+        case .convenience: return "🏪"
+        case .mart:        return "🛒"
+        case .restaurant:  return "🍽️"
+        }
+    }
+
+    /// Kakao Local API 카테고리 코드 (nil이면 키워드 검색)
+    var kakaoCode: String? {
+        switch self {
+        case .convenience: return "CS2"
+        case .mart:        return "MT1"
+        case .restaurant:  return "FD6"
+        default:           return nil
+        }
+    }
+
+    /// 카테고리 코드가 없는 경우 사용할 검색 키워드
+    var keyword: String? {
+        switch self {
+        case .accessible:  return "무장애 관광"
+        case .petFriendly: return "반려동물 동반"
+        case .halal:       return "할랄"
+        default:           return nil
+        }
+    }
+}
+
+// MARK: - MapPlaceItem
+
+struct MapPlaceItem: Identifiable, Equatable, Hashable {
+    let id: String
+    let name: String
+    let address: String?
+    let latitude: Double
+    let longitude: Double
+    let category: String?
+    let isOfficialSpot: Bool  // 안내사가 등록한 공식 스팟
+    let placeUrl: String?
+
+    static func == (lhs: MapPlaceItem, rhs: MapPlaceItem) -> Bool { lhs.id == rhs.id }
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}
+
+// MARK: - Conversions
+
+extension KakaoLocalPlace {
+    func toMapPlaceItem() -> MapPlaceItem {
+        MapPlaceItem(
+            id: id,
+            name: placeName,
+            address: roadAddressName.isEmpty ? addressName : roadAddressName,
+            latitude: Double(y) ?? 0,
+            longitude: Double(x) ?? 0,
+            category: categoryName,
+            isOfficialSpot: false,
+            placeUrl: placeUrl.isEmpty ? nil : placeUrl
+        )
+    }
+}
+
+extension TravelerMapPlaceDTO {
+    func toMapPlaceItem() -> MapPlaceItem {
+        MapPlaceItem(
+            id: "official_\(id)",
+            name: name,
+            address: address,
+            latitude: Double(latitude) ?? 0,
+            longitude: Double(longitude) ?? 0,
+            category: nil,
+            isOfficialSpot: true,
+            placeUrl: nil
+        )
+    }
+}

--- a/HiTrip/Features/Map/ViewModels/MapViewModel.swift
+++ b/HiTrip/Features/Map/ViewModels/MapViewModel.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Combine
+import CoreLocation
+import RxSwift
+
+// MARK: - MapViewModel
+
+final class MapViewModel: NSObject, ObservableObject {
+
+    // MARK: - Map State
+
+    /// 지도 중심 좌표 (트립 목적지 기준 초기화, GPS 이동 시 변경)
+    @Published var mapCenter: CLLocationCoordinate2D
+    /// 실제 기기 위치
+    @Published var currentLocation: CLLocationCoordinate2D?
+    /// KakaoMapView draw 바인딩
+    @Published var drawMap = false
+
+    // MARK: - Places
+
+    /// 서버 공식 스팟 (안내사 등록)
+    @Published var officialSpots: [MapPlaceItem] = []
+    /// 카테고리/키워드 검색 결과
+    @Published var searchResults: [MapPlaceItem] = []
+    /// 카드 탭 → 상세 Sheet 표시용
+    @Published var selectedPlace: MapPlaceItem?
+
+    // MARK: - Category
+
+    @Published var selectedCategory: MapCategory?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    // MARK: - Camera Signal
+
+    /// GPS 버튼 탭 시 값이 바뀌어 KakaoMapView가 카메라를 이동시킴
+    @Published var cameraTarget: CameraTarget?
+
+    struct CameraTarget: Equatable {
+        let id = UUID()
+        let coordinate: CLLocationCoordinate2D
+        static func == (l: CameraTarget, r: CameraTarget) -> Bool { l.id == r.id }
+    }
+
+    // MARK: - Radius (Mock: 1km)
+
+    let allowedRadiusMeters: Double = 1000
+
+    // MARK: - Dependencies
+
+    private let store = TripDataStore.shared
+    private let localAPI = KakaoLocalAPIService()
+    private let locationManager = CLLocationManager()
+    private let disposeBag = DisposeBag()
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    override init() {
+        // 트립 목적지 좌표가 없으면 서울 시청 기본값
+        mapCenter = CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780)
+        super.init()
+        setupLocation()
+        loadOfficialSpots()
+        observeStore()
+    }
+
+    // MARK: - Official Spots
+
+    private func observeStore() {
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.loadOfficialSpots() }
+            .store(in: &cancellables)
+    }
+
+    private func loadOfficialSpots() {
+        // TravelerRepository.fetchMapPlaces() 결과를 Store에 추가하면 여기서 읽음
+        // 현재는 Mock: TripDataStore의 officialSchedules 위치를 활용
+        // 실 서버 연동 시: store.mapPlaces.map { $0.toMapPlaceItem() }
+        officialSpots = []
+    }
+
+    // MARK: - Category Search
+
+    func selectCategory(_ category: MapCategory) {
+        if selectedCategory == category {
+            selectedCategory = nil
+            searchResults = []
+            return
+        }
+
+        selectedCategory = category
+        searchResults = []
+        errorMessage = nil
+
+        let center = currentLocation ?? mapCenter
+        isLoading = true
+
+        let search: Single<[KakaoLocalPlace]>
+
+        if let code = category.kakaoCode {
+            search = localAPI.searchByCategory(
+                code: code,
+                longitude: center.longitude,
+                latitude: center.latitude,
+                radiusMeters: Int(allowedRadiusMeters)
+            )
+        } else if let keyword = category.keyword {
+            search = localAPI.searchByKeyword(
+                keyword: keyword,
+                longitude: center.longitude,
+                latitude: center.latitude,
+                radiusMeters: Int(allowedRadiusMeters)
+            )
+        } else {
+            isLoading = false
+            return
+        }
+
+        search
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] places in
+                    self?.isLoading = false
+                    self?.searchResults = places.map { $0.toMapPlaceItem() }
+                },
+                onFailure: { [weak self] error in
+                    self?.isLoading = false
+                    self?.errorMessage = "검색에 실패했습니다."
+                    print("⚠️ [MapViewModel] 카테고리 검색 실패: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Display Places
+
+    /// 카드 스크롤 + 마커에 표시할 전체 장소
+    /// 공식 스팟 우선 → 검색 결과
+    var displayPlaces: [MapPlaceItem] {
+        officialSpots + searchResults
+    }
+
+    // MARK: - GPS
+
+    func moveToCurrentLocation() {
+        locationManager.requestLocation()
+        if let loc = currentLocation {
+            cameraTarget = CameraTarget(coordinate: loc)
+        }
+    }
+
+    // MARK: - Location Setup
+
+    private func setupLocation() {
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.requestWhenInUseAuthorization()
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension MapViewModel: CLLocationManagerDelegate {
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let loc = locations.last else { return }
+        currentLocation = loc.coordinate
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("⚠️ [MapViewModel] 위치 오류: \(error.localizedDescription)")
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.requestLocation()
+        default:
+            break
+        }
+    }
+}

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -157,7 +157,7 @@ struct PlaceCardView: View {
         VStack(alignment: .leading, spacing: 0) {
             // 썸네일
             ZStack {
-                Color(HiTripColor.gray200)
+                HiTripColor.gray200
                 Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "mappin.and.ellipse")
                     .font(.system(size: 28))
                     .foregroundColor(place.isOfficialSpot ? HiTripColor.primary800 : .orange)

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -54,7 +54,7 @@ struct NearbyMapView: View {
         }
         .navigationTitle("지도")
         .navigationBarHidden(true)
-        .onAppear  { viewModel.drawMap = true  }
+        .onAppear  { viewModel.drawMap = true }
         .onDisappear { viewModel.drawMap = false }
         .sheet(item: $viewModel.selectedPlace) { place in
             PlaceDetailSheet(place: place)

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+import CoreLocation
+
+// MARK: - NearbyMapView
+/// 지도 탭 메인 화면
+///
+/// 구성:
+/// - 풀스크린 KakaoMap (허용 반경 + 마커)
+/// - 상단: 페이지 제목 + 카테고리 필터 칩
+/// - 우하단: GPS 버튼
+/// - 하단: 장소 카드 가로 스크롤
+
+struct NearbyMapView: View {
+
+    @StateObject private var viewModel = MapViewModel()
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            // MARK: 풀스크린 지도
+            KakaoMapView(
+                latitude: viewModel.mapCenter.latitude,
+                longitude: viewModel.mapCenter.longitude,
+                draw: $viewModel.drawMap,
+                markers: viewModel.displayPlaces,
+                userLocation: viewModel.currentLocation,
+                radiusMeters: viewModel.allowedRadiusMeters,
+                cameraTarget: viewModel.cameraTarget
+            )
+            .ignoresSafeArea()
+
+            // MARK: 상단 오버레이
+            VStack(spacing: 0) {
+                titleBar
+                    .padding(.top, 8)
+                    .padding(.horizontal, 16)
+
+                categoryBar
+                    .padding(.top, 8)
+
+                Spacer()
+
+                // MARK: 하단 GPS + 카드
+                VStack(spacing: 8) {
+                    gpsButton
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.trailing, 16)
+
+                    if !viewModel.displayPlaces.isEmpty {
+                        placeCardScroll
+                    }
+                }
+                .padding(.bottom, 24)
+            }
+        }
+        .navigationTitle("지도")
+        .navigationBarHidden(true)
+        .onAppear  { viewModel.drawMap = true  }
+        .onDisappear { viewModel.drawMap = false }
+        .sheet(item: $viewModel.selectedPlace) { place in
+            PlaceDetailSheet(place: place)
+        }
+    }
+
+    // MARK: - Title Bar
+
+    private var titleBar: some View {
+        HStack {
+            Text("주변 인기 스팟")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(HiTripColor.textBlack)
+            Spacer()
+            if viewModel.isLoading {
+                ProgressView()
+                    .scaleEffect(0.8)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .cornerRadius(14)
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+    }
+
+    // MARK: - Category Filter
+
+    private var categoryBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MapCategory.allCases) { category in
+                    categoryChip(category)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+
+    private func categoryChip(_ category: MapCategory) -> some View {
+        let isSelected = viewModel.selectedCategory == category
+        return Button {
+            viewModel.selectCategory(category)
+        } label: {
+            HStack(spacing: 4) {
+                Text(category.emoji)
+                    .font(.system(size: 13))
+                Text(category.rawValue)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(isSelected ? .white : HiTripColor.textBlack)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(isSelected ? HiTripColor.primary800 : Color.white)
+            .cornerRadius(20)
+            .shadow(color: .black.opacity(0.08), radius: 4, y: 1)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - GPS Button
+
+    private var gpsButton: some View {
+        Button {
+            viewModel.moveToCurrentLocation()
+        } label: {
+            Image(systemName: "location.fill")
+                .font(.system(size: 18))
+                .foregroundColor(HiTripColor.primary800)
+                .frame(width: 46, height: 46)
+                .background(Color.white)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
+        }
+    }
+
+    // MARK: - Place Card Scroll
+
+    private var placeCardScroll: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(viewModel.displayPlaces) { place in
+                    PlaceCardView(place: place)
+                        .onTapGesture { viewModel.selectedPlace = place }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 4)
+        }
+    }
+}
+
+// MARK: - PlaceCardView
+
+struct PlaceCardView: View {
+
+    let place: MapPlaceItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 썸네일
+            ZStack {
+                Color(HiTripColor.gray200)
+                Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "mappin.and.ellipse")
+                    .font(.system(size: 28))
+                    .foregroundColor(place.isOfficialSpot ? HiTripColor.primary800 : .orange)
+            }
+            .frame(width: 155, height: 95)
+            .clipped()
+
+            VStack(alignment: .leading, spacing: 3) {
+                if place.isOfficialSpot {
+                    Text("📍 공식 스팟")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(HiTripColor.primary800)
+                }
+                Text(place.name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+                    .lineLimit(1)
+
+                if let category = place.category, !category.isEmpty {
+                    Text(category)
+                        .font(.system(size: 11))
+                        .foregroundColor(HiTripColor.gray400)
+                        .lineLimit(1)
+                }
+                if let address = place.address, !address.isEmpty {
+                    Text(address)
+                        .font(.system(size: 11))
+                        .foregroundColor(HiTripColor.gray400)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 155)
+        .background(Color.white)
+        .cornerRadius(12)
+        .shadow(color: .black.opacity(0.08), radius: 6, y: 2)
+    }
+}
+
+// MARK: - PlaceDetailSheet
+
+struct PlaceDetailSheet: View {
+
+    let place: MapPlaceItem
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // 헤더 이미지 영역
+                    ZStack {
+                        HiTripColor.gray200
+                        Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "mappin.and.ellipse")
+                            .font(.system(size: 50))
+                            .foregroundColor(place.isOfficialSpot ? HiTripColor.primary800 : .orange)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 180)
+
+                    VStack(alignment: .leading, spacing: 20) {
+                        // 배지 + 이름
+                        VStack(alignment: .leading, spacing: 8) {
+                            if place.isOfficialSpot {
+                                Text("📍 공식 일정 스팟")
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(HiTripColor.primary800)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 4)
+                                    .background(HiTripColor.primary800.opacity(0.1))
+                                    .cornerRadius(8)
+                            }
+                            Text(place.name)
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(HiTripColor.textBlack)
+                        }
+
+                        Divider()
+
+                        if let category = place.category, !category.isEmpty {
+                            infoRow(icon: "tag", label: "카테고리", value: category)
+                        }
+                        if let address = place.address, !address.isEmpty {
+                            infoRow(icon: "mappin.and.ellipse", label: "주소", value: address)
+                        }
+                        if let url = place.placeUrl, !url.isEmpty {
+                            infoRow(icon: "link", label: "카카오맵", value: url)
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                            .foregroundColor(HiTripColor.textBlack)
+                    }
+                }
+            }
+        }
+    }
+
+    private func infoRow(icon: String, label: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .foregroundColor(HiTripColor.gray400)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.system(size: 12))
+                    .foregroundColor(HiTripColor.gray400)
+                Text(value)
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.textBlack)
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Spot/Views/KakaoMapView.swift
+++ b/HiTrip/Features/Spot/Views/KakaoMapView.swift
@@ -3,18 +3,12 @@ import KakaoMapsSDK
 import CoreLocation
 
 // MARK: - KakaoMapView
-/// KakaoMapsSDK의 KMViewContainer를 SwiftUI에서 사용하기 위한 래퍼
+/// KakaoMapsSDK를 SwiftUI에서 사용하기 위한 UIViewControllerRepresentable 래퍼
 ///
-/// 지원 기능:
-/// - 기본 지도 렌더링
-/// - 공식 스팟 / 검색 결과 마커 표시 (파란/주황 구분)
-/// - 허용 반경 폴리곤 오버레이
-/// - 현재 위치 마커
-/// - cameraTarget 변경 시 카메라 이동
+/// UIViewRepresentable 대신 UIViewControllerRepresentable을 사용하는 이유:
+/// KakaoMapsSDK는 UIViewController 라이프사이클(viewWillAppear/Disappear)을 필요로 함
 
-struct KakaoMapView: UIViewRepresentable {
-
-    // MARK: - Properties
+struct KakaoMapView: UIViewControllerRepresentable {
 
     let latitude: Double
     let longitude: Double
@@ -25,330 +19,258 @@ struct KakaoMapView: UIViewRepresentable {
     var cameraTarget: MapViewModel.CameraTarget?
     var onMarkerTapped: ((MapPlaceItem) -> Void)?
 
-    // MARK: - UIViewRepresentable
-
-    func makeUIView(context: Context) -> KMViewContainer {
-        let view = KMViewContainer()
-        view.sizeToFit()
-        context.coordinator.createController(view)
-        return view
-    }
-
-    func updateUIView(_ uiView: KMViewContainer, context: Context) {
-        let coord = context.coordinator
-
-        if draw {
-            if coord.isEnginePrepared { coord.controller?.activateEngine() }
-        } else {
-            coord.controller?.pauseEngine()
-        }
-
-        guard coord.isMapReady else {
-            coord.pendingMarkers     = markers
-            coord.pendingUserLoc     = userLocation
-            coord.pendingRadius      = radiusMeters
-            coord.pendingCameraMove  = cameraTarget
-            return
-        }
-
-        coord.updateMarkers(markers)
-
-        if let loc = userLocation {
-            coord.updateUserLocation(loc)
-        }
-
-        if radiusMeters > 0 {
-            coord.updateRadius(
-                center: MapPoint(longitude: longitude, latitude: latitude),
-                meters: radiusMeters
-            )
-        }
-
-        if let target = cameraTarget, target != coord.lastCameraTarget {
-            coord.lastCameraTarget = target
-            coord.moveCamera(to: target.coordinate)
-        }
-    }
-
-    static func dismantleUIView(_ uiView: KMViewContainer, coordinator: Coordinator) {
-        coordinator.controller?.resetEngine()
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(
+    func makeUIViewController(context: Context) -> KakaoMapViewController {
+        let vc = KakaoMapViewController(
             latitude: latitude,
             longitude: longitude,
             onMarkerTapped: onMarkerTapped
         )
+        return vc
     }
 
-    // MARK: - Coordinator
-
-    class Coordinator: NSObject, MapControllerDelegate {
-
-        var controller: KMController?
-        let latitude: Double
-        let longitude: Double
-        var onMarkerTapped: ((MapPlaceItem) -> Void)?
-
-        var isEnginePrepared = false
-        var isMapReady       = false
-        private var first    = true
-
-        // 지도 준비 전 대기 중인 데이터
-        var pendingMarkers:    [MapPlaceItem]                  = []
-        var pendingUserLoc:    CLLocationCoordinate2D?
-        var pendingRadius:     Double                          = 0
-        var pendingCameraMove: MapViewModel.CameraTarget?
-
-        var lastCameraTarget: MapViewModel.CameraTarget?
-
-        // itemID → MapPlaceItem 룩업 (마커 탭 처리용)
-        private var markerLookup: [String: MapPlaceItem] = [:]
-
-        init(latitude: Double, longitude: Double, onMarkerTapped: ((MapPlaceItem) -> Void)?) {
-            self.latitude        = latitude
-            self.longitude       = longitude
-            self.onMarkerTapped  = onMarkerTapped
-            super.init()
+    func updateUIViewController(_ vc: KakaoMapViewController, context: Context) {
+        if draw {
+            vc.activate()
+        } else {
+            vc.pause()
         }
 
-        func createController(_ view: KMViewContainer) {
-            controller = KMController(viewContainer: view)
-            controller?.delegate = self
-            controller?.prepareEngine()
-        }
+        guard vc.isMapReady else { return }
 
-        // MARK: - MapControllerDelegate
-
-        func addViews() {
-            let info = MapviewInfo(
-                viewName: "mapView",
-                viewInfoName: "map",
-                defaultPosition: MapPoint(longitude: longitude, latitude: latitude),
-                defaultLevel: 15
-            )
-            controller?.addView(info)
-        }
-
-        func addViewSucceeded(_ viewName: String, viewInfoName: String) {
-            print("✅ [KakaoMap] addViewSucceeded")
-            isMapReady = true
-            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
-
-            registerPoiStyles(mapView)
-            setupShapeLayer(mapView)
-
-            // 대기 중이던 업데이트 적용
-            updateMarkers(pendingMarkers);     pendingMarkers = []
-            if let loc = pendingUserLoc { updateUserLocation(loc); pendingUserLoc = nil }
-            if pendingRadius > 0 {
-                updateRadius(center: MapPoint(longitude: longitude, latitude: latitude), meters: pendingRadius)
-                pendingRadius = 0
-            }
-            if let t = pendingCameraMove {
-                lastCameraTarget = t
-                moveCamera(to: t.coordinate)
-                pendingCameraMove = nil
-            }
-        }
-
-        func addViewFailed(_ viewName: String, viewInfoName: String) {
-            print("❌ [KakaoMap] addViewFailed: \(viewName)")
-        }
-
-        func containerDidResized(_ size: CGSize) {
-            let mapView = controller?.getView("mapView") as? KakaoMap
-            mapView?.viewRect = CGRect(origin: .zero, size: size)
-            if first {
-                first = false
-                isEnginePrepared = true
-                controller?.activateEngine()
-            }
-        }
-
-        func authenticationSucceeded() { print("✅ [KakaoMap] 인증 성공") }
-        func authenticationFailed(_ errorCode: Int, desc: String) {
-            print("❌ [KakaoMap] 인증 실패 \(errorCode): \(desc)")
-        }
-
-        // MARK: - POI Styles
-
-        private func registerPoiStyles(_ mapView: KakaoMap) {
-            let lm = mapView.getLabelManager()
-
-            // 공식 스팟 — 파란 원
-            let blueImg  = circleImage(color: .systemBlue,   size: 20)
-            let blueIcon = PoiIconStyle(symbol: blueImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
-            let blueStyle = PoiStyle(styleID: "official", styles: [PerLevelPoiStyle(iconStyle: blueIcon, level: 0)])
-            lm.addPoiStyle(blueStyle)
-
-            // 검색 결과 — 주황 원
-            let orangeImg  = circleImage(color: .systemOrange, size: 16)
-            let orangeIcon = PoiIconStyle(symbol: orangeImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
-            let orangeStyle = PoiStyle(styleID: "search", styles: [PerLevelPoiStyle(iconStyle: orangeIcon, level: 0)])
-            lm.addPoiStyle(orangeStyle)
-
-            // 내 위치 — 빨간 원
-            let redImg   = circleImage(color: .systemRed,    size: 18)
-            let redIcon  = PoiIconStyle(symbol: redImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
-            let redStyle = PoiStyle(styleID: "user", styles: [PerLevelPoiStyle(iconStyle: redIcon, level: 0)])
-            lm.addPoiStyle(redStyle)
-        }
-
-        private func circleImage(color: UIColor, size: CGFloat) -> UIImage {
-            let rect = CGRect(x: 0, y: 0, width: size, height: size)
-            UIGraphicsBeginImageContextWithOptions(rect.size, false, 0)
-            let ctx = UIGraphicsGetCurrentContext()!
-            ctx.setFillColor(color.cgColor)
-            ctx.addEllipse(in: rect)
-            ctx.fillPath()
-            ctx.setStrokeColor(UIColor.white.cgColor)
-            ctx.setLineWidth(2)
-            ctx.addEllipse(in: rect.insetBy(dx: 1, dy: 1))
-            ctx.strokePath()
-            let img = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
-            UIGraphicsEndImageContext()
-            return img
-        }
-
-        // MARK: - Markers
-
-        func updateMarkers(_ items: [MapPlaceItem]) {
-            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
-            let lm = mapView.getLabelManager()
-            lm.removeLabelLayer(layerID: "officialLayer")
-            lm.removeLabelLayer(layerID: "searchLayer")
-            markerLookup.removeAll()
-
-            addPoiLayer(
-                mapView: mapView,
-                layerID: "officialLayer",
-                styleID: "official",
-                zOrder: 20,
-                items: items.filter { $0.isOfficialSpot }
-            )
-            addPoiLayer(
-                mapView: mapView,
-                layerID: "searchLayer",
-                styleID: "search",
-                zOrder: 10,
-                items: items.filter { !$0.isOfficialSpot }
+        vc.updateMarkers(markers)
+        if let loc = userLocation { vc.updateUserLocation(loc) }
+        if radiusMeters > 0 {
+            vc.updateRadius(
+                center: MapPoint(longitude: longitude, latitude: latitude),
+                meters: radiusMeters
             )
         }
+        if let target = cameraTarget, target != vc.lastCameraTarget {
+            vc.lastCameraTarget = target
+            vc.moveCamera(to: target.coordinate)
+        }
+    }
 
-        private func addPoiLayer(mapView: KakaoMap, layerID: String, styleID: String, zOrder: Int, items: [MapPlaceItem]) {
-            guard !items.isEmpty else { return }
-            let lm = mapView.getLabelManager()
-            let opt = LabelLayerOptions(
-                layerID: layerID,
-                competitionType: .none,
-                competitionUnit: .poi,
-                orderType: .rank,
-                zOrder: zOrder
+    static func dismantleUIViewController(_ vc: KakaoMapViewController, coordinator: ()) {
+        vc.controller?.resetEngine()
+    }
+}
+
+// MARK: - KakaoMapViewController
+
+final class KakaoMapViewController: UIViewController, MapControllerDelegate {
+
+    var controller: KMController?
+    let latitude: Double
+    let longitude: Double
+    var onMarkerTapped: ((MapPlaceItem) -> Void)?
+
+    var isMapReady = false
+    var lastCameraTarget: MapViewModel.CameraTarget?
+    private var markerLookup: [String: MapPlaceItem] = [:]
+
+    init(latitude: Double, longitude: Double, onMarkerTapped: ((MapPlaceItem) -> Void)?) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.onMarkerTapped = onMarkerTapped
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+
+        let container = KMViewContainer()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: view.topAnchor),
+            container.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        controller = KMController(viewContainer: container)
+        controller?.delegate = self
+        controller?.prepareEngine()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        controller?.activateEngine()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        controller?.pauseEngine()
+    }
+
+    func activate() { controller?.activateEngine() }
+    func pause()    { controller?.pauseEngine()    }
+
+    // MARK: - MapControllerDelegate
+
+    func addViews() {
+        print("🗺️ [KakaoMap] addViews 호출됨")
+        let info = MapviewInfo(
+            viewName: "mapView",
+            viewInfoName: "map",
+            defaultPosition: MapPoint(longitude: longitude, latitude: latitude),
+            defaultLevel: 15
+        )
+        controller?.addView(info)
+    }
+
+    func addViewSucceeded(_ viewName: String, viewInfoName: String) {
+        print("✅ [KakaoMap] addViewSucceeded")
+        isMapReady = true
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        mapView.viewRect = view.bounds
+        registerPoiStyles(mapView)
+        setupShapeStyles(mapView)
+    }
+
+    func addViewFailed(_ viewName: String, viewInfoName: String) {
+        print("❌ [KakaoMap] addViewFailed: \(viewName)")
+    }
+
+    func containerDidResized(_ size: CGSize) {
+        guard size.width > 0, size.height > 0 else { return }
+        let mapView = controller?.getView("mapView") as? KakaoMap
+        mapView?.viewRect = CGRect(origin: .zero, size: size)
+    }
+
+    func authenticationSucceeded() { print("✅ [KakaoMap] 인증 성공") }
+    func authenticationFailed(_ errorCode: Int, desc: String) {
+        print("❌ [KakaoMap] 인증 실패 \(errorCode): \(desc)")
+    }
+
+    // MARK: - POI Styles
+
+    private func registerPoiStyles(_ mapView: KakaoMap) {
+        let lm = mapView.getLabelManager()
+        for (id, color, size) in [("official", UIColor.systemBlue, 20.0),
+                                   ("search",   UIColor.systemOrange, 16.0),
+                                   ("user",     UIColor.systemRed,    18.0)] {
+            let img   = circleImage(color: color, size: size)
+            let icon  = PoiIconStyle(symbol: img, anchorPoint: CGPoint(x: 0.5, y: 0.5))
+            let style = PoiStyle(styleID: id, styles: [PerLevelPoiStyle(iconStyle: icon, level: 0)])
+            lm.addPoiStyle(style)
+        }
+    }
+
+    private func circleImage(color: UIColor, size: CGFloat) -> UIImage {
+        let rect = CGRect(x: 0, y: 0, width: size, height: size)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, 0)
+        let ctx = UIGraphicsGetCurrentContext()!
+        ctx.setFillColor(color.cgColor)
+        ctx.addEllipse(in: rect); ctx.fillPath()
+        ctx.setStrokeColor(UIColor.white.cgColor); ctx.setLineWidth(2)
+        ctx.addEllipse(in: rect.insetBy(dx: 1, dy: 1)); ctx.strokePath()
+        let img = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
+        UIGraphicsEndImageContext()
+        return img
+    }
+
+    // MARK: - Shape Styles
+
+    private func setupShapeStyles(_ mapView: KakaoMap) {
+        let sm = mapView.getShapeManager()
+        sm.addPolygonStyleSet(PolygonStyleSet(styleSetID: "radiusFill", styles: [
+            PolygonStyle(styles: [PerLevelPolygonStyle(
+                color: UIColor.systemBlue.withAlphaComponent(0.12),
+                strokeWidth: 0, strokeColor: .clear, level: 0)])
+        ]))
+        sm.addPolylineStyleSet(PolylineStyleSet(styleSetID: "radiusBorder", styles: [
+            PolylineStyle(styles: [PerLevelPolylineStyle(
+                bodyColor: UIColor.systemBlue.withAlphaComponent(0.7),
+                bodyWidth: 2, strokeColor: .clear, strokeWidth: 0, level: 0)])
+        ]))
+    }
+
+    // MARK: - Markers
+
+    func updateMarkers(_ items: [MapPlaceItem]) {
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        let lm = mapView.getLabelManager()
+        lm.removeLabelLayer(layerID: "officialLayer")
+        lm.removeLabelLayer(layerID: "searchLayer")
+        markerLookup.removeAll()
+        addPoiLayer(mapView: mapView, layerID: "officialLayer", styleID: "official", zOrder: 20,
+                    items: items.filter { $0.isOfficialSpot })
+        addPoiLayer(mapView: mapView, layerID: "searchLayer",   styleID: "search",   zOrder: 10,
+                    items: items.filter { !$0.isOfficialSpot })
+    }
+
+    private func addPoiLayer(mapView: KakaoMap, layerID: String, styleID: String, zOrder: Int, items: [MapPlaceItem]) {
+        guard !items.isEmpty else { return }
+        let lm  = mapView.getLabelManager()
+        let opt = LabelLayerOptions(layerID: layerID, competitionType: .none, competitionUnit: .poi, orderType: .rank, zOrder: zOrder)
+        guard let layer = lm.addLabelLayer(option: opt) else { return }
+        for item in items {
+            let poiOpt = PoiOptions(styleID: styleID)
+            poiOpt.rank = 0; poiOpt.clickable = true
+            let pt = MapPoint(longitude: item.longitude, latitude: item.latitude)
+            if let poi = layer.addPoi(option: poiOpt, at: pt) {
+                poi.show()
+                markerLookup[poi.itemID] = item
+            }
+        }
+    }
+
+    // MARK: - User Location
+
+    func updateUserLocation(_ coordinate: CLLocationCoordinate2D) {
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        let lm  = mapView.getLabelManager()
+        lm.removeLabelLayer(layerID: "userLayer")
+        let opt   = LabelLayerOptions(layerID: "userLayer", competitionType: .none, competitionUnit: .poi, orderType: .rank, zOrder: 30)
+        let layer = lm.addLabelLayer(option: opt)
+        let poiOpt = PoiOptions(styleID: "user"); poiOpt.rank = 0
+        layer?.addPoi(option: poiOpt, at: MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude))?.show()
+    }
+
+    // MARK: - Radius
+
+    func updateRadius(center: MapPoint, meters: Double) {
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        let sm = mapView.getShapeManager()
+        sm.removeShapeLayer(layerID: "radiusLayer")
+        guard let layer = sm.addShapeLayer(layerID: "radiusLayer", zOrder: 1) else { return }
+        let pts = circlePoints(center: center, radiusMeters: meters, count: 64)
+
+        let fillOpt = MapPolygonShapeOptions(shapeID: "radiusFill", styleID: "radiusFill", zOrder: 0)
+        fillOpt.polygons = [MapPolygon(exteriorRing: pts, hole: nil, styleIndex: 0)]
+        layer.addMapPolygonShape(fillOpt)?.show()
+
+        let borderOpt = MapPolylineShapeOptions(shapeID: "radiusBorder", styleID: "radiusBorder", zOrder: 1)
+        borderOpt.polylines = [MapPolyline(line: pts + [pts[0]], styleIndex: 0)]
+        layer.addMapPolylineShape(borderOpt)?.show()
+    }
+
+    private func circlePoints(center: MapPoint, radiusMeters: Double, count: Int) -> [MapPoint] {
+        let lat = center.wgsCoord.latitude  * .pi / 180
+        let lng = center.wgsCoord.longitude * .pi / 180
+        let R   = 6371000.0
+        return (0..<count).map { i in
+            let angle = 2 * Double.pi * Double(i) / Double(count)
+            return MapPoint(
+                longitude: (lng + (radiusMeters / R) * sin(angle) / cos(lat)) * 180 / .pi,
+                latitude:  (lat + (radiusMeters / R) * cos(angle)) * 180 / .pi
             )
-            guard let layer = lm.addLabelLayer(option: opt) else { return }
-            for item in items {
-                let poiOpt = PoiOptions(styleID: styleID)
-                poiOpt.rank = 0
-                poiOpt.clickable = true
-                let pt = MapPoint(longitude: item.longitude, latitude: item.latitude)
-                if let poi = layer.addPoi(option: poiOpt, at: pt) {
-                    poi.show()
-                    markerLookup[poi.itemID] = item
-                }
-            }
         }
+    }
 
-        // MARK: - User Location
+    // MARK: - Camera
 
-        func updateUserLocation(_ coordinate: CLLocationCoordinate2D) {
-            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
-            let lm = mapView.getLabelManager()
-            lm.removeLabelLayer(layerID: "userLayer")
-            let opt = LabelLayerOptions(layerID: "userLayer", competitionType: .none, competitionUnit: .poi, orderType: .rank, zOrder: 30)
-            let layer = lm.addLabelLayer(option: opt)
-            let poiOpt = PoiOptions(styleID: "user")
-            poiOpt.rank = 0
-            let pt = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
-            layer?.addPoi(option: poiOpt, at: pt)?.show()
-        }
-
-        // MARK: - Radius Polygon
-
-        private func setupShapeLayer(_ mapView: KakaoMap) {
-            let sm = mapView.getShapeManager()
-
-            // 반경 채움 스타일
-            let fillStyle = PolygonStyleSet(styleSetID: "radiusFill", styles: [
-                PolygonStyle(styles: [
-                    PerLevelPolygonStyle(color: UIColor.systemBlue.withAlphaComponent(0.12),
-                                        strokeWidth: 0,
-                                        strokeColor: .clear,
-                                        level: 0)
-                ])
-            ])
-            sm.addPolygonStyleSet(fillStyle)
-
-            // 반경 외곽선 스타일
-            let borderStyle = PolylineStyleSet(styleSetID: "radiusBorder", styles: [
-                PolylineStyle(styles: [
-                    PerLevelPolylineStyle(bodyColor: UIColor.systemBlue.withAlphaComponent(0.7),
-                                         bodyWidth: 2,
-                                         strokeColor: .clear,
-                                         strokeWidth: 0,
-                                         level: 0)
-                ])
-            ])
-            sm.addPolylineStyleSet(borderStyle)
-
-            sm.addShapeLayer(layerID: "radiusLayer", zOrder: 1)
-        }
-
-        func updateRadius(center: MapPoint, meters: Double) {
-            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
-            let sm = mapView.getShapeManager()
-
-            // 레이어 재생성
-            sm.removeShapeLayer(layerID: "radiusLayer")
-            guard let layer = sm.addShapeLayer(layerID: "radiusLayer", zOrder: 1) else { return }
-
-            let pts = circlePoints(center: center, radiusMeters: meters, count: 64)
-
-            // 채움 폴리곤
-            let fillOpt = MapPolygonShapeOptions(shapeID: "radiusFill", styleID: "radiusFill", zOrder: 0)
-            fillOpt.polygons = [MapPolygon(exteriorRing: pts, hole: nil, styleIndex: 0)]
-            layer.addMapPolygonShape(fillOpt)?.show()
-
-            // 외곽선 폴리라인 (닫힌 링)
-            let borderOpt = MapPolylineShapeOptions(shapeID: "radiusBorder", styleID: "radiusBorder", zOrder: 1)
-            borderOpt.polylines = [MapPolyline(line: pts + [pts[0]], styleIndex: 0)]
-            layer.addMapPolylineShape(borderOpt)?.show()
-        }
-
-        private func circlePoints(center: MapPoint, radiusMeters: Double, count: Int) -> [MapPoint] {
-            let lat = center.wgsCoord.latitude  * .pi / 180
-            let lng = center.wgsCoord.longitude * .pi / 180
-            let R   = 6371000.0
-
-            return (0..<count).map { i in
-                let angle = 2 * Double.pi * Double(i) / Double(count)
-                let dLat  = (radiusMeters / R) * cos(angle)
-                let dLng  = (radiusMeters / R) * sin(angle) / cos(lat)
-                return MapPoint(
-                    longitude: (lng + dLng) * 180 / .pi,
-                    latitude:  (lat + dLat) * 180 / .pi
-                )
-            }
-        }
-
-        // MARK: - Camera
-
-        func moveCamera(to coordinate: CLLocationCoordinate2D) {
-            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
-            let pt = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
-            let update = CameraUpdate.make(target: pt, zoomLevel: 15, mapView: mapView)
-            mapView.moveCamera(update)
-        }
+    func moveCamera(to coordinate: CLLocationCoordinate2D) {
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        let pt     = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
+        let update = CameraUpdate.make(target: pt, zoomLevel: 15, mapView: mapView)
+        mapView.moveCamera(update)
     }
 }

--- a/HiTrip/Features/Spot/Views/KakaoMapView.swift
+++ b/HiTrip/Features/Spot/Views/KakaoMapView.swift
@@ -203,7 +203,6 @@ struct KakaoMapView: UIViewRepresentable {
             ctx.setFillColor(color.cgColor)
             ctx.addEllipse(in: rect)
             ctx.fillPath()
-            // 흰 테두리
             ctx.setStrokeColor(UIColor.white.cgColor)
             ctx.setLineWidth(2)
             ctx.addEllipse(in: rect.insetBy(dx: 1, dy: 1))
@@ -277,30 +276,54 @@ struct KakaoMapView: UIViewRepresentable {
 
         // MARK: - Radius Polygon
 
+        private func setupShapeLayer(_ mapView: KakaoMap) {
+            let sm = mapView.getShapeManager()
+
+            // 반경 채움 스타일
+            let fillStyle = PolygonStyleSet(styleSetID: "radiusFill", styles: [
+                PolygonStyle(styles: [
+                    PerLevelPolygonStyle(color: UIColor.systemBlue.withAlphaComponent(0.12),
+                                        strokeWidth: 0,
+                                        strokeColor: .clear,
+                                        level: 0)
+                ])
+            ])
+            sm.addPolygonStyleSet(fillStyle)
+
+            // 반경 외곽선 스타일
+            let borderStyle = PolylineStyleSet(styleSetID: "radiusBorder", styles: [
+                PolylineStyle(styles: [
+                    PerLevelPolylineStyle(bodyColor: UIColor.systemBlue.withAlphaComponent(0.7),
+                                         bodyWidth: 2,
+                                         strokeColor: .clear,
+                                         strokeWidth: 0,
+                                         level: 0)
+                ])
+            ])
+            sm.addPolylineStyleSet(borderStyle)
+
+            sm.addShapeLayer(layerID: "radiusLayer", zOrder: 1)
+        }
+
         func updateRadius(center: MapPoint, meters: Double) {
             guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
             let sm = mapView.getShapeManager()
-            sm.removeShapeLayer(layerID: "radiusLayer")
 
-            let layerOpt = ShapeLayerOptions(layerID: "radiusLayer", zOrder: 1)
-            guard let layer = sm.addShapeLayer(option: layerOpt) else { return }
+            // 레이어 재생성
+            sm.removeShapeLayer(layerID: "radiusLayer")
+            guard let layer = sm.addShapeLayer(layerID: "radiusLayer", zOrder: 1) else { return }
 
             let pts = circlePoints(center: center, radiusMeters: meters, count: 64)
 
-            let fillStyle = PolygonStyle(styles: [
-                PerLevelPolygonStyle(color: UIColor.systemBlue.withAlphaComponent(0.12), level: 0)
-            ])
-            let strokeStyle = PolylineStyle(styles: [
-                PerLevelPolylineStyle(width: 2.0, color: UIColor.systemBlue.withAlphaComponent(0.7), strokeWidth: 0, strokeColor: .clear, level: 0)
-            ])
+            // 채움 폴리곤
+            let fillOpt = MapPolygonShapeOptions(shapeID: "radiusFill", styleID: "radiusFill", zOrder: 0)
+            fillOpt.polygons = [MapPolygon(exteriorRing: pts, hole: nil, styleIndex: 0)]
+            layer.addMapPolygonShape(fillOpt)?.show()
 
-            let shapeOpt = PolygonShapeOptions(shapeID: "radius", zOrder: 0, basePosition: center)
-            shapeOpt.polygons = [Polygon(exteriorRing: pts, hole: nil, styleIndex: 0)]
-            shapeOpt.polygonStyles = PolygonStyles(styles: [fillStyle])
-            shapeOpt.polylines = [Polyline(points: pts + [pts[0]], styleIndex: 0)]
-            shapeOpt.polylineStyles = PolylineStyles(styles: [strokeStyle])
-
-            layer.addPolygonShape(shapeOpt)?.show()
+            // 외곽선 폴리라인 (닫힌 링)
+            let borderOpt = MapPolylineShapeOptions(shapeID: "radiusBorder", styleID: "radiusBorder", zOrder: 1)
+            borderOpt.polylines = [MapPolyline(line: pts + [pts[0]], styleIndex: 0)]
+            layer.addMapPolylineShape(borderOpt)?.show()
         }
 
         private func circlePoints(center: MapPoint, radiusMeters: Double, count: Int) -> [MapPoint] {
@@ -324,14 +347,8 @@ struct KakaoMapView: UIViewRepresentable {
         func moveCamera(to coordinate: CLLocationCoordinate2D) {
             guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
             let pt = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
-            mapView.moveCamera(CameraUpdate.scrollTo(pt))
-        }
-
-        // MARK: - Setup Shape Layer
-
-        private func setupShapeLayer(_ mapView: KakaoMap) {
-            let sm = mapView.getShapeManager()
-            let _ = sm.addShapeLayer(option: ShapeLayerOptions(layerID: "radiusLayer", zOrder: 1))
+            let update = CameraUpdate.make(target: pt, zoomLevel: 15, mapView: mapView)
+            mapView.moveCamera(update)
         }
     }
 }

--- a/HiTrip/Features/Spot/Views/KakaoMapView.swift
+++ b/HiTrip/Features/Spot/Views/KakaoMapView.swift
@@ -1,18 +1,16 @@
 import SwiftUI
 import KakaoMapsSDK
+import CoreLocation
 
 // MARK: - KakaoMapView
 /// KakaoMapsSDK의 KMViewContainer를 SwiftUI에서 사용하기 위한 래퍼
 ///
-/// SwiftUI는 UIKit 뷰를 직접 사용할 수 없어서
-/// UIViewRepresentable 프로토콜로 감싸야 함.
-///
-/// 핵심 라이프사이클:
-/// 1. makeUIView → KMViewContainer 생성
-/// 2. prepareEngine() → 엔진 준비
-/// 3. containerDidResized() → 컨테이너 크기 확정 시 엔진 활성화
-/// 4. addViews() → 엔진 활성화 후 지도 뷰 추가
-/// 5. onDisappear → pauseEngine / dismantleUIView → resetEngine
+/// 지원 기능:
+/// - 기본 지도 렌더링
+/// - 공식 스팟 / 검색 결과 마커 표시 (파란/주황 구분)
+/// - 허용 반경 폴리곤 오버레이
+/// - 현재 위치 마커
+/// - cameraTarget 변경 시 카메라 이동
 
 struct KakaoMapView: UIViewRepresentable {
 
@@ -21,6 +19,11 @@ struct KakaoMapView: UIViewRepresentable {
     let latitude: Double
     let longitude: Double
     @Binding var draw: Bool
+    var markers: [MapPlaceItem] = []
+    var userLocation: CLLocationCoordinate2D?
+    var radiusMeters: Double = 0
+    var cameraTarget: MapViewModel.CameraTarget?
+    var onMarkerTapped: ((MapPlaceItem) -> Void)?
 
     // MARK: - UIViewRepresentable
 
@@ -31,19 +34,39 @@ struct KakaoMapView: UIViewRepresentable {
         return view
     }
 
-    /// draw 상태에 따라 엔진 활성화/일시정지
-    ///
-    /// ⚠️ 주의: activateEngine은 containerDidResized 이후에 호출해야 함.
-    /// 컨테이너 크기가 확정되기 전에 활성화하면 렌더링 영역이 0이라 지도가 안 보임.
-    /// 그래서 첫 활성화는 containerDidResized에서 하고,
-    /// 여기서는 이미 활성화된 이후의 재개/일시정지만 담당.
     func updateUIView(_ uiView: KMViewContainer, context: Context) {
+        let coord = context.coordinator
+
         if draw {
-            if context.coordinator.isEnginePrepared {
-                context.coordinator.controller?.activateEngine()
-            }
+            if coord.isEnginePrepared { coord.controller?.activateEngine() }
         } else {
-            context.coordinator.controller?.pauseEngine()
+            coord.controller?.pauseEngine()
+        }
+
+        guard coord.isMapReady else {
+            coord.pendingMarkers     = markers
+            coord.pendingUserLoc     = userLocation
+            coord.pendingRadius      = radiusMeters
+            coord.pendingCameraMove  = cameraTarget
+            return
+        }
+
+        coord.updateMarkers(markers)
+
+        if let loc = userLocation {
+            coord.updateUserLocation(loc)
+        }
+
+        if radiusMeters > 0 {
+            coord.updateRadius(
+                center: MapPoint(longitude: longitude, latitude: latitude),
+                meters: radiusMeters
+            )
+        }
+
+        if let target = cameraTarget, target != coord.lastCameraTarget {
+            coord.lastCameraTarget = target
+            coord.moveCamera(to: target.coordinate)
         }
     }
 
@@ -52,7 +75,11 @@ struct KakaoMapView: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(latitude: latitude, longitude: longitude)
+        Coordinator(
+            latitude: latitude,
+            longitude: longitude,
+            onMarkerTapped: onMarkerTapped
+        )
     }
 
     // MARK: - Coordinator
@@ -62,16 +89,27 @@ struct KakaoMapView: UIViewRepresentable {
         var controller: KMController?
         let latitude: Double
         let longitude: Double
+        var onMarkerTapped: ((MapPlaceItem) -> Void)?
 
-        /// containerDidResized가 한 번이라도 호출되었는지
         var isEnginePrepared = false
+        var isMapReady       = false
+        private var first    = true
 
-        /// 첫 번째 containerDidResized에서만 엔진 활성화
-        var first = true
+        // 지도 준비 전 대기 중인 데이터
+        var pendingMarkers:    [MapPlaceItem]                  = []
+        var pendingUserLoc:    CLLocationCoordinate2D?
+        var pendingRadius:     Double                          = 0
+        var pendingCameraMove: MapViewModel.CameraTarget?
 
-        init(latitude: Double, longitude: Double) {
-            self.latitude = latitude
-            self.longitude = longitude
+        var lastCameraTarget: MapViewModel.CameraTarget?
+
+        // itemID → MapPlaceItem 룩업 (마커 탭 처리용)
+        private var markerLookup: [String: MapPlaceItem] = [:]
+
+        init(latitude: Double, longitude: Double, onMarkerTapped: ((MapPlaceItem) -> Void)?) {
+            self.latitude        = latitude
+            self.longitude       = longitude
+            self.onMarkerTapped  = onMarkerTapped
             super.init()
         }
 
@@ -83,44 +121,45 @@ struct KakaoMapView: UIViewRepresentable {
 
         // MARK: - MapControllerDelegate
 
-        /// 엔진 준비 완료 → 지도 뷰 추가
         func addViews() {
-            let defaultPosition = MapPoint(
-                longitude: longitude,
-                latitude: latitude
-            )
-            let mapviewInfo = MapviewInfo(
-                viewName: "spotMap",
+            let info = MapviewInfo(
+                viewName: "mapView",
                 viewInfoName: "map",
-                defaultPosition: defaultPosition,
+                defaultPosition: MapPoint(longitude: longitude, latitude: latitude),
                 defaultLevel: 15
             )
-
-            controller?.addView(mapviewInfo)
+            controller?.addView(info)
         }
 
         func addViewSucceeded(_ viewName: String, viewInfoName: String) {
-            print("✅ [KakaoMap] addViewSucceeded: \(viewName)")
+            print("✅ [KakaoMap] addViewSucceeded")
+            isMapReady = true
+            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
 
-            // 지도 뷰가 추가된 후 렌더링 영역 재설정
-            let mapView = controller?.getView("spotMap") as? KakaoMap
-            print("🗺️ [KakaoMap] mapView: \(String(describing: mapView))")
+            registerPoiStyles(mapView)
+            setupShapeLayer(mapView)
+
+            // 대기 중이던 업데이트 적용
+            updateMarkers(pendingMarkers);     pendingMarkers = []
+            if let loc = pendingUserLoc { updateUserLocation(loc); pendingUserLoc = nil }
+            if pendingRadius > 0 {
+                updateRadius(center: MapPoint(longitude: longitude, latitude: latitude), meters: pendingRadius)
+                pendingRadius = 0
+            }
+            if let t = pendingCameraMove {
+                lastCameraTarget = t
+                moveCamera(to: t.coordinate)
+                pendingCameraMove = nil
+            }
         }
 
         func addViewFailed(_ viewName: String, viewInfoName: String) {
             print("❌ [KakaoMap] addViewFailed: \(viewName)")
         }
 
-        /// 컨테이너 크기가 확정될 때 호출
-        ///
-        /// 이 시점에서 지도의 렌더링 영역(viewRect)을 설정하고,
-        /// 첫 호출 시 엔진을 활성화해야 지도가 정상 렌더링됨.
         func containerDidResized(_ size: CGSize) {
-            print("📐 [KakaoMap] containerDidResized: \(size)")
-
-            let mapView = controller?.getView("spotMap") as? KakaoMap
+            let mapView = controller?.getView("mapView") as? KakaoMap
             mapView?.viewRect = CGRect(origin: .zero, size: size)
-
             if first {
                 first = false
                 isEnginePrepared = true
@@ -128,12 +167,171 @@ struct KakaoMapView: UIViewRepresentable {
             }
         }
 
-        func authenticationSucceeded() {
-            print("✅ [KakaoMap] 인증 성공")
+        func authenticationSucceeded() { print("✅ [KakaoMap] 인증 성공") }
+        func authenticationFailed(_ errorCode: Int, desc: String) {
+            print("❌ [KakaoMap] 인증 실패 \(errorCode): \(desc)")
         }
 
-        func authenticationFailed(_ errorCode: Int, desc: String) {
-            print("❌ [KakaoMap] 인증 실패: code=\(errorCode), \(desc)")
+        // MARK: - POI Styles
+
+        private func registerPoiStyles(_ mapView: KakaoMap) {
+            let lm = mapView.getLabelManager()
+
+            // 공식 스팟 — 파란 원
+            let blueImg  = circleImage(color: .systemBlue,   size: 20)
+            let blueIcon = PoiIconStyle(symbol: blueImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
+            let blueStyle = PoiStyle(styleID: "official", styles: [PerLevelPoiStyle(iconStyle: blueIcon, level: 0)])
+            lm.addPoiStyle(blueStyle)
+
+            // 검색 결과 — 주황 원
+            let orangeImg  = circleImage(color: .systemOrange, size: 16)
+            let orangeIcon = PoiIconStyle(symbol: orangeImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
+            let orangeStyle = PoiStyle(styleID: "search", styles: [PerLevelPoiStyle(iconStyle: orangeIcon, level: 0)])
+            lm.addPoiStyle(orangeStyle)
+
+            // 내 위치 — 빨간 원
+            let redImg   = circleImage(color: .systemRed,    size: 18)
+            let redIcon  = PoiIconStyle(symbol: redImg, anchorPoint: CGPoint(x: 0.5, y: 0.5))
+            let redStyle = PoiStyle(styleID: "user", styles: [PerLevelPoiStyle(iconStyle: redIcon, level: 0)])
+            lm.addPoiStyle(redStyle)
+        }
+
+        private func circleImage(color: UIColor, size: CGFloat) -> UIImage {
+            let rect = CGRect(x: 0, y: 0, width: size, height: size)
+            UIGraphicsBeginImageContextWithOptions(rect.size, false, 0)
+            let ctx = UIGraphicsGetCurrentContext()!
+            ctx.setFillColor(color.cgColor)
+            ctx.addEllipse(in: rect)
+            ctx.fillPath()
+            // 흰 테두리
+            ctx.setStrokeColor(UIColor.white.cgColor)
+            ctx.setLineWidth(2)
+            ctx.addEllipse(in: rect.insetBy(dx: 1, dy: 1))
+            ctx.strokePath()
+            let img = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
+            UIGraphicsEndImageContext()
+            return img
+        }
+
+        // MARK: - Markers
+
+        func updateMarkers(_ items: [MapPlaceItem]) {
+            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+            let lm = mapView.getLabelManager()
+            lm.removeLabelLayer(layerID: "officialLayer")
+            lm.removeLabelLayer(layerID: "searchLayer")
+            markerLookup.removeAll()
+
+            addPoiLayer(
+                mapView: mapView,
+                layerID: "officialLayer",
+                styleID: "official",
+                zOrder: 20,
+                items: items.filter { $0.isOfficialSpot }
+            )
+            addPoiLayer(
+                mapView: mapView,
+                layerID: "searchLayer",
+                styleID: "search",
+                zOrder: 10,
+                items: items.filter { !$0.isOfficialSpot }
+            )
+        }
+
+        private func addPoiLayer(mapView: KakaoMap, layerID: String, styleID: String, zOrder: Int, items: [MapPlaceItem]) {
+            guard !items.isEmpty else { return }
+            let lm = mapView.getLabelManager()
+            let opt = LabelLayerOptions(
+                layerID: layerID,
+                competitionType: .none,
+                competitionUnit: .poi,
+                orderType: .rank,
+                zOrder: zOrder
+            )
+            guard let layer = lm.addLabelLayer(option: opt) else { return }
+            for item in items {
+                let poiOpt = PoiOptions(styleID: styleID)
+                poiOpt.rank = 0
+                poiOpt.clickable = true
+                let pt = MapPoint(longitude: item.longitude, latitude: item.latitude)
+                if let poi = layer.addPoi(option: poiOpt, at: pt) {
+                    poi.show()
+                    markerLookup[poi.itemID] = item
+                }
+            }
+        }
+
+        // MARK: - User Location
+
+        func updateUserLocation(_ coordinate: CLLocationCoordinate2D) {
+            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+            let lm = mapView.getLabelManager()
+            lm.removeLabelLayer(layerID: "userLayer")
+            let opt = LabelLayerOptions(layerID: "userLayer", competitionType: .none, competitionUnit: .poi, orderType: .rank, zOrder: 30)
+            let layer = lm.addLabelLayer(option: opt)
+            let poiOpt = PoiOptions(styleID: "user")
+            poiOpt.rank = 0
+            let pt = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
+            layer?.addPoi(option: poiOpt, at: pt)?.show()
+        }
+
+        // MARK: - Radius Polygon
+
+        func updateRadius(center: MapPoint, meters: Double) {
+            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+            let sm = mapView.getShapeManager()
+            sm.removeShapeLayer(layerID: "radiusLayer")
+
+            let layerOpt = ShapeLayerOptions(layerID: "radiusLayer", zOrder: 1)
+            guard let layer = sm.addShapeLayer(option: layerOpt) else { return }
+
+            let pts = circlePoints(center: center, radiusMeters: meters, count: 64)
+
+            let fillStyle = PolygonStyle(styles: [
+                PerLevelPolygonStyle(color: UIColor.systemBlue.withAlphaComponent(0.12), level: 0)
+            ])
+            let strokeStyle = PolylineStyle(styles: [
+                PerLevelPolylineStyle(width: 2.0, color: UIColor.systemBlue.withAlphaComponent(0.7), strokeWidth: 0, strokeColor: .clear, level: 0)
+            ])
+
+            let shapeOpt = PolygonShapeOptions(shapeID: "radius", zOrder: 0, basePosition: center)
+            shapeOpt.polygons = [Polygon(exteriorRing: pts, hole: nil, styleIndex: 0)]
+            shapeOpt.polygonStyles = PolygonStyles(styles: [fillStyle])
+            shapeOpt.polylines = [Polyline(points: pts + [pts[0]], styleIndex: 0)]
+            shapeOpt.polylineStyles = PolylineStyles(styles: [strokeStyle])
+
+            layer.addPolygonShape(shapeOpt)?.show()
+        }
+
+        private func circlePoints(center: MapPoint, radiusMeters: Double, count: Int) -> [MapPoint] {
+            let lat = center.wgsCoord.latitude  * .pi / 180
+            let lng = center.wgsCoord.longitude * .pi / 180
+            let R   = 6371000.0
+
+            return (0..<count).map { i in
+                let angle = 2 * Double.pi * Double(i) / Double(count)
+                let dLat  = (radiusMeters / R) * cos(angle)
+                let dLng  = (radiusMeters / R) * sin(angle) / cos(lat)
+                return MapPoint(
+                    longitude: (lng + dLng) * 180 / .pi,
+                    latitude:  (lat + dLat) * 180 / .pi
+                )
+            }
+        }
+
+        // MARK: - Camera
+
+        func moveCamera(to coordinate: CLLocationCoordinate2D) {
+            guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+            let pt = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
+            mapView.moveCamera(CameraUpdate.scrollTo(pt))
+        }
+
+        // MARK: - Setup Shape Layer
+
+        private func setupShapeLayer(_ mapView: KakaoMap) {
+            let sm = mapView.getShapeManager()
+            let _ = sm.addShapeLayer(option: ShapeLayerOptions(layerID: "radiusLayer", zOrder: 1))
         }
     }
 }


### PR DESCRIPTION
## 개요

하단 네비게이션 3번째 탭을 검색에서 **지도**로 전면 교체하고, KakaoMapsSDK 연동 및 렌더링 문제를 해결한 PR입니다.

---

## 주요 변경 내용

### 1. 지도 탭 신규 구현

**`NearbyMapView`** — 지도 탭 메인 화면
- 풀스크린 KakaoMap 배경
- 상단: 페이지 제목 + 카테고리 필터 칩 (무장애 · 반려동물 · 할랄 · 편의점 · 마트 · 음식점)
- 우하단: GPS 현위치 버튼
- 하단: 장소 카드 가로 스크롤 + 탭 시 상세 Sheet

**`MapViewModel`** — 지도 비즈니스 로직
- `CLLocationManager` 기반 실시간 GPS 위치 추적
- Kakao Local REST API 카테고리/키워드 검색 (RxSwift Single)
- 공식 스팟 + 검색 결과 통합 (`displayPlaces`)
- 허용 반경 Mock 1km (서버 연동 시 교체 예정)

**`KakaoLocalAPIService`** — Kakao Local API 래퍼
- 카테고리 코드 검색 (`/v2/local/search/category`)
- 키워드 검색 (`/v2/local/search/keyword`)
- 반경 내 장소 필터링

**`MapPlaceItem` / `MapCategory`** — 지도 도메인 모델
- 공식 스팟과 검색 결과를 통합하는 모델
- 6개 카테고리 enum (emoji, Kakao API 코드 매핑)

**`AppInfoView`** — 프로필 > 버전정보 화면
- Hero 헤더 + 서비스소개 + 앱정보 + 이용약관 링크

---

### 2. KakaoMap 렌더링 버그 수정

#### 문제
`UIViewRepresentable`로 구현 시 `addViews()` 콜백이 호출되지 않아 지도가 렌더링되지 않음

#### 원인
KakaoMapsSDK는 내부적으로 `UIViewController` 라이프사이클(`viewWillAppear` / `viewWillDisappear`)을 기반으로 `activateEngine()` / `pauseEngine()` 타이밍을 맞춰야 하는데, `UIViewRepresentable`에는 해당 라이프사이클이 없음

#### 해결
`UIViewRepresentable` → **`UIViewControllerRepresentable` + `KakaoMapViewController`** 로 교체

```
prepareEngine() → viewWillAppear → activateEngine() → addViews() → addViewSucceeded() ✅
```

#### 추가 수정
- KakaoMapsSDK API 오용 수정 (`MapPolygonShapeOptions`, `MapPolyline`, `CameraUpdate.make` 등)
- `NearbyMapView` iOS 호환성 수정 (`Color(HiTripColor.gray200)` → `HiTripColor.gray200`)

---

## 테스트 체크리스트

- [x] 지도 탭 진입 → KakaoMap 정상 렌더링
- [x] 카테고리 칩 탭 → Kakao Local API 검색 결과 마커 표시
- [x] 장소 카드 스크롤 → 탭 시 상세 Sheet 표시
- [ ] GPS 버튼 → 현재 위치로 카메라 이동 (실기기 필요)
- [ ] 1km 반경 폴리곤 오버레이 확인

---

## 참고 사항

- Kakao REST API 키: `APIKeys.swift` (`.gitignore` 등록, 미커밋)
- 허용 반경은 현재 **Mock 1km** — 서버 연동 후 `MapViewModel.allowedRadiusMeters` 교체
- 공식 스팟(`officialSpots`)은 서버 API 연동 전까지 빈 배열

🤖 Generated with [Claude Code](https://claude.com/claude-code)