### PR TITLE
feat: 여행객 앱 UI 전반 개선 및 개인 할일 기능 추가

### DIFF
--- a/HiTrip.xcodeproj/project.pbxproj
+++ b/HiTrip.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -413,7 +413,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/HiTrip/App/HiTripApp.swift
+++ b/HiTrip/App/HiTripApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 
 // MARK: - HiTripApp
 /// 앱 진입점 (@main)
@@ -6,7 +7,7 @@ import SwiftUI
 /// 구조:
 /// - @UIApplicationDelegateAdaptor: UIKit AppDelegate 연결 (Push 등)
 /// - @StateObject router: 앱 전체에서 공유할 화면 전환 매니저
-/// - .environmentObject(router): 모든 하위 View에서 접근 가능
+/// - .modelContainer: SwiftData (PersonalTodo 로컬 저장)
 
 @main
 struct HiTripApp: App {
@@ -19,5 +20,6 @@ struct HiTripApp: App {
             RootView()
                 .environmentObject(router)
         }
+        .modelContainer(for: PersonalTodo.self)
     }
 }

--- a/HiTrip/Core/Extensions/View+CardStyle.swift
+++ b/HiTrip/Core/Extensions/View+CardStyle.swift
@@ -33,7 +33,7 @@ struct HiTripCardModifier: ViewModifier {
         }
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 12, x: 0, y: 4)
     }
 }
 

--- a/HiTrip/Core/Network/APIEnvironment.swift
+++ b/HiTrip/Core/Network/APIEnvironment.swift
@@ -22,7 +22,7 @@ enum APIEnvironment {
     // MARK: - 현재 환경 (여기서 전환)
 
     /// ⚠️ 서버 연동 시 .remote로 변경
-    static let current: APIEnvironment = .remote
+    static let current: APIEnvironment = .mock
 
     // MARK: - Base URL
 

--- a/HiTrip/Core/Network/KakaoLocalAPIService.swift
+++ b/HiTrip/Core/Network/KakaoLocalAPIService.swift
@@ -9,9 +9,10 @@ struct KakaoLocalPlace: Decodable, Identifiable {
     let categoryName: String
     let addressName: String
     let roadAddressName: String
-    let x: String   // longitude
-    let y: String   // latitude
+    let x: String           // longitude
+    let y: String           // latitude
     let placeUrl: String
+    let distance: String?   // 현위치 기준 거리 (m)
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -21,6 +22,7 @@ struct KakaoLocalPlace: Decodable, Identifiable {
         case roadAddressName  = "road_address_name"
         case x, y
         case placeUrl         = "place_url"
+        case distance
     }
 }
 

--- a/HiTrip/Data/Repositories/MockTravelerRepository.swift
+++ b/HiTrip/Data/Repositories/MockTravelerRepository.swift
@@ -206,8 +206,8 @@ private extension MockTravelerRepository {
             id: 1,
             title: "제주 힐링 여행 2026",
             destination: "제주",
-            startDate: "2026-06-21",
-            endDate: "2026-06-24",
+            startDate: "2026-07-19",
+            endDate: "2026-07-22",
             status: "ongoing",
             managerName: "김담당",
             managerContact: ["phone": "010-1234-5678"],
@@ -290,18 +290,18 @@ private extension MockTravelerRepository {
         [
             TravelerNoticeDTO(id: 1, title: "⚠️ 한라산 등반 안전 수칙",
                 content: "내일 한라산 등반 시 반드시 등산화를 착용해 주세요. 기상 변화가 심하므로 방수 재킷도 필수입니다. 오전 9시 30분 호텔 로비에서 집결합니다.",
-                priority: "important", publishedAt: "2026-06-21T18:00:00.000000Z",
-                createdAt: "2026-06-21T18:00:00.000000Z", updatedAt: "2026-06-21T18:00:00.000000Z"),
+                priority: "important", publishedAt: "2026-07-19T18:00:00.000000Z",
+                createdAt: "2026-07-19T18:00:00.000000Z", updatedAt: "2026-07-19T18:00:00.000000Z"),
 
             TravelerNoticeDTO(id: 2, title: "우도 스노클링 장비 신청 마감",
                 content: "내일 우도 스노클링 체험을 원하시는 분은 오늘 밤 10시까지 담당자에게 연락 주시기 바랍니다. 장비는 현장에서 제공됩니다.",
-                priority: "normal", publishedAt: "2026-06-21T20:00:00.000000Z",
-                createdAt: "2026-06-21T20:00:00.000000Z", updatedAt: "2026-06-21T20:00:00.000000Z"),
+                priority: "normal", publishedAt: "2026-07-19T20:00:00.000000Z",
+                createdAt: "2026-07-19T20:00:00.000000Z", updatedAt: "2026-07-19T20:00:00.000000Z"),
 
             TravelerNoticeDTO(id: 3, title: "내일 조식 시간 변경 안내",
-                content: "6월 22일(월) 조식이 08:00으로 변경되었습니다. 한라산 등반 일정이 앞당겨진 관계로 시간을 엄수해 주시기 바랍니다.",
-                priority: "normal", publishedAt: "2026-06-21T21:00:00.000000Z",
-                createdAt: "2026-06-21T21:00:00.000000Z", updatedAt: "2026-06-21T21:00:00.000000Z"),
+                content: "7월 20일(일) 조식이 08:00으로 변경되었습니다. 한라산 등반 일정이 앞당겨진 관계로 시간을 엄수해 주시기 바랍니다.",
+                priority: "normal", publishedAt: "2026-07-19T21:00:00.000000Z",
+                createdAt: "2026-07-19T21:00:00.000000Z", updatedAt: "2026-07-19T21:00:00.000000Z"),
         ]
     }
 
@@ -418,11 +418,11 @@ private extension MockTravelerRepository {
     // MARK: Helpers
 
     private func tripDayDate(_ day: Int) -> String {
-        // 여행 시작: 2026-06-21 (day 1)
+        // 여행 시작: 2026-07-19 (day 1) → 오늘 2026-07-20이 2일차
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
         df.locale = Locale(identifier: "en_US_POSIX")
-        let start = df.date(from: "2026-06-21") ?? Date()
+        let start = df.date(from: "2026-07-19") ?? Date()
         let date = Calendar.current.date(byAdding: .day, value: day - 1, to: start) ?? start
         return df.string(from: date)
     }

--- a/HiTrip/Features/Auth/Views/AgreementView.swift
+++ b/HiTrip/Features/Auth/Views/AgreementView.swift
@@ -13,7 +13,7 @@ struct AgreementView: View {
 
     var body: some View {
         ZStack {
-            HiTripColor.screenBackground.ignoresSafeArea()
+            Color.white.ignoresSafeArea()
 
             VStack(spacing: 0) {
                 Text("서비스 이용 약관")

--- a/HiTrip/Features/Auth/Views/InviteLoginFlowView.swift
+++ b/HiTrip/Features/Auth/Views/InviteLoginFlowView.swift
@@ -14,7 +14,7 @@ struct InviteLoginFlowView: View {
 
     var body: some View {
         ZStack {
-            HiTripColor.screenBackground
+            Color.white
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
@@ -85,11 +85,11 @@ struct InviteLoginFlowView: View {
                 .foregroundColor(.orange)
             Text("전화번호: 010-1234-5678\n생년월일: 1995년 3월 15일\n초대코드: HITRIP2026")
                 .font(.system(size: 12))
-                .foregroundColor(.orange.opacity(0.8))
+                .foregroundColor(.orange.opacity(0.14))
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.orange.opacity(0.08))
+        .background(Color.orange.opacity(0.14))
         .cornerRadius(10)
         .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.orange.opacity(0.3), lineWidth: 1))
     }
@@ -111,7 +111,7 @@ struct InviteLoginFlowView: View {
                     .frame(width: 40, height: 40)
                     .background(Color.white)
                     .clipShape(Circle())
-                    .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                    .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 4, y: 2)
             }
 
             Spacer()

--- a/HiTrip/Features/Auth/Views/LoginView.swift
+++ b/HiTrip/Features/Auth/Views/LoginView.swift
@@ -25,7 +25,7 @@ struct LoginView: View {
     var body: some View {
         ZStack {
             // 배경색
-            HiTripColor.screenBackground
+            Color.white
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {

--- a/HiTrip/Features/Auth/Views/SignUpFlowView.swift
+++ b/HiTrip/Features/Auth/Views/SignUpFlowView.swift
@@ -27,7 +27,7 @@ struct SignUpFlowView: View {
     var body: some View {
         ZStack {
             // 배경색
-            HiTripColor.screenBackground
+            Color.white
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {

--- a/HiTrip/Features/Chat/Views/ChatListView.swift
+++ b/HiTrip/Features/Chat/Views/ChatListView.swift
@@ -52,7 +52,7 @@ struct ChatListView: View {
 
                 Spacer()
             }
-            .background(HiTripColor.screenBackground)
+            .background(Color.white)
             .navigationTitle("메시지")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/HiTrip/Features/Chat/Views/ChatRoomView.swift
+++ b/HiTrip/Features/Chat/Views/ChatRoomView.swift
@@ -32,7 +32,7 @@ struct ChatRoomView: View {
             // 입력창
             messageInputBar
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .navigationBarHidden(true)
         .onAppear {
             viewModel.fetchMessages(chatRoomId: chatRoom.id)

--- a/HiTrip/Features/Emergency/Views/EmergencyView.swift
+++ b/HiTrip/Features/Emergency/Views/EmergencyView.swift
@@ -5,135 +5,148 @@ import SwiftUI
 ///
 /// 구성:
 /// - 상단: 112 / 119 퀵 전화 버튼
-/// - 담당자: 서버에서 받은 여행사 담당자 연락처
-/// - 긴급 요청 전송: POST /api/traveler/emergency-requests/
+/// - 담당자: 긴급 요청 전송 행
 /// - 카테고리별 연락처 리스트 (긴급/의료/관광/개인)
 
 struct EmergencyView: View {
 
     @ObservedObject var viewModel: EmergencyViewModel
     @Environment(\.openURL) private var openURL
-    @State private var showAddSheet = false
     @State private var showEmergencyRequest = false
 
     var body: some View {
-        NavigationStack {
-            List {
+        ScrollView {
+            VStack(spacing: 0) {
                 // 112 / 119 퀵버튼
-                quickCallSection
+                quickCallRow
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
+                    .padding(.bottom, 16)
 
-                // 담당자에게 긴급 요청 전송
-                emergencyRequestSection
+                // 담당자 긴급 요청 + 카테고리별 연락처
+                contactList
+                    .padding(.horizontal, 20)
 
-                // 카테고리별 연락처
-                ForEach(ContactCategory.allCases, id: \.self) { category in
-                    let categoryContacts = viewModel.contactsByCategory(category)
-                    if !categoryContacts.isEmpty {
-                        Section(category.rawValue) {
-                            ForEach(categoryContacts) { contact in
-                                contactRow(contact)
-                            }
-                            .onDelete { indexSet in
-                                deleteContacts(in: categoryContacts, at: indexSet)
-                            }
-                        }
-                    }
-                }
+                Spacer().frame(height: 40)
             }
-            .listStyle(.insetGrouped)
-            .navigationTitle("긴급 연락")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button { showAddSheet = true } label: {
-                        Image(systemName: "plus")
-                    }
-                }
-            }
-            .sheet(isPresented: $showAddSheet) {
-                EmergencyAddView(viewModel: viewModel)
-            }
-            .sheet(isPresented: $showEmergencyRequest) {
-                emergencyRequestSheet
-            }
-            .onChange(of: showAddSheet) { isPresented in
-                if !isPresented {
-                    viewModel.fetchContacts()
-                    viewModel.resetForm()
-                }
-            }
-            .alert("긴급 요청 전송 완료", isPresented: $viewModel.emergencySentSuccess) {
-                Button("확인", role: .cancel) {}
-            } message: {
-                Text("담당자에게 긴급 요청이 전송됐습니다. 잠시만 기다려주세요.")
-            }
-            .onAppear {
-                viewModel.fetchContacts()
-            }
+        }
+        .background(HiTripColor.screenBackground)
+        .navigationTitle("긴급 연락")
+        .navigationBarTitleDisplayMode(.large)
+        .sheet(isPresented: $showEmergencyRequest) {
+            emergencyRequestSheet
+        }
+        .alert("긴급 요청 전송 완료", isPresented: $viewModel.emergencySentSuccess) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text("담당자에게 긴급 요청이 전송됐습니다. 잠시만 기다려주세요.")
+        }
+        .onAppear {
+            viewModel.fetchContacts()
         }
     }
 
     // MARK: - 112 / 119 퀵버튼
 
-    private var quickCallSection: some View {
-        Section {
-            HStack(spacing: 12) {
-                quickCallButton(title: "경찰", number: "112", icon: "shield.fill", color: .blue)
-                quickCallButton(title: "소방/구급", number: "119", icon: "flame.fill", color: .red)
-            }
-            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+    private var quickCallRow: some View {
+        HStack(spacing: 12) {
+            quickCallButton(number: "112", label: "경찰", color: .blue)
+            quickCallButton(number: "119", label: "소방/ 구급", color: Color(red: 0.85, green: 0.25, blue: 0.22))
         }
     }
 
-    private func quickCallButton(title: String, number: String, icon: String, color: Color) -> some View {
+    private func quickCallButton(number: String, label: String, color: Color) -> some View {
         Button {
             if let url = viewModel.makeCallURL(phoneNumber: number) { openURL(url) }
         } label: {
-            VStack(spacing: 8) {
-                Image(systemName: icon).font(.system(size: 28)).foregroundColor(.white)
-                Text(title).font(.system(size: 14, weight: .semibold)).foregroundColor(.white)
-                Text(number).font(.system(size: 20, weight: .bold)).foregroundColor(.white)
+            VStack(spacing: 6) {
+                Text(number)
+                    .font(.system(size: 32, weight: .bold))
+                    .foregroundColor(.white)
+                Text(label)
+                    .font(.system(size: 14))
+                    .foregroundColor(.white)
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 16)
+            .padding(.vertical, 22)
             .background(color)
-            .cornerRadius(12)
+            .cornerRadius(14)
         }
         .buttonStyle(.plain)
     }
 
-    // MARK: - 긴급 요청 전송
+    // MARK: - 연락처 리스트 카드
 
-    private var emergencyRequestSection: some View {
-        Section {
-            Button {
+    private var contactList: some View {
+        VStack(spacing: 0) {
+            // 담당자에게 긴급 요청
+            contactRow(
+                title: "담당자에게 긴급 요청",
+                subtitle: "도움 메시지를 여행사 담당자에게 전송합니다"
+            ) {
                 showEmergencyRequest = true
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(.white)
-                        .frame(width: 36, height: 36)
-                        .background(Color.orange)
-                        .cornerRadius(8)
+            }
 
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("담당자에게 긴급 요청")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(HiTripColor.textBlack)
-                        Text("도움 메시지를 여행사 담당자에게 전송합니다")
+            Divider()
+
+            // 카테고리별 연락처
+            ForEach(ContactCategory.allCases, id: \.self) { category in
+                let items = viewModel.contactsByCategory(category)
+                if !items.isEmpty {
+                    // 섹션 헤더
+                    HStack {
+                        Text(category.rawValue)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(HiTripColor.gray500)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+                    .padding(.bottom, 4)
+
+                    ForEach(items) { contact in
+                        Divider()
+                        contactRow(title: contact.name, subtitle: nil) {
+                            if let url = viewModel.makeCallURL(phoneNumber: contact.phoneNumber) {
+                                openURL(url)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .background(Color.white)
+        .cornerRadius(14)
+        .shadow(color: .black.opacity(0.04), radius: 6, x: 0, y: 2)
+    }
+
+    // MARK: - 연락처 행
+
+    private func contactRow(title: String, subtitle: String?, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.system(size: 16))
+                        .foregroundColor(HiTripColor.textBlack)
+
+                    if let subtitle {
+                        Text(subtitle)
                             .font(.system(size: 12))
                             .foregroundColor(HiTripColor.gray400)
                     }
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 14))
-                        .foregroundColor(HiTripColor.gray300)
                 }
+
+                Spacer()
+
+                Image(systemName: "phone")
+                    .font(.system(size: 18))
+                    .foregroundColor(HiTripColor.textBlack)
             }
-            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
         }
+        .buttonStyle(.plain)
     }
 
     // MARK: - 긴급 요청 시트
@@ -200,56 +213,6 @@ struct EmergencyView: View {
                     Button("취소") { showEmergencyRequest = false }
                 }
             }
-        }
-    }
-
-    // MARK: - 연락처 행
-
-    private func contactRow(_ contact: EmergencyContact) -> some View {
-        Button {
-            if let url = viewModel.makeCallURL(phoneNumber: contact.phoneNumber) { openURL(url) }
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: contact.iconName)
-                    .font(.system(size: 18))
-                    .foregroundColor(iconColor(for: contact.category))
-                    .frame(width: 32, height: 32)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(contact.name)
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(HiTripColor.textGrayA)
-                    Text(contact.phoneNumber)
-                        .font(.system(size: 14))
-                        .foregroundColor(HiTripColor.gray400)
-                }
-
-                Spacer()
-
-                Image(systemName: "phone.fill")
-                    .font(.system(size: 16))
-                    .foregroundColor(HiTripColor.primary800)
-            }
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - 헬퍼
-
-    private func iconColor(for category: ContactCategory) -> Color {
-        switch category {
-        case .manager:   return HiTripColor.primary800
-        case .emergency: return .red
-        case .medical:   return .orange
-        case .tourism:   return HiTripColor.primary800
-        case .personal:  return .gray
-        }
-    }
-
-    private func deleteContacts(in categoryContacts: [EmergencyContact], at indexSet: IndexSet) {
-        for index in indexSet {
-            let contact = categoryContacts[index]
-            if !contact.isPreset { viewModel.deleteContact(id: contact.id) }
         }
     }
 }

--- a/HiTrip/Features/Emergency/Views/EmergencyView.swift
+++ b/HiTrip/Features/Emergency/Views/EmergencyView.swift
@@ -30,7 +30,7 @@ struct EmergencyView: View {
                 Spacer().frame(height: 40)
             }
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .navigationTitle("긴급 연락")
         .navigationBarTitleDisplayMode(.large)
         .sheet(isPresented: $showEmergencyRequest) {
@@ -117,7 +117,7 @@ struct EmergencyView: View {
         }
         .background(Color.white)
         .cornerRadius(14)
-        .shadow(color: .black.opacity(0.04), radius: 6, x: 0, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, x: 0, y: 2)
     }
 
     // MARK: - 연락처 행
@@ -170,7 +170,7 @@ struct EmergencyView: View {
                 TextEditor(text: $viewModel.emergencyMessage)
                     .frame(minHeight: 120)
                     .padding(12)
-                    .background(HiTripColor.screenBackground)
+                    .background(Color.white)
                     .cornerRadius(12)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)

--- a/HiTrip/Features/Map/Models/MapPlaceItem.swift
+++ b/HiTrip/Features/Map/Models/MapPlaceItem.swift
@@ -55,6 +55,15 @@ struct MapPlaceItem: Identifiable, Equatable, Hashable {
     let category: String?
     let isOfficialSpot: Bool  // 안내사가 등록한 공식 스팟
     let placeUrl: String?
+    let distanceMeters: Int?  // 현위치 기준 거리 (m)
+    let rating: Double?       // 평점 (Mock — Kakao Local API 미제공)
+    let ratingCount: Int?     // 리뷰 수 (Mock)
+
+    /// 도보 이동 시간 (분) — 도보 80m/분 기준
+    var walkingMinutes: Int? {
+        guard let d = distanceMeters else { return nil }
+        return max(1, d / 80)
+    }
 
     static func == (lhs: MapPlaceItem, rhs: MapPlaceItem) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
@@ -72,7 +81,10 @@ extension KakaoLocalPlace {
             longitude: Double(x) ?? 0,
             category: categoryName,
             isOfficialSpot: false,
-            placeUrl: placeUrl.isEmpty ? nil : placeUrl
+            placeUrl: placeUrl.isEmpty ? nil : placeUrl,
+            distanceMeters: distance.flatMap { Int($0) },
+            rating: nil,
+            ratingCount: nil
         )
     }
 }
@@ -87,7 +99,10 @@ extension TravelerMapPlaceDTO {
             longitude: Double(longitude) ?? 0,
             category: nil,
             isOfficialSpot: true,
-            placeUrl: nil
+            placeUrl: nil,
+            distanceMeters: nil,
+            rating: nil,
+            ratingCount: nil
         )
     }
 }

--- a/HiTrip/Features/Map/ViewModels/MapViewModel.swift
+++ b/HiTrip/Features/Map/ViewModels/MapViewModel.swift
@@ -35,11 +35,19 @@ final class MapViewModel: NSObject, ObservableObject {
 
     /// GPS 버튼 탭 시 값이 바뀌어 KakaoMapView가 카메라를 이동시킴
     @Published var cameraTarget: CameraTarget?
+    /// 줌 인/아웃 신호
+    @Published var zoomTrigger: ZoomTrigger?
 
     struct CameraTarget: Equatable {
         let id = UUID()
         let coordinate: CLLocationCoordinate2D
         static func == (l: CameraTarget, r: CameraTarget) -> Bool { l.id == r.id }
+    }
+
+    struct ZoomTrigger: Equatable {
+        let id = UUID()
+        let delta: Int  // +1 = 줌인, -1 = 줌아웃
+        static func == (l: ZoomTrigger, r: ZoomTrigger) -> Bool { l.id == r.id }
     }
 
     // MARK: - Radius (Mock: 1km)
@@ -150,6 +158,9 @@ final class MapViewModel: NSObject, ObservableObject {
             cameraTarget = CameraTarget(coordinate: loc)
         }
     }
+
+    func zoomIn()  { zoomTrigger = ZoomTrigger(delta: +1) }
+    func zoomOut() { zoomTrigger = ZoomTrigger(delta: -1) }
 
     // MARK: - Location Setup
 

--- a/HiTrip/Features/Map/Views/MapRangeSettingView.swift
+++ b/HiTrip/Features/Map/Views/MapRangeSettingView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+// MARK: - MapRangeSettingView
+/// 허용 반경 설정 화면
+///
+/// 구성:
+/// - 날짜 탭 (여행 일차 선택)
+/// - 반경 슬라이더 (500m ~ 5km)
+/// - 미리보기 지도 (KakaoMap)
+/// - 저장 버튼
+
+struct MapRangeSettingView: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - State
+
+    @State private var selectedDay: Int = 1
+    @State private var radiusKm: Double = 1.0    // km 단위
+
+    private let totalDays = 5                    // Mock: 5일 일정
+    private let minKm: Double = 0.5
+    private let maxKm: Double = 5.0
+
+    var radiusMeters: Double { radiusKm * 1000 }
+
+    // MARK: - Mock Center (서울 시청)
+
+    private let centerLatitude  = 37.5665
+    private let centerLongitude = 126.9780
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+
+                // MARK: 날짜 탭
+                dayTabBar
+                    .padding(.top, 16)
+
+                Divider()
+                    .padding(.top, 12)
+
+                // MARK: 반경 슬라이더
+                radiusSection
+                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
+
+                // MARK: 미리보기 지도
+                mapPreview
+                    .padding(.top, 20)
+
+                Spacer()
+
+                // MARK: 저장 버튼
+                saveButton
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 32)
+            }
+            .navigationTitle("허용 반경 설정")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                            .foregroundColor(HiTripColor.textBlack)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Day Tab Bar
+
+    private var dayTabBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(1...totalDays, id: \.self) { day in
+                    Button {
+                        selectedDay = day
+                    } label: {
+                        Text("\(day)일차")
+                            .font(.system(size: 14, weight: selectedDay == day ? .semibold : .regular))
+                            .foregroundColor(selectedDay == day ? .white : HiTripColor.gray400)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(selectedDay == day ? HiTripColor.primary800 : Color.clear)
+                            .cornerRadius(20)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 20)
+                                    .stroke(selectedDay == day ? Color.clear : HiTripColor.gray200, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+
+    // MARK: - Radius Section
+
+    private var radiusSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("허용 반경")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
+                Spacer()
+                Text(radiusLabel)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(HiTripColor.primary800)
+            }
+
+            Slider(value: $radiusKm, in: minKm...maxKm, step: 0.5)
+                .tint(HiTripColor.primary800)
+
+            HStack {
+                Text("500m")
+                    .font(.system(size: 12))
+                    .foregroundColor(HiTripColor.gray400)
+                Spacer()
+                Text("5km")
+                    .font(.system(size: 12))
+                    .foregroundColor(HiTripColor.gray400)
+            }
+        }
+    }
+
+    private var radiusLabel: String {
+        if radiusKm < 1.0 {
+            return "\(Int(radiusKm * 1000))m"
+        } else if radiusKm == radiusKm.rounded() {
+            return "\(Int(radiusKm))km"
+        } else {
+            return String(format: "%.1fkm", radiusKm)
+        }
+    }
+
+    // MARK: - Map Preview
+
+    @State private var drawPreviewMap = false
+
+    private var mapPreview: some View {
+        ZStack {
+            KakaoMapView(
+                latitude: centerLatitude,
+                longitude: centerLongitude,
+                draw: $drawPreviewMap,
+                radiusMeters: radiusMeters
+            )
+            .cornerRadius(16)
+            .padding(.horizontal, 20)
+
+            // 반경 레이블 오버레이
+            VStack {
+                HStack {
+                    Spacer()
+                    Text("반경 \(radiusLabel)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.black.opacity(0.5))
+                        .cornerRadius(8)
+                        .padding(.top, 12)
+                        .padding(.trailing, 32)
+                }
+                Spacer()
+            }
+        }
+        .frame(height: 220)
+        .onAppear  { drawPreviewMap = true  }
+        .onDisappear { drawPreviewMap = false }
+    }
+
+    // MARK: - Save Button
+
+    private var saveButton: some View {
+        Button {
+            // TODO: ViewModel에 반경 저장
+            dismiss()
+        } label: {
+            Text("저장하기")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(HiTripColor.primary800)
+                .cornerRadius(14)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/HiTrip/Features/Map/Views/MapRangeSettingView.swift
+++ b/HiTrip/Features/Map/Views/MapRangeSettingView.swift
@@ -1,33 +1,33 @@
 import SwiftUI
 
 // MARK: - MapRangeSettingView
-/// 허용 반경 설정 화면
+/// 지도 범위 설정 화면 — 피그마 디자인 반영
 ///
 /// 구성:
-/// - 날짜 탭 (여행 일차 선택)
-/// - 반경 슬라이더 (500m ~ 5km)
-/// - 미리보기 지도 (KakaoMap)
-/// - 저장 버튼
+/// - 날짜 탭 (여행 일차 선택, 파란 pill)
+/// - 선택 일차 주소 표시
+/// - 슬라이더 (좁게 1 ~ 넓게 5, 5단계)
+/// - 미리보기 지도 (반경 원 표시)
+/// - 하단 버튼: 내 위치로 이동 / 현재 일정 위치로 이동
+/// - 저장하기 버튼
 
 struct MapRangeSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    // MARK: - State
-
     @State private var selectedDay: Int = 1
-    @State private var radiusKm: Double = 1.0    // km 단위
+    @State private var radiusStep: Int = 2        // 1~5 단계
+    @State private var drawPreviewMap = false
 
-    private let totalDays = 5                    // Mock: 5일 일정
-    private let minKm: Double = 0.5
-    private let maxKm: Double = 5.0
+    private let totalDays = 5                     // Mock: 5일 일정
+    private let mockAddress = "제주도 서귀포시 중문동 123-45"
 
-    var radiusMeters: Double { radiusKm * 1000 }
+    // 단계별 실제 반경 (m)
+    private let radiusOptions: [Double] = [300, 600, 1000, 1500, 2500]
+    private var radiusMeters: Double { radiusOptions[radiusStep - 1] }
 
-    // MARK: - Mock Center (서울 시청)
-
-    private let centerLatitude  = 37.5665
-    private let centerLongitude = 126.9780
+    private let centerLatitude  = 33.2508
+    private let centerLongitude = 126.4125
 
     var body: some View {
         NavigationStack {
@@ -35,38 +35,74 @@ struct MapRangeSettingView: View {
 
                 // MARK: 날짜 탭
                 dayTabBar
-                    .padding(.top, 16)
+                    .padding(.top, 20)
 
-                Divider()
-                    .padding(.top, 12)
+                // MARK: 주소
+                HStack(spacing: 6) {
+                    Image(systemName: "mappin.circle.fill")
+                        .font(.system(size: 15))
+                        .foregroundColor(HiTripColor.primary800)
+                    Text(mockAddress)
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.gray500)
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
 
-                // MARK: 반경 슬라이더
-                radiusSection
+                // MARK: 슬라이더 (좁게 ↔ 넓게, 5단계)
+                radiusSliderSection
                     .padding(.horizontal, 20)
-                    .padding(.top, 24)
+                    .padding(.top, 20)
 
                 // MARK: 미리보기 지도
                 mapPreview
-                    .padding(.top, 20)
+                    .padding(.top, 16)
 
                 Spacer()
 
-                // MARK: 저장 버튼
-                saveButton
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 32)
+                // MARK: 하단 이동 버튼 2개
+                HStack(spacing: 12) {
+                    moveButton(title: "내 위치로 이동") {
+                        // TODO: 내 위치로 이동
+                    }
+                    moveButton(title: "현재 일정 위치로 이동") {
+                        // TODO: 현재 일정 위치로 이동
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 12)
+
+                // MARK: 저장하기
+                Button {
+                    dismiss()
+                } label: {
+                    Text("저장하기")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(HiTripColor.primary800)
+                        .cornerRadius(14)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 32)
             }
-            .navigationTitle("허용 반경 설정")
+            .background(Color.white)
+            .navigationTitle("지도 범위 설정")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button { dismiss() } label: {
-                        Image(systemName: "xmark")
+                        Image(systemName: "chevron.left")
                             .foregroundColor(HiTripColor.textBlack)
                     }
                 }
             }
         }
+        .onAppear  { drawPreviewMap = true  }
+        .onDisappear { drawPreviewMap = false }
     }
 
     // MARK: - Day Tab Bar
@@ -80,10 +116,10 @@ struct MapRangeSettingView: View {
                     } label: {
                         Text("\(day)일차")
                             .font(.system(size: 14, weight: selectedDay == day ? .semibold : .regular))
-                            .foregroundColor(selectedDay == day ? .white : HiTripColor.gray400)
-                            .padding(.horizontal, 16)
+                            .foregroundColor(selectedDay == day ? .white : HiTripColor.gray500)
+                            .padding(.horizontal, 18)
                             .padding(.vertical, 8)
-                            .background(selectedDay == day ? HiTripColor.primary800 : Color.clear)
+                            .background(selectedDay == day ? HiTripColor.primary800 : Color.white)
                             .cornerRadius(20)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 20)
@@ -97,96 +133,71 @@ struct MapRangeSettingView: View {
         }
     }
 
-    // MARK: - Radius Section
+    // MARK: - Radius Slider Section
 
-    private var radiusSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("허용 반경")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(HiTripColor.textBlack)
-                Spacer()
-                Text(radiusLabel)
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(HiTripColor.primary800)
+    private var radiusSliderSection: some View {
+        VStack(spacing: 8) {
+            // 단계 인디케이터
+            HStack(spacing: 0) {
+                ForEach(1...5, id: \.self) { step in
+                    Circle()
+                        .fill(step <= radiusStep ? HiTripColor.primary800 : HiTripColor.gray200)
+                        .frame(width: 10, height: 10)
+                    if step < 5 {
+                        Rectangle()
+                            .fill(step < radiusStep ? HiTripColor.primary800 : HiTripColor.gray200)
+                            .frame(height: 3)
+                    }
+                }
             }
+            .frame(height: 10)
 
-            Slider(value: $radiusKm, in: minKm...maxKm, step: 0.5)
-                .tint(HiTripColor.primary800)
+            // 드래그 슬라이더 (내부 사용 용도로 Slider 그대로, 스텝 스냅)
+            Slider(value: Binding(
+                get: { Double(radiusStep) },
+                set: { radiusStep = Int($0.rounded()) }
+            ), in: 1...5, step: 1)
+            .tint(HiTripColor.primary800)
 
+            // 레이블
             HStack {
-                Text("500m")
+                Text("좁게")
                     .font(.system(size: 12))
                     .foregroundColor(HiTripColor.gray400)
                 Spacer()
-                Text("5km")
+                Text("넓게")
                     .font(.system(size: 12))
                     .foregroundColor(HiTripColor.gray400)
             }
-        }
-    }
-
-    private var radiusLabel: String {
-        if radiusKm < 1.0 {
-            return "\(Int(radiusKm * 1000))m"
-        } else if radiusKm == radiusKm.rounded() {
-            return "\(Int(radiusKm))km"
-        } else {
-            return String(format: "%.1fkm", radiusKm)
         }
     }
 
     // MARK: - Map Preview
 
-    @State private var drawPreviewMap = false
-
     private var mapPreview: some View {
-        ZStack {
-            KakaoMapView(
-                latitude: centerLatitude,
-                longitude: centerLongitude,
-                draw: $drawPreviewMap,
-                radiusMeters: radiusMeters
-            )
-            .cornerRadius(16)
-            .padding(.horizontal, 20)
-
-            // 반경 레이블 오버레이
-            VStack {
-                HStack {
-                    Spacer()
-                    Text("반경 \(radiusLabel)")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(Color.black.opacity(0.5))
-                        .cornerRadius(8)
-                        .padding(.top, 12)
-                        .padding(.trailing, 32)
-                }
-                Spacer()
-            }
-        }
-        .frame(height: 220)
-        .onAppear  { drawPreviewMap = true  }
-        .onDisappear { drawPreviewMap = false }
+        KakaoMapView(
+            latitude: centerLatitude,
+            longitude: centerLongitude,
+            draw: $drawPreviewMap,
+            radiusMeters: radiusMeters
+        )
+        .frame(height: 240)
+        .cornerRadius(0)
+        .padding(.horizontal, 20)
+        .cornerRadius(16)
     }
 
-    // MARK: - Save Button
+    // MARK: - Move Button
 
-    private var saveButton: some View {
-        Button {
-            // TODO: ViewModel에 반경 저장
-            dismiss()
-        } label: {
-            Text("저장하기")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.white)
+    private func moveButton(title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(HiTripColor.gray500)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(HiTripColor.primary800)
-                .cornerRadius(14)
+                .padding(.vertical, 14)
+                .background(HiTripColor.gray100)
+                .cornerRadius(12)
         }
         .buttonStyle(.plain)
     }

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -24,7 +24,8 @@ struct NearbyMapView: View {
                 markers: viewModel.displayPlaces,
                 userLocation: viewModel.currentLocation,
                 radiusMeters: viewModel.allowedRadiusMeters,
-                cameraTarget: viewModel.cameraTarget
+                cameraTarget: viewModel.cameraTarget,
+                zoomTrigger: viewModel.zoomTrigger
             )
             .ignoresSafeArea()
 
@@ -41,9 +42,14 @@ struct NearbyMapView: View {
 
                 // MARK: 하단 GPS + 카드
                 VStack(spacing: 8) {
-                    gpsButton
-                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    HStack {
+                        Spacer()
+                        VStack(spacing: 8) {
+                            gpsButton
+                            zoomButtons
+                        }
                         .padding(.trailing, 16)
+                    }
 
                     if !viewModel.displayPlaces.isEmpty {
                         placeCardScroll
@@ -131,6 +137,29 @@ struct NearbyMapView: View {
         }
     }
 
+    // MARK: - Zoom Buttons
+
+    private var zoomButtons: some View {
+        VStack(spacing: 0) {
+            Button { viewModel.zoomIn() } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(HiTripColor.textBlack)
+                    .frame(width: 46, height: 46)
+            }
+            Divider().frame(width: 30)
+            Button { viewModel.zoomOut() } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(HiTripColor.textBlack)
+                    .frame(width: 46, height: 46)
+            }
+        }
+        .background(Color.white)
+        .cornerRadius(12)
+        .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
+    }
+
     // MARK: - Place Card Scroll
 
     private var placeCardScroll: some View {
@@ -158,14 +187,15 @@ struct PlaceCardView: View {
             // 썸네일
             ZStack {
                 HiTripColor.gray200
-                Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "mappin.and.ellipse")
+                Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "photo")
                     .font(.system(size: 28))
-                    .foregroundColor(place.isOfficialSpot ? HiTripColor.primary800 : .orange)
+                    .foregroundColor(HiTripColor.gray300)
             }
-            .frame(width: 155, height: 95)
+            .frame(width: 155, height: 100)
             .clipped()
+            .cornerRadius(12, corners: [.topLeft, .topRight])
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 4) {
                 if place.isOfficialSpot {
                     Text("📍 공식 스팟")
                         .font(.system(size: 10, weight: .semibold))
@@ -176,17 +206,32 @@ struct PlaceCardView: View {
                     .foregroundColor(HiTripColor.textBlack)
                     .lineLimit(1)
 
-                if let category = place.category, !category.isEmpty {
-                    Text(category)
-                        .font(.system(size: 11))
-                        .foregroundColor(HiTripColor.gray400)
-                        .lineLimit(1)
-                }
-                if let address = place.address, !address.isEmpty {
-                    Text(address)
-                        .font(.system(size: 11))
-                        .foregroundColor(HiTripColor.gray400)
-                        .lineLimit(1)
+                HStack(spacing: 6) {
+                    // 별점
+                    if let rating = place.rating {
+                        HStack(spacing: 2) {
+                            Image(systemName: "star.fill")
+                                .font(.system(size: 10))
+                                .foregroundColor(.yellow)
+                            Text(String(format: "%.1f", rating))
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundColor(HiTripColor.textBlack)
+                        }
+                        if place.walkingMinutes != nil {
+                            Text("·").font(.system(size: 11)).foregroundColor(HiTripColor.gray300)
+                        }
+                    }
+                    // 도보 시간
+                    if let mins = place.walkingMinutes {
+                        Text("도보 \(mins)분")
+                            .font(.system(size: 11))
+                            .foregroundColor(HiTripColor.gray400)
+                    } else if let category = place.category, !category.isEmpty {
+                        Text(category)
+                            .font(.system(size: 11))
+                            .foregroundColor(HiTripColor.gray400)
+                            .lineLimit(1)
+                    }
                 }
             }
             .padding(.horizontal, 10)

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -74,12 +74,17 @@ struct NearbyMapView: View {
             Text("주변 인기 스팟")
                 .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
-                .shadow(color: .white.opacity(0.8), radius: 4, x: 0, y: 0)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(.ultraThinMaterial)
+                .cornerRadius(10)
             Spacer()
             if viewModel.isLoading {
                 ProgressView()
                     .scaleEffect(0.8)
-                    .background(Color.white.opacity(0.8).clipShape(Circle()))
+                    .padding(8)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Circle())
             }
         }
     }

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -118,7 +118,7 @@ struct NearbyMapView: View {
             .padding(.vertical, 7)
             .background(isSelected ? HiTripColor.primary800 : Color.white)
             .cornerRadius(20)
-            .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 4, y: 1)
         }
         .buttonStyle(.plain)
     }
@@ -137,7 +137,7 @@ struct NearbyMapView: View {
                     .frame(width: 42, height: 42)
                     .background(Color.white)
                     .clipShape(Circle())
-                    .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
+                    .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
             }
 
             // 줌 버튼 가로 배치 (— +)
@@ -159,7 +159,7 @@ struct NearbyMapView: View {
             }
             .background(Color.white)
             .cornerRadius(10)
-            .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
         }
     }
 
@@ -241,7 +241,7 @@ struct PlaceCardView: View {
         .frame(width: 160)
         .background(Color.white)
         .cornerRadius(12)
-        .shadow(color: .black.opacity(0.10), radius: 8, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 8, y: 2)
     }
 }
 
@@ -273,7 +273,7 @@ struct PlaceDetailSheet: View {
                                     .foregroundColor(HiTripColor.primary800)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 4)
-                                    .background(HiTripColor.primary800.opacity(0.1))
+                                    .background(HiTripColor.primary800.opacity(0.14))
                                     .cornerRadius(8)
                             }
                             Text(place.name)

--- a/HiTrip/Features/Map/Views/NearbyMapView.swift
+++ b/HiTrip/Features/Map/Views/NearbyMapView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 import CoreLocation
 
 // MARK: - NearbyMapView
-/// 지도 탭 메인 화면
+/// 지도 탭 메인 화면 — 피그마 디자인 반영
 ///
 /// 구성:
 /// - 풀스크린 KakaoMap (허용 반경 + 마커)
-/// - 상단: 페이지 제목 + 카테고리 필터 칩
-/// - 우하단: GPS 버튼
-/// - 하단: 장소 카드 가로 스크롤
+/// - 상단 좌측: "주변 인기 스팟" 타이틀 (그림자 텍스트)
+/// - 상단: 카테고리 필터 칩 (흰 배경 알약)
+/// - 우측 중단: GPS 원형 버튼 + 줌(— +) 가로 버튼
+/// - 하단: 장소 카드 가로 스크롤 (이미지 + 이름 + 카테고리 + 별점(N) + 도보)
 
 struct NearbyMapView: View {
 
@@ -29,65 +30,61 @@ struct NearbyMapView: View {
             )
             .ignoresSafeArea()
 
-            // MARK: 상단 오버레이
+            // MARK: 오버레이 레이어
             VStack(spacing: 0) {
-                titleBar
-                    .padding(.top, 8)
-                    .padding(.horizontal, 16)
 
-                categoryBar
-                    .padding(.top, 8)
+                // 상단: 타이틀 + 카테고리
+                VStack(alignment: .leading, spacing: 10) {
+                    titleLabel
+                        .padding(.horizontal, 20)
+
+                    categoryBar
+                }
+                .padding(.top, 12)
 
                 Spacer()
 
-                // MARK: 하단 GPS + 카드
-                VStack(spacing: 8) {
-                    HStack {
-                        Spacer()
-                        VStack(spacing: 8) {
-                            gpsButton
-                            zoomButtons
-                        }
+                // 우측 컨트롤: GPS + 줌
+                HStack {
+                    Spacer()
+                    rightControls
                         .padding(.trailing, 16)
-                    }
-
-                    if !viewModel.displayPlaces.isEmpty {
-                        placeCardScroll
-                    }
+                        .padding(.bottom, viewModel.displayPlaces.isEmpty ? 32 : 8)
                 }
-                .padding(.bottom, 24)
+
+                // 하단 장소 카드
+                if !viewModel.displayPlaces.isEmpty {
+                    placeCardScroll
+                        .padding(.bottom, 24)
+                }
             }
         }
-        .navigationTitle("지도")
         .navigationBarHidden(true)
-        .onAppear  { viewModel.drawMap = true }
+        .onAppear  { viewModel.drawMap = true  }
         .onDisappear { viewModel.drawMap = false }
         .sheet(item: $viewModel.selectedPlace) { place in
             PlaceDetailSheet(place: place)
         }
     }
 
-    // MARK: - Title Bar
+    // MARK: - Title Label
 
-    private var titleBar: some View {
+    private var titleLabel: some View {
         HStack {
             Text("주변 인기 스팟")
-                .font(.system(size: 18, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(HiTripColor.textBlack)
+                .shadow(color: .white.opacity(0.8), radius: 4, x: 0, y: 0)
             Spacer()
             if viewModel.isLoading {
                 ProgressView()
                     .scaleEffect(0.8)
+                    .background(Color.white.opacity(0.8).clipShape(Circle()))
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(.ultraThinMaterial)
-        .cornerRadius(14)
-        .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
     }
 
-    // MARK: - Category Filter
+    // MARK: - Category Bar
 
     private var categoryBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -96,7 +93,7 @@ struct NearbyMapView: View {
                     categoryChip(category)
                 }
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 20)
         }
     }
 
@@ -116,48 +113,49 @@ struct NearbyMapView: View {
             .padding(.vertical, 7)
             .background(isSelected ? HiTripColor.primary800 : Color.white)
             .cornerRadius(20)
-            .shadow(color: .black.opacity(0.08), radius: 4, y: 1)
+            .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
         }
         .buttonStyle(.plain)
     }
 
-    // MARK: - GPS Button
+    // MARK: - Right Controls (GPS + Zoom)
 
-    private var gpsButton: some View {
-        Button {
-            viewModel.moveToCurrentLocation()
-        } label: {
-            Image(systemName: "location.fill")
-                .font(.system(size: 18))
-                .foregroundColor(HiTripColor.primary800)
-                .frame(width: 46, height: 46)
-                .background(Color.white)
-                .clipShape(Circle())
-                .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
-        }
-    }
-
-    // MARK: - Zoom Buttons
-
-    private var zoomButtons: some View {
-        VStack(spacing: 0) {
-            Button { viewModel.zoomIn() } label: {
-                Image(systemName: "plus")
+    private var rightControls: some View {
+        VStack(spacing: 10) {
+            // GPS 버튼 (원형)
+            Button {
+                viewModel.moveToCurrentLocation()
+            } label: {
+                Image(systemName: "location")
                     .font(.system(size: 16, weight: .medium))
                     .foregroundColor(HiTripColor.textBlack)
-                    .frame(width: 46, height: 46)
+                    .frame(width: 42, height: 42)
+                    .background(Color.white)
+                    .clipShape(Circle())
+                    .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
             }
-            Divider().frame(width: 30)
-            Button { viewModel.zoomOut() } label: {
-                Image(systemName: "minus")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(HiTripColor.textBlack)
-                    .frame(width: 46, height: 46)
+
+            // 줌 버튼 가로 배치 (— +)
+            HStack(spacing: 0) {
+                Button { viewModel.zoomOut() } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                        .frame(width: 42, height: 42)
+                }
+                Divider()
+                    .frame(height: 24)
+                Button { viewModel.zoomIn() } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                        .frame(width: 42, height: 42)
+                }
             }
+            .background(Color.white)
+            .cornerRadius(10)
+            .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
         }
-        .background(Color.white)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.14), radius: 6, y: 2)
     }
 
     // MARK: - Place Card Scroll
@@ -170,7 +168,7 @@ struct NearbyMapView: View {
                         .onTapGesture { viewModel.selectedPlace = place }
                 }
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 20)
             .padding(.vertical, 4)
         }
     }
@@ -184,63 +182,61 @@ struct PlaceCardView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 썸네일
+            // 썸네일 이미지
             ZStack {
                 HiTripColor.gray200
-                Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "photo")
+                Image(systemName: "photo")
                     .font(.system(size: 28))
                     .foregroundColor(HiTripColor.gray300)
             }
-            .frame(width: 155, height: 100)
+            .frame(width: 160, height: 120)
             .clipped()
             .cornerRadius(12, corners: [.topLeft, .topRight])
 
+            // 텍스트 영역
             VStack(alignment: .leading, spacing: 4) {
-                if place.isOfficialSpot {
-                    Text("📍 공식 스팟")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(HiTripColor.primary800)
-                }
                 Text(place.name)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(HiTripColor.textBlack)
                     .lineLimit(1)
 
-                HStack(spacing: 6) {
-                    // 별점
+                if let category = place.category, !category.isEmpty {
+                    Text(category)
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray400)
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: 4) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.yellow)
+
                     if let rating = place.rating {
-                        HStack(spacing: 2) {
-                            Image(systemName: "star.fill")
-                                .font(.system(size: 10))
-                                .foregroundColor(.yellow)
-                            Text(String(format: "%.1f", rating))
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundColor(HiTripColor.textBlack)
-                        }
-                        if place.walkingMinutes != nil {
-                            Text("·").font(.system(size: 11)).foregroundColor(HiTripColor.gray300)
-                        }
+                        Text(String(format: "%.1f", rating))
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(HiTripColor.textBlack)
                     }
-                    // 도보 시간
-                    if let mins = place.walkingMinutes {
-                        Text("도보 \(mins)분")
-                            .font(.system(size: 11))
+                    if let count = place.ratingCount {
+                        Text("(\(count))")
+                            .font(.system(size: 12))
                             .foregroundColor(HiTripColor.gray400)
-                    } else if let category = place.category, !category.isEmpty {
-                        Text(category)
-                            .font(.system(size: 11))
-                            .foregroundColor(HiTripColor.gray400)
-                            .lineLimit(1)
                     }
+                }
+
+                if let mins = place.walkingMinutes {
+                    Text("도보 \(mins)분")
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray400)
                 }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
         }
-        .frame(width: 155)
+        .frame(width: 160)
         .background(Color.white)
         .cornerRadius(12)
-        .shadow(color: .black.opacity(0.08), radius: 6, y: 2)
+        .shadow(color: .black.opacity(0.10), radius: 8, y: 2)
     }
 }
 
@@ -255,18 +251,16 @@ struct PlaceDetailSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    // 헤더 이미지 영역
                     ZStack {
                         HiTripColor.gray200
-                        Image(systemName: place.isOfficialSpot ? "mappin.circle.fill" : "mappin.and.ellipse")
+                        Image(systemName: "photo")
                             .font(.system(size: 50))
-                            .foregroundColor(place.isOfficialSpot ? HiTripColor.primary800 : .orange)
+                            .foregroundColor(HiTripColor.gray300)
                     }
                     .frame(maxWidth: .infinity)
-                    .frame(height: 180)
+                    .frame(height: 200)
 
                     VStack(alignment: .leading, spacing: 20) {
-                        // 배지 + 이름
                         VStack(alignment: .leading, spacing: 8) {
                             if place.isOfficialSpot {
                                 Text("📍 공식 일정 스팟")
@@ -280,6 +274,26 @@ struct PlaceDetailSheet: View {
                             Text(place.name)
                                 .font(.system(size: 22, weight: .bold))
                                 .foregroundColor(HiTripColor.textBlack)
+
+                            HStack(spacing: 4) {
+                                Image(systemName: "star.fill")
+                                    .font(.system(size: 13))
+                                    .foregroundColor(.yellow)
+                                if let rating = place.rating {
+                                    Text(String(format: "%.1f", rating))
+                                        .font(.system(size: 14, weight: .medium))
+                                }
+                                if let count = place.ratingCount {
+                                    Text("(\(count))")
+                                        .font(.system(size: 13))
+                                        .foregroundColor(HiTripColor.gray400)
+                                }
+                                if let mins = place.walkingMinutes {
+                                    Text("· 도보 \(mins)분")
+                                        .font(.system(size: 13))
+                                        .foregroundColor(HiTripColor.gray400)
+                                }
+                            }
                         }
 
                         Divider()

--- a/HiTrip/Features/Profile/Views/AppInfoView.swift
+++ b/HiTrip/Features/Profile/Views/AppInfoView.swift
@@ -30,7 +30,7 @@ struct AppInfoView: View {
                     .padding(.bottom, 40)
             }
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .navigationTitle("버전정보")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -54,7 +54,7 @@ struct AppInfoView: View {
 
                 Text("여행 중 안전·관리·콘텐츠 통합 SaaS\n여행사·가이드·여행자를 연결하는\n스마트 여행 플랫폼")
                     .font(.system(size: 15))
-                    .foregroundColor(.white.opacity(0.9))
+                    .foregroundColor(.white.opacity(0.14))
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
 
@@ -63,7 +63,7 @@ struct AppInfoView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 18)
                     .padding(.vertical, 6)
-                    .background(Color.white.opacity(0.25))
+                    .background(Color.white.opacity(0.14))
                     .clipShape(Capsule())
 
                 Spacer().frame(height: 12)
@@ -99,7 +99,7 @@ struct AppInfoView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
         .padding(.horizontal, 20)
     }
 
@@ -140,7 +140,7 @@ struct AppInfoView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
         .padding(.horizontal, 20)
     }
 

--- a/HiTrip/Features/Profile/Views/ProfileEditView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileEditView.swift
@@ -14,7 +14,7 @@ struct ProfileEditView: View {
 
     var body: some View {
         ZStack {
-            HiTripColor.screenBackground
+            Color.white
                 .ignoresSafeArea()
 
             ScrollView {
@@ -46,7 +46,7 @@ struct ProfileEditView: View {
                         .frame(width: 40, height: 40)
                         .background(Color.white)
                         .clipShape(Circle())
-                        .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 4, y: 2)
                 }
             }
         }
@@ -58,7 +58,7 @@ struct ProfileEditView: View {
         VStack(spacing: 8) {
             ZStack {
                 Circle()
-                    .fill(Color(hex: "FADADD").opacity(0.5))
+                    .fill(Color(hex: "FADADD").opacity(0.14))
                     .frame(width: 110, height: 110)
                 Text("🙋‍♀️")
                     .font(.system(size: 56))
@@ -74,7 +74,7 @@ struct ProfileEditView: View {
                 .foregroundColor(HiTripColor.primary800)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
-                .background(HiTripColor.primary800.opacity(0.08))
+                .background(HiTripColor.primary800.opacity(0.14))
                 .cornerRadius(8)
         }
     }
@@ -105,7 +105,7 @@ struct ProfileEditView: View {
         }
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
     }
 
     // MARK: - Status Section (결제/서류)
@@ -132,7 +132,7 @@ struct ProfileEditView: View {
         }
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
     }
 
     // MARK: - Components
@@ -146,7 +146,7 @@ struct ProfileEditView: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
-        .background(HiTripColor.gray100.opacity(0.5))
+        .background(HiTripColor.gray100.opacity(0.14))
     }
 
     private func infoRow(icon: String, label: String, value: String) -> some View {
@@ -186,10 +186,10 @@ struct ProfileEditView: View {
             HStack(spacing: 4) {
                 Image(systemName: isVerified ? "checkmark.circle.fill" : "xmark.circle.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(isVerified ? .green : .red.opacity(0.6))
+                    .foregroundColor(isVerified ? .green : .red.opacity(0.14))
                 Text(isVerified ? "확인됨" : "미확인")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(isVerified ? .green : .red.opacity(0.6))
+                    .foregroundColor(isVerified ? .green : .red.opacity(0.14))
             }
         }
         .padding(.horizontal, 20)

--- a/HiTrip/Features/Profile/Views/ProfileView.swift
+++ b/HiTrip/Features/Profile/Views/ProfileView.swift
@@ -28,7 +28,7 @@ struct ProfileView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                HiTripColor.screenBackground
+                Color.white
                     .ignoresSafeArea()
 
                 ScrollView {
@@ -66,7 +66,7 @@ struct ProfileView: View {
                             .frame(width: 40, height: 40)
                             .background(Color.white)
                             .clipShape(Circle())
-                            .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 4, y: 2)
                     }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -77,7 +77,7 @@ struct ProfileView: View {
                             .frame(width: 40, height: 40)
                             .background(Color.white)
                             .clipShape(Circle())
-                            .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 4, y: 2)
                     }
                 }
             }
@@ -110,7 +110,7 @@ struct ProfileView: View {
             // 아바타 (분홍 원형 배경 + 이모지)
             ZStack {
                 Circle()
-                    .fill(Color(hex: "FADADD").opacity(0.5))
+                    .fill(Color(hex: "FADADD").opacity(0.14))
                     .frame(width: 110, height: 110)
 
                 Text("🙋‍♀️")
@@ -142,7 +142,7 @@ struct ProfileView: View {
             statItem(
                 title: "여권",
                 value: viewModel.passportVerified ? "확인" : "미확인",
-                color: viewModel.passportVerified ? .green : .orange
+                color: viewModel.passportVerified ? .green : HiTripColor.gray400
             )
 
             Divider()
@@ -151,13 +151,13 @@ struct ProfileView: View {
             statItem(
                 title: "예약",
                 value: viewModel.bookingVerified ? "확인" : "미확인",
-                color: viewModel.bookingVerified ? .green : .orange
+                color: viewModel.bookingVerified ? .green : HiTripColor.gray400
             )
         }
         .padding(.vertical, 18)
         .background(Color.white)
         .cornerRadius(14)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
     }
 
     private func statItem(title: String, value: String, color: Color = HiTripColor.primary800) -> some View {
@@ -201,7 +201,7 @@ struct ProfileView: View {
         }
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
         .padding(.horizontal, 24)
     }
 

--- a/HiTrip/Features/Schedule/Models/PersonalTodo.swift
+++ b/HiTrip/Features/Schedule/Models/PersonalTodo.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+// MARK: - PersonalTodo
+/// 여행객이 직접 추가하는 개인 할일 (SwiftData — 로컬 저장)
+///
+/// 가이드가 관리하는 TripTodo와 별도로 존재.
+/// tripServerId: 어느 여행 패키지에 속하는지 구분 (서버 tripId)
+
+@Model
+final class PersonalTodo {
+
+    var id: UUID
+    var title: String
+    var isCompleted: Bool
+    var createdAt: Date
+    var tripId: UUID             // TripPackage.id 기준
+
+    init(title: String, tripId: UUID) {
+        self.id = UUID()
+        self.title = title
+        self.isCompleted = false
+        self.createdAt = Date()
+        self.tripId = tripId
+    }
+}

--- a/HiTrip/Features/Schedule/Models/TripDataStore.swift
+++ b/HiTrip/Features/Schedule/Models/TripDataStore.swift
@@ -92,7 +92,9 @@ final class TripDataStore: ObservableObject {
             .subscribe(
                 onSuccess: { [weak self] dto in
                     guard let self else { return }
-                    self.currentPackage = dto.toTripPackage()
+                    var pkg = dto.toTripPackage()
+                    pkg.translations = Self.defaultTranslations
+                    self.currentPackage = pkg
                     self.trips = [dto.toTrip()]
                     self.isLoading = false
                     self.isDataLoaded = true
@@ -305,4 +307,15 @@ final class TripDataStore: ObservableObject {
     var pendingTodos: [TripTodo] { todos.filter { !$0.isCompleted } }
     var completedTodos: [TripTodo] { todos.filter { $0.isCompleted } }
 
+    // MARK: - 기본 번역 문장
+
+    static let defaultTranslations: [TripTranslation] = [
+        TripTranslation(original: "화장실 어디예요?",    translated: "Where is the restroom?",       category: "기본"),
+        TripTranslation(original: "얼마예요?",          translated: "How much is it?",              category: "쇼핑"),
+        TripTranslation(original: "이것 주세요.",        translated: "I'll take this, please.",      category: "식당"),
+        TripTranslation(original: "영어 하세요?",        translated: "Do you speak English?",        category: "기본"),
+        TripTranslation(original: "천천히 말해주세요.",   translated: "Please speak slowly.",         category: "기본"),
+        TripTranslation(original: "길을 잃었어요.",       translated: "I'm lost.",                    category: "교통"),
+        TripTranslation(original: "병원에 데려다 주세요.", translated: "Please take me to a hospital.", category: "긴급"),
+    ]
 }

--- a/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
@@ -14,7 +14,6 @@ final class TripDetailViewModel: ObservableObject {
 
     enum DetailTab: String, CaseIterable {
         case mySchedule = "내 일정"
-        case calendar   = "캘린더"
         case todo       = "할 일"
     }
 
@@ -35,8 +34,24 @@ final class TripDetailViewModel: ObservableObject {
 
     init(trip: Trip) {
         self.trip = trip
-        self.selectedDate = trip.date
-        self.displayedMonth = trip.date
+        let today = Calendar.current.startOfDay(for: Date())
+        let pkg = TripDataStore.shared.currentPackage
+        let initialDate: Date
+        if let pkg {
+            let start = Calendar.current.startOfDay(for: pkg.startDate)
+            let end   = Calendar.current.startOfDay(for: pkg.endDate)
+            if today >= start && today <= end {
+                initialDate = today
+            } else if today < start {
+                initialDate = start
+            } else {
+                initialDate = end
+            }
+        } else {
+            initialDate = today
+        }
+        self.selectedDate   = initialDate
+        self.displayedMonth = initialDate
 
         // Store의 변경을 감지하여 View 갱신
         store.objectWillChange

--- a/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripDetailViewModel.swift
@@ -14,7 +14,8 @@ final class TripDetailViewModel: ObservableObject {
 
     enum DetailTab: String, CaseIterable {
         case mySchedule = "내 일정"
-        case todo = "할 일"
+        case calendar   = "캘린더"
+        case todo       = "할 일"
     }
 
     // MARK: - Store Reference

--- a/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripListViewModel.swift
@@ -133,6 +133,26 @@ final class TripListViewModel: ObservableObject {
         store.officialSchedulesByDay()
     }
 
+    /// 정렬된 일차 목록
+    var sortedDayNumbers: [Int] {
+        Array(schedulesByDay.keys).sorted()
+    }
+
+    /// 총 여행 일수
+    var totalDays: Int {
+        store.currentPackage?.totalDays ?? 1
+    }
+
+    /// 여행 시작일
+    var tripStartDate: Date {
+        store.currentPackage?.startDate ?? Date()
+    }
+
+    /// 특정 일차의 날짜 반환
+    func date(forDay day: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: day - 1, to: tripStartDate) ?? tripStartDate
+    }
+
     // MARK: - 지금 갈만한 곳 (서버 스팟 DTO 직접 노출)
 
     /// 추천 + 인기 스팟 합산 (displayOrder 기준 정렬)

--- a/HiTrip/Features/Schedule/Views/AllTripsView.swift
+++ b/HiTrip/Features/Schedule/Views/AllTripsView.swift
@@ -27,7 +27,7 @@ struct AllTripsView: View {
 
     var body: some View {
         ZStack {
-            HiTripColor.screenBackground
+            Color.white
                 .ignoresSafeArea()
 
             ScrollView {
@@ -159,7 +159,7 @@ struct AllTripsView: View {
         .padding(14)
         .background(Color.white)
         .cornerRadius(14)
-        .shadow(color: .black.opacity(0.04), radius: 6, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 6, y: 2)
     }
 
     // MARK: - Helpers

--- a/HiTrip/Features/Schedule/Views/LocalLanguageView.swift
+++ b/HiTrip/Features/Schedule/Views/LocalLanguageView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+import AVFoundation
+
+// MARK: - LocalLanguageView
+/// 현지 언어 쓰기 화면
+///
+/// 여행 목적지 언어로 된 필수 회화 문장과 발음 가이드를 제공.
+/// 데이터: 서버 연동 전 Mock 데이터 사용
+
+struct LocalLanguageView: View {
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var speechSynthesizer = SpeechSynthesizerService()
+
+    // Mock 데이터 — 서버 연동 시 ViewModel + Repository로 교체
+    private let phrases: [LocalPhrase] = LocalPhrase.mockData
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(phrases) { phrase in
+                    phraseRow(phrase)
+                    Divider()
+                }
+            }
+            .background(Color.white)
+        }
+        .background(Color.white)
+        .navigationTitle("현지 언어 쓰기")
+        .navigationBarTitleDisplayMode(.large)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button { dismiss() } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(HiTripColor.textBlack)
+                }
+            }
+        }
+    }
+
+    // MARK: - 문장 행
+
+    private func phraseRow(_ phrase: LocalPhrase) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(phrase.korean)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+
+                HStack(spacing: 4) {
+                    Text("발음:")
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.gray500)
+                    Text(phrase.pronunciation)
+                        .font(.system(size: 14))
+                        .foregroundColor(HiTripColor.gray500)
+                }
+            }
+
+            Spacer()
+
+            // 스피커 버튼
+            Button {
+                speechSynthesizer.speak(phrase.local, language: phrase.languageCode)
+            } label: {
+                Image(systemName: "speaker.wave.2.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.white)
+                    .frame(width: 36, height: 36)
+                    .background(HiTripColor.primary800)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 18)
+    }
+}
+
+// MARK: - LocalPhrase Model
+
+struct LocalPhrase: Identifiable {
+    let id = UUID()
+    let korean: String        // 한국어 표시 문장
+    let local: String         // 현지 언어 문장 (TTS용)
+    let pronunciation: String // 한글 발음 표기
+    let languageCode: String  // BCP-47 언어 코드
+
+    static let mockData: [LocalPhrase] = [
+        LocalPhrase(korean: "안녕하세요. 커피 하나 부탁드려요.",
+                    local: "こんにちは、コーヒーを一つお願いします。",
+                    pronunciation: "곤니찌와, 코히 히토츠 오네가이시마스",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "안녕하세요. 메뉴판 부탁드립니다.",
+                    local: "こんにちは、メニューをお願いします。",
+                    pronunciation: "곤니찌와, 메-뉴오 오네가이시마스",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "계산 부탁드립니다.",
+                    local: "お会計をお願いします。",
+                    pronunciation: "오칸조오 오네가이시마스",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "이것은 얼마인가요?",
+                    local: "これはいくらですか？",
+                    pronunciation: "코레와 이쿠라데스카",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "화장실이 어디에 있나요?",
+                    local: "トイレはどこですか？",
+                    pronunciation: "토이레와 도코데스카",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "사진 찍어도 될까요?",
+                    local: "写真を撮ってもいいですか？",
+                    pronunciation: "샤신오 톳테모 이이데스카",
+                    languageCode: "ja-JP"),
+        LocalPhrase(korean: "영어를 할 수 있으신가요?",
+                    local: "英語を話せますか？",
+                    pronunciation: "에-고오 하나세마스카",
+                    languageCode: "ja-JP"),
+    ]
+}
+
+// MARK: - SpeechSynthesizerService
+
+final class SpeechSynthesizerService: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
+
+    private let synthesizer = AVSpeechSynthesizer()
+
+    override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func speak(_ text: String, language: String) {
+        synthesizer.stopSpeaking(at: .immediate)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: language)
+        utterance.rate = 0.45
+        synthesizer.speak(utterance)
+    }
+}

--- a/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
+++ b/HiTrip/Features/Schedule/Views/MyScheduleListView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 
 // MARK: - MyScheduleListView
 /// "내 일정" 탭 — 선택 날짜의 공식 일정을 개별 카드로 표시
-///
-/// 카드 하나 = 장소 하나 (인천국제공항, 마담란 레스토랑, 대성당 등)
 
 struct MyScheduleListView: View {
 
@@ -20,11 +18,10 @@ struct MyScheduleListView: View {
                         .padding(.top, 16)
                         .padding(.horizontal, 20)
                 }
-
                 Spacer().frame(height: 40)
             }
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
     }
 
     // MARK: - Card List
@@ -39,46 +36,42 @@ struct MyScheduleListView: View {
 
     private func scheduleCard(_ schedule: TripOfficialSchedule) -> some View {
         HStack(spacing: 14) {
-            // 이모지 썸네일
+            // 썸네일 (이모지 배경)
             ZStack {
-                HiTripColor.primary800.opacity(0.08)
-                Text(schedule.emoji ?? "📍")
-                    .font(.system(size: 28))
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(HiTripColor.gray100)
+                Text(schedule.emoji)
+                    .font(.system(size: 32))
             }
-            .frame(width: 68, height: 68)
-            .cornerRadius(14)
+            .frame(width: 80, height: 80)
 
             VStack(alignment: .leading, spacing: 6) {
-                // 시간
-                Text(timeRange(schedule))
-                    .font(.system(size: 12))
-                    .foregroundColor(HiTripColor.gray400)
+                // 날짜
+                HStack(spacing: 4) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 11))
+                        .foregroundColor(HiTripColor.gray400)
+                    Text(dateLabel(schedule.date))
+                        .font(.system(size: 12))
+                        .foregroundColor(HiTripColor.gray400)
+                }
 
-                // 장소명
+                // 장소명 (제목)
                 Text(schedule.placeName ?? schedule.title)
                     .font(.system(size: 16, weight: .bold))
                     .foregroundColor(HiTripColor.textBlack)
                     .lineLimit(1)
 
-                // 주요 내용 또는 이동 수단
+                // 위치 / 내용
                 if let content = schedule.mainContent, !content.isEmpty {
                     HStack(spacing: 4) {
-                        Image(systemName: "location.circle")
-                            .font(.system(size: 12))
+                        Image(systemName: "mappin.circle")
+                            .font(.system(size: 11))
                             .foregroundColor(HiTripColor.gray400)
                         Text(content)
                             .font(.system(size: 13))
                             .foregroundColor(HiTripColor.gray400)
                             .lineLimit(1)
-                    }
-                } else if let transport = schedule.transport {
-                    HStack(spacing: 4) {
-                        Image(systemName: transportIcon(transport))
-                            .font(.system(size: 12))
-                            .foregroundColor(HiTripColor.gray400)
-                        Text(transport)
-                            .font(.system(size: 13))
-                            .foregroundColor(HiTripColor.gray400)
                     }
                 }
             }
@@ -89,9 +82,10 @@ struct MyScheduleListView: View {
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(HiTripColor.gray300)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 14)
-        .hiTripCard()
+        .padding(16)
+        .background(Color.white)
+        .cornerRadius(14)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 10, x: 0, y: 2)
     }
 
     // MARK: - Empty State
@@ -115,20 +109,10 @@ struct MyScheduleListView: View {
 
     // MARK: - Helpers
 
-    private func timeRange(_ schedule: TripOfficialSchedule) -> String {
+    private func dateLabel(_ date: Date) -> String {
         let fmt = DateFormatter()
-        fmt.dateFormat = "HH:mm"
-        return "\(fmt.string(from: schedule.startTime)) ~ \(fmt.string(from: schedule.endTime))"
-    }
-
-    private func transportIcon(_ transport: String) -> String {
-        switch transport {
-        case "도보":    return "figure.walk"
-        case "전용버스": return "bus"
-        case "자가용":  return "car"
-        case "택시":    return "car.side"
-        case "공항버스": return "airplane"
-        default:       return "arrow.right"
-        }
+        fmt.locale = Locale(identifier: "ko_KR")
+        fmt.dateFormat = "yyyy년 M월 d일"
+        return fmt.string(from: date)
     }
 }

--- a/HiTrip/Features/Schedule/Views/NoticeListView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticeListView.swift
@@ -40,7 +40,7 @@ struct NoticeListView: View {
             .padding(.horizontal, 20)
             .padding(.top, 16)
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .navigationTitle("공지사항")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)

--- a/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
@@ -29,24 +29,41 @@ struct ScheduleTabView: View {
     // MARK: - Empty State
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 0) {
+            // 상단 헤더 (TripDetailView와 동일한 높이 영역)
+            HStack {
+                Text("내 여행 일정")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(HiTripColor.textBlack)
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 24)
+
+            Divider()
+
             Spacer()
 
-            Image(systemName: "calendar.badge.plus")
-                .font(.system(size: 48))
-                .foregroundColor(HiTripColor.gray300)
+            VStack(spacing: 12) {
+                Image(systemName: "calendar.badge.clock")
+                    .font(.system(size: 44))
+                    .foregroundColor(HiTripColor.gray300)
 
-            Text("등록된 일정이 없습니다")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(HiTripColor.textBlack)
+                Text("등록된 일정이 없습니다")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(HiTripColor.textBlack)
 
-            Text("여행 일정을 추가해보세요!")
-                .font(.system(size: 14))
-                .foregroundColor(HiTripColor.gray500)
+                Text("여행사에서 일정을 등록하면\n여기에 표시됩니다")
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray400)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+            }
 
             Spacer()
         }
-        .navigationTitle("일정")
-        .navigationBarTitleDisplayMode(.inline)
+        .background(HiTripColor.screenBackground)
+        .navigationBarHidden(true)
     }
 }

--- a/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
+++ b/HiTrip/Features/Schedule/Views/ScheduleTabView.swift
@@ -63,7 +63,7 @@ struct ScheduleTabView: View {
 
             Spacer()
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .navigationBarHidden(true)
     }
 }

--- a/HiTrip/Features/Schedule/Views/TodayScheduleView.swift
+++ b/HiTrip/Features/Schedule/Views/TodayScheduleView.swift
@@ -1,46 +1,47 @@
 import SwiftUI
 
-// MARK: - TodayScheduleView
-/// 오늘의 일정 전체 보기 화면
-///
-/// 여행사가 그룹에 등록한 공식 일정(TripOfficialSchedule)을
-/// 타임라인 형태로 표시한다.
-///
-/// 홈 화면 "오늘의 일정" → "전체 보기 >" 탭 시 이동.
-///
-/// 디자인:
-/// - 타임라인 형태: 시간순 정렬
-/// - 각 일정: 이모지 + 제목 + 시간 + 연결선
-
 struct TodayScheduleView: View {
 
     @ObservedObject var viewModel: TripListViewModel
     @Environment(\.dismiss) private var dismiss
 
-    var body: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                if viewModel.todaySchedules.isEmpty {
-                    emptyState
-                        .padding(.top, 80)
-                } else {
-                    timelineList
-                        .padding(.top, 20)
-                }
+    @State private var selectedDay: Int
 
-                Spacer().frame(height: 40)
+    init(viewModel: TripListViewModel) {
+        self.viewModel = viewModel
+        _selectedDay = State(initialValue: viewModel.currentDayNumber)
+    }
+
+    private var schedules: [TripOfficialSchedule] {
+        (viewModel.schedulesByDay[selectedDay] ?? [])
+            .sorted { $0.startTime < $1.startTime }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            dayTabStrip
+            Divider()
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    if schedules.isEmpty {
+                        emptyState.padding(.top, 80)
+                    } else {
+                        timelineList.padding(.top, 24)
+                    }
+                    Spacer().frame(height: 40)
+                }
+                .padding(.horizontal, 20)
             }
-            .padding(.horizontal, 20)
+            .background(Color.white)
         }
-        .background(HiTripColor.screenBackground)
-        .navigationTitle("오늘의 일정")
+        .background(Color.white)
+        .navigationTitle("여행 일정")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
+                Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundColor(HiTripColor.textBlack)
@@ -49,94 +50,160 @@ struct TodayScheduleView: View {
         }
     }
 
-    // MARK: - Timeline List
+    // MARK: - Day Tab Strip
 
-    private var timelineList: some View {
-        VStack(spacing: 0) {
-            ForEach(Array(viewModel.todaySchedules.enumerated()), id: \.element.id) { index, schedule in
-                timelineRow(schedule, isLast: index == viewModel.todaySchedules.count - 1)
+    private var dayTabStrip: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Array(1...max(1, viewModel.totalDays)), id: \.self) { day in
+                        dayTab(day: day, proxy: proxy)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+            }
+            .onAppear {
+                proxy.scrollTo(selectedDay, anchor: .center)
             }
         }
     }
 
-    // MARK: - Timeline Row
+    private func dayTab(day: Int, proxy: ScrollViewProxy) -> some View {
+        let isSelected = selectedDay == day
+        let isToday = day == viewModel.currentDayNumber
+        let date = viewModel.date(forDay: day)
+        let dateStr = shortDate(date)
 
-    private func timelineRow(_ schedule: TripOfficialSchedule, isLast: Bool) -> some View {
-        HStack(alignment: .top, spacing: 16) {
-            // 왼쪽: 타임라인 도트 + 연결선
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selectedDay = day
+                proxy.scrollTo(day, anchor: .center)
+            }
+        } label: {
+            VStack(spacing: 2) {
+                HStack(spacing: 4) {
+                    Text("\(day)일차")
+                        .font(.system(size: 14, weight: isSelected ? .bold : .medium))
+                    if isToday {
+                        Text("오늘")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(HiTripColor.primary800)
+                            .cornerRadius(6)
+                    }
+                }
+                Text(dateStr)
+                    .font(.system(size: 11))
+                    .foregroundColor(isSelected ? HiTripColor.primary800 : HiTripColor.gray400)
+            }
+            .foregroundColor(isSelected ? HiTripColor.textBlack : HiTripColor.gray400)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(isSelected ? HiTripColor.primary800.opacity(0.08) : Color.clear)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? HiTripColor.primary800 : Color.clear, lineWidth: 1.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .id(day)
+    }
+
+    // MARK: - Timeline List
+
+    private var timelineList: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(schedules.enumerated()), id: \.element.id) { index, schedule in
+                timelineRow(schedule, index: index, isLast: index == schedules.count - 1)
+            }
+        }
+    }
+
+    private func timelineRow(_ schedule: TripOfficialSchedule, index: Int, isLast: Bool) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+
+            // 타임라인 세로선 + 도트
             VStack(spacing: 0) {
-                // 도트
                 Circle()
                     .fill(HiTripColor.primary800)
-                    .frame(width: 12, height: 12)
+                    .frame(width: 10, height: 10)
+                    .padding(.top, 14)
 
-                // 연결선
                 if !isLast {
                     Rectangle()
                         .fill(HiTripColor.gray200)
                         .frame(width: 2)
-                        .frame(minHeight: 60)
+                        .frame(minHeight: 50)
                 }
             }
+            .frame(width: 10)
 
-            // 오른쪽: 일정 카드
-            VStack(alignment: .leading, spacing: 8) {
-                // 시간 + 소요시간
-                HStack {
+            // 카드
+            VStack(alignment: .leading, spacing: 10) {
+
+                // 시간 행
+                HStack(spacing: 6) {
                     Text(schedule.timeText)
-                        .font(.system(size: 13))
-                        .foregroundColor(HiTripColor.gray500)
-
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(HiTripColor.primary800)
                     if let dur = schedule.durationDisplay {
-                        Text("(\(dur))")
+                        Text("·")
+                            .foregroundColor(HiTripColor.gray300)
+                        Text(dur)
                             .font(.system(size: 12))
                             .foregroundColor(HiTripColor.gray400)
                     }
                 }
 
-                // 이모지 + 제목
-                HStack(spacing: 8) {
+                // 이모지 + 장소명
+                HStack(alignment: .center, spacing: 10) {
                     Text(schedule.emoji)
-                        .font(.system(size: 24))
+                        .font(.system(size: 28))
+                        .frame(width: 40, height: 40)
+                        .background(HiTripColor.gray100)
+                        .cornerRadius(10)
 
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: 3) {
                         Text(schedule.placeName ?? schedule.title)
-                            .font(.system(size: 17, weight: .bold))
+                            .font(.system(size: 16, weight: .bold))
                             .foregroundColor(HiTripColor.textBlack)
 
-                        if let content = schedule.mainContent, !content.isEmpty,
-                           schedule.placeName != nil {
+                        if let content = schedule.mainContent, !content.isEmpty, schedule.placeName != nil {
                             Text(content)
                                 .font(.system(size: 13))
                                 .foregroundColor(HiTripColor.gray500)
+                                .lineLimit(2)
                         }
                     }
                 }
 
-                // 상세 정보 (집합장소, 이동수단)
+                // 이동수단/집합 뱃지
                 if let detail = schedule.detailText {
                     HStack(spacing: 4) {
-                        Image(systemName: "info.circle")
+                        Image(systemName: "info.circle.fill")
                             .font(.system(size: 11))
-                            .foregroundColor(HiTripColor.primary800.opacity(0.7))
+                            .foregroundColor(HiTripColor.primary800.opacity(0.6))
                         Text(detail)
                             .font(.system(size: 12))
-                            .foregroundColor(HiTripColor.primary800.opacity(0.8))
+                            .foregroundColor(HiTripColor.primary800)
                     }
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
-                    .background(HiTripColor.primary800.opacity(0.06))
+                    .background(HiTripColor.primary800.opacity(0.07))
                     .cornerRadius(8)
                 }
             }
-            .padding(.vertical, 12)
+            .padding(.vertical, 14)
             .padding(.horizontal, 16)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.white)
             .cornerRadius(16)
-            .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
-
-            Spacer()
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 12, x: 0, y: 4)
+            .padding(.bottom, isLast ? 0 : 12)
         }
     }
 
@@ -147,14 +214,24 @@ struct TodayScheduleView: View {
             Image(systemName: "calendar.badge.clock")
                 .font(.system(size: 40))
                 .foregroundColor(HiTripColor.gray300)
-
-            Text("오늘 등록된 일정이 없습니다")
+            Text("\(selectedDay)일차 일정이 없습니다")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(HiTripColor.textBlack)
-
             Text("여행사에서 일정을 등록하면 여기에 표시됩니다")
                 .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
+                .multilineTextAlignment(.center)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 32)
+    }
+
+    // MARK: - Helpers
+
+    private func shortDate(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "ko_KR")
+        fmt.dateFormat = "M/d (E)"
+        return fmt.string(from: date)
     }
 }

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -36,7 +36,7 @@ struct TripDetailView: View {
             // 탭 콘텐츠
             tabContent
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .onAppear { viewModel.selectedTab = initialTab }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -60,7 +60,7 @@ struct TripDetailView: View {
         .padding(16)
         .background(Color.white)
         .cornerRadius(16)
-        .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 12, x: 0, y: 4)
     }
 
     // MARK: - Tab Selector
@@ -102,8 +102,6 @@ struct TripDetailView: View {
         switch viewModel.selectedTab {
         case .mySchedule:
             MyScheduleListView(viewModel: viewModel)
-        case .calendar:
-            TripCalendarView(viewModel: viewModel)
         case .todo:
             TripTodoView(viewModel: viewModel)
         }

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -102,6 +102,8 @@ struct TripDetailView: View {
         switch viewModel.selectedTab {
         case .mySchedule:
             MyScheduleListView(viewModel: viewModel)
+        case .calendar:
+            TripCalendarView(viewModel: viewModel)
         case .todo:
             TripTodoView(viewModel: viewModel)
         }

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -54,7 +54,7 @@ struct TripListView: View {
 
                     // 내일의 일정 (있을 때만 표시)
                     if !viewModel.tomorrowSchedules.isEmpty {
-                        tomorrowScheduleSection
+
                     }
 
                     // 지금 갈만한 곳
@@ -70,7 +70,7 @@ struct TripListView: View {
                 }
                 .padding(.horizontal, 20)
             }
-            .background(HiTripColor.screenBackground)
+            .background(Color.white)
             .navigationDestination(isPresented: $showEmergency) {
                 EmergencyView(viewModel: AppDIContainer.shared.makeEmergencyViewModel())
             }
@@ -142,45 +142,38 @@ struct TripListView: View {
                         .foregroundColor(.white)
                     Text("여행사에서 일정을 등록하면 여기에 표시됩니다")
                         .font(.system(size: 12))
-                        .foregroundColor(.white.opacity(0.75))
+                        .foregroundColor(.white.opacity(0.14))
                 }
                 Spacer()
             }
             .padding(20)
-            .background(
-                LinearGradient(
-                    colors: [HiTripColor.primary800, HiTripColor.secondary600],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
+            .background(HiTripColor.primary800)
             .cornerRadius(16)
         } else {
             // 여행 데이터 있음
-            HStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 16) {
+
+                // 버스 이모지
+                Text("🚌")
+                    .font(.system(size: 44))
+
+                // 중앙: 진행률 레이블 + 바 + 완료 텍스트
                 VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 10) {
-                        Text("🚌")
-                            .font(.system(size: 36))
+                    Text(viewModel.daysRemainingText)
+                        .font(.system(size: 13))
+                        .foregroundColor(.white.opacity(0.75))
 
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(viewModel.daysRemainingText)
-                                .font(.system(size: 13))
-                                .foregroundColor(.white.opacity(0.85))
-
-                            GeometryReader { geo in
-                                ZStack(alignment: .leading) {
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .fill(Color.white.opacity(0.3))
-                                        .frame(height: 6)
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .fill(Color.white)
-                                        .frame(width: geo.size.width * viewModel.progressRate, height: 6)
-                                }
-                            }
-                            .frame(height: 6)
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.white.opacity(0.25))
+                                .frame(height: 6)
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.white)
+                                .frame(width: geo.size.width * viewModel.progressRate, height: 6)
                         }
                     }
+                    .frame(height: 6)
 
                     Text(viewModel.progressText)
                         .font(.system(size: 22, weight: .bold))
@@ -189,33 +182,19 @@ struct TripListView: View {
 
                 Spacer()
 
-                VStack(alignment: .trailing, spacing: 6) {
-                    if !viewModel.weatherLocation.isEmpty {
-                        Text(viewModel.weatherLocation)
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(.white)
-                    }
-                    if !viewModel.weatherDescription.isEmpty {
-                        Text(viewModel.weatherDescription)
-                            .font(.system(size: 13))
-                            .foregroundColor(.white.opacity(0.85))
-                    }
-                    if !viewModel.participantsText.isEmpty {
-                        Spacer().frame(height: 4)
+                // 우측: 참여자
+                if !viewModel.participantsText.isEmpty {
+                    VStack {
+                        Spacer()
                         Text(viewModel.participantsText)
-                            .font(.system(size: 12))
-                            .foregroundColor(.white.opacity(0.8))
+                            .font(.system(size: 13))
+                            .foregroundColor(.white.opacity(0.80))
                     }
                 }
             }
-            .padding(20)
-            .background(
-                LinearGradient(
-                    colors: [HiTripColor.primary800, HiTripColor.secondary600],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
+            .padding(.horizontal, 20)
+            .padding(.vertical, 18)
+            .background(HiTripColor.primary800)
             .cornerRadius(16)
         }
     }
@@ -322,18 +301,7 @@ struct TripListView: View {
                     }
                 }
 
-                // 3개 초과 시 나머지 개수 표시
-                if viewModel.todaySchedules.count > 3 {
-                    Button {
-                        showTodaySchedule = true
-                    } label: {
-                        Text("+ \(viewModel.todaySchedules.count - 3)개 더 보기")
-                            .font(.system(size: 13))
-                            .foregroundColor(HiTripColor.accentLink)
-                            .padding(.vertical, 10)
-                    }
-                    .frame(maxWidth: .infinity)
-                }
+
             }
         }
         .padding(.horizontal, 4)
@@ -385,7 +353,7 @@ struct TripListView: View {
             .padding(.vertical, 4)
             .background(Color.white)
             .cornerRadius(16)
-            .shadow(color: Color(hex: "B4BCC9").opacity(0.12), radius: 12, x: 0, y: 4)
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 12, x: 0, y: 4)
         }
         .padding(.horizontal, 4)
         .padding(.top, 8)

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -27,6 +27,9 @@ struct TripListView: View {
     /// 오늘의 일정 전체 보기 이동
     @State private var showTodaySchedule: Bool = false
 
+    /// 현지 언어 쓰기 이동
+    @State private var showLocalLanguage: Bool = false
+
     /// 선택된 스팟 상세보기
     @State private var selectedSpot: TravelerSpotDTO?
 
@@ -70,6 +73,9 @@ struct TripListView: View {
             .background(HiTripColor.screenBackground)
             .navigationDestination(isPresented: $showEmergency) {
                 EmergencyView(viewModel: AppDIContainer.shared.makeEmergencyViewModel())
+            }
+            .navigationDestination(isPresented: $showLocalLanguage) {
+                LocalLanguageView()
             }
             .navigationDestination(isPresented: $showNoticeList) {
                 NoticeListView(viewModel: viewModel)
@@ -463,6 +469,7 @@ struct TripListView: View {
                 .foregroundColor(HiTripColor.gray300)
         }
         .hiTripCard(padding: 16)
+        .onTapGesture { showLocalLanguage = true }
     }
 
     // MARK: - Emergency Banner

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -108,9 +108,14 @@ struct TripListView: View {
 
     // MARK: - Trip Day Pill
 
-    /// "제주 힐링여행 · 2일차" 알약 배지
+    /// "제주 힐링여행 · 2일차" 알약 배지 — 여행 없으면 숨김
+    @ViewBuilder
     private var tripDayPill: some View {
-        Text("\(viewModel.currentTripName) · \(viewModel.currentDayText)")
+        let label = viewModel.currentDayText.isEmpty
+            ? viewModel.currentTripName
+            : "\(viewModel.currentTripName) · \(viewModel.currentDayText)"
+
+        Text(label)
             .font(.system(size: 13, weight: .medium))
             .foregroundColor(HiTripColor.accentLink)
             .padding(.horizontal, 12)
@@ -123,70 +128,96 @@ struct TripListView: View {
 
     // MARK: - Progress Card
 
-    /// 여행 진행률 카드 (파란 배경)
+    /// 여행 진행률 카드 — 여행 없으면 대기 상태 표시
+    @ViewBuilder
     private var progressCard: some View {
-        HStack(spacing: 0) {
-            // 왼쪽: 버스 아이콘 + 진행률
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 10) {
-                    // 버스 이모지
-                    Text("🚌")
-                        .font(.system(size: 36))
+        if viewModel.currentDayText.isEmpty {
+            // 여행 데이터 없음
+            HStack(spacing: 14) {
+                Text("🚌")
+                    .font(.system(size: 36))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("여행을 기다리는 중...")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(.white)
+                    Text("여행사에서 일정을 등록하면 여기에 표시됩니다")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(0.75))
+                }
+                Spacer()
+            }
+            .padding(20)
+            .background(
+                LinearGradient(
+                    colors: [HiTripColor.primary800, HiTripColor.secondary600],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .cornerRadius(16)
+        } else {
+            // 여행 데이터 있음
+            HStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 10) {
+                        Text("🚌")
+                            .font(.system(size: 36))
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(viewModel.daysRemainingText)
-                            .font(.system(size: 13))
-                            .foregroundColor(.white.opacity(0.85))
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(viewModel.daysRemainingText)
+                                .font(.system(size: 13))
+                                .foregroundColor(.white.opacity(0.85))
 
-                        // 프로그레스 바
-                        GeometryReader { geo in
-                            ZStack(alignment: .leading) {
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(Color.white.opacity(0.3))
-                                    .frame(height: 6)
-
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(Color.white)
-                                    .frame(width: geo.size.width * viewModel.progressRate, height: 6)
+                            GeometryReader { geo in
+                                ZStack(alignment: .leading) {
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Color.white.opacity(0.3))
+                                        .frame(height: 6)
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Color.white)
+                                        .frame(width: geo.size.width * viewModel.progressRate, height: 6)
+                                }
                             }
+                            .frame(height: 6)
                         }
-                        .frame(height: 6)
                     }
+
+                    Text(viewModel.progressText)
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundColor(.white)
                 }
 
-                Text(viewModel.progressText)
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundColor(.white)
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 6) {
+                    if !viewModel.weatherLocation.isEmpty {
+                        Text(viewModel.weatherLocation)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.white)
+                    }
+                    if !viewModel.weatherDescription.isEmpty {
+                        Text(viewModel.weatherDescription)
+                            .font(.system(size: 13))
+                            .foregroundColor(.white.opacity(0.85))
+                    }
+                    if !viewModel.participantsText.isEmpty {
+                        Spacer().frame(height: 4)
+                        Text(viewModel.participantsText)
+                            .font(.system(size: 12))
+                            .foregroundColor(.white.opacity(0.8))
+                    }
+                }
             }
-
-            Spacer()
-
-            // 오른쪽: 날씨 + 참여자
-            VStack(alignment: .trailing, spacing: 6) {
-                Text(viewModel.weatherLocation)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
-
-                Text(viewModel.weatherDescription)
-                    .font(.system(size: 13))
-                    .foregroundColor(.white.opacity(0.85))
-
-                Spacer().frame(height: 4)
-
-                Text(viewModel.participantsText)
-                    .font(.system(size: 12))
-                    .foregroundColor(.white.opacity(0.8))
-            }
-        }
-        .padding(20)
-        .background(
-            LinearGradient(
-                colors: [HiTripColor.primary800, HiTripColor.secondary600],
-                startPoint: .leading,
-                endPoint: .trailing
+            .padding(20)
+            .background(
+                LinearGradient(
+                    colors: [HiTripColor.primary800, HiTripColor.secondary600],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
             )
-        )
-        .cornerRadius(16)
+            .cornerRadius(16)
+        }
     }
 
     // MARK: - Notice Card
@@ -373,10 +404,19 @@ struct TripListView: View {
             }
 
             if viewModel.nearbySpotDTOs.isEmpty {
-                Text("등록된 추천 장소가 없습니다.")
-                    .font(.system(size: 14))
-                    .foregroundColor(HiTripColor.gray400)
-                    .padding(.vertical, 8)
+                HStack {
+                    Spacer()
+                    VStack(spacing: 8) {
+                        Image(systemName: "mappin.slash")
+                            .font(.system(size: 28))
+                            .foregroundColor(HiTripColor.gray300)
+                        Text("등록된 추천 장소가 없습니다")
+                            .font(.system(size: 13))
+                            .foregroundColor(HiTripColor.gray400)
+                    }
+                    .padding(.vertical, 20)
+                    Spacer()
+                }
             } else {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 12) {

--- a/HiTrip/Features/Schedule/Views/TripTodoView.swift
+++ b/HiTrip/Features/Schedule/Views/TripTodoView.swift
@@ -1,20 +1,35 @@
 import SwiftUI
+import SwiftData
 
 // MARK: - TripTodoView
-/// 할 일 탭 — 서버 체크리스트 표시
+/// 할 일 탭
 ///
-/// 데이터: GET /api/traveler/checklists/ (여행사 설정, 읽기 전용)
-/// 허용 동작: 토글(체크/해제) → PATCH /api/traveler/checklists/{id}/
-/// 불가 동작: 추가/수정/삭제 (여행사 전용 권한)
+/// 두 가지 할일을 함께 표시:
+/// - 가이드 체크리스트: 서버에서 내려옴, 토글만 가능
+/// - 내 할일: SwiftData 로컬 저장, 직접 추가/완료/삭제 가능
 
 struct TripTodoView: View {
 
     @ObservedObject var viewModel: TripDetailViewModel
 
+    // SwiftData — 현재 여행의 개인 할일만 쿼리
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \PersonalTodo.createdAt) private var allPersonalTodos: [PersonalTodo]
+
+    // 현재 여행 ID 기준 필터
+    private var personalTodos: [PersonalTodo] {
+        guard let tripId = TripDataStore.shared.currentPackage?.id else { return [] }
+        return allPersonalTodos.filter { $0.tripId == tripId }
+    }
+
+    @State private var newTodoText = ""
+    @State private var isAddingTodo = false
+    @FocusState private var isTextFieldFocused: Bool
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                if viewModel.allTodos.isEmpty {
+                if viewModel.allTodos.isEmpty && personalTodos.isEmpty {
                     emptyState
                         .padding(.top, 60)
                 } else {
@@ -22,54 +37,108 @@ struct TripTodoView: View {
                         .padding(.top, 20)
                         .padding(.horizontal, 20)
                 }
-
                 Spacer().frame(height: 40)
             }
         }
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
     }
 
-    // MARK: - 체크리스트 콘텐츠
+    // MARK: - 전체 콘텐츠
 
     private var checklistContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // 진행 현황 요약 카드
+        VStack(alignment: .leading, spacing: 16) {
+
+            // 진행 현황 카드
             progressSummary
-                .padding(.bottom, 20)
 
-            // 카테고리 칩
-            categoryChip
-                .padding(.bottom, 12)
+            // ── 가이드 체크리스트 섹션 ──
+            if !viewModel.allTodos.isEmpty {
+                sectionHeader(title: "✈️ 가이드 체크리스트", isGuide: true)
 
-            // 플레이스홀더 행 (비활성)
-            placeholderRow
-                .padding(.bottom, 4)
-
-            // 전체 체크리스트 (미완료 → 완료 순)
-            VStack(spacing: 0) {
-                ForEach(viewModel.pendingTodos) { todo in
-                    todoRow(todo)
-                    Divider().padding(.leading, 40)
+                VStack(spacing: 0) {
+                    ForEach(viewModel.pendingTodos) { todo in
+                        guideTodoRow(todo)
+                        Divider().padding(.leading, 52)
+                    }
+                    ForEach(viewModel.completedTodos) { todo in
+                        guideTodoRow(todo)
+                        if todo.id != viewModel.completedTodos.last?.id {
+                            Divider().padding(.leading, 52)
+                        }
+                    }
                 }
-                ForEach(viewModel.completedTodos) { todo in
-                    todoRow(todo)
-                    Divider().padding(.leading, 40)
+                .background(Color.white)
+                .cornerRadius(14)
+                .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 10, x: 0, y: 2)
+            }
+
+            // ── 내 할일 섹션 ──
+            sectionHeader(title: "📝 내 할일", isGuide: false)
+
+            VStack(spacing: 0) {
+                // 추가 입력 행
+                addRow
+
+                let pending   = personalTodos.filter { !$0.isCompleted }
+                let completed = personalTodos.filter {  $0.isCompleted }
+
+                if !pending.isEmpty {
+                    Divider().padding(.leading, 52)
+                    ForEach(pending) { todo in
+                        personalTodoRow(todo)
+                        if todo.id != pending.last?.id {
+                            Divider().padding(.leading, 52)
+                        }
+                    }
+                }
+                if !completed.isEmpty {
+                    Divider().padding(.leading, 52)
+                    ForEach(completed) { todo in
+                        personalTodoRow(todo)
+                        if todo.id != completed.last?.id {
+                            Divider().padding(.leading, 52)
+                        }
+                    }
                 }
             }
             .background(Color.white)
             .cornerRadius(14)
-            .shadow(color: Color.black.opacity(0.04), radius: 6, x: 0, y: 2)
+            .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 10, x: 0, y: 2)
+        }
+    }
+
+    // MARK: - 섹션 헤더
+
+    private func sectionHeader(title: String, isGuide: Bool) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(HiTripColor.gray500)
+            Spacer()
+            if isGuide {
+                Text("가이드 전용")
+                    .font(.system(size: 11))
+                    .foregroundColor(HiTripColor.gray300)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(HiTripColor.gray100)
+                    .cornerRadius(8)
+            }
         }
     }
 
     // MARK: - 진행 현황 카드
 
     private var progressSummary: some View {
-        let total = viewModel.allTodos.count
-        let done  = viewModel.completedTodos.count
+        let guideDone    = viewModel.completedTodos.count
+        let guideTotal   = viewModel.allTodos.count
+        let personalDone = personalTodos.filter { $0.isCompleted }.count
+        let personalTotal = personalTodos.count
+        let done  = guideDone + personalDone
+        let total = guideTotal + personalTotal
         let ratio = total > 0 ? CGFloat(done) / CGFloat(total) : 0
 
-        return VStack(alignment: .leading, spacing: 8) {
+        return VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text("체크리스트")
                     .font(.system(size: 16, weight: .bold))
@@ -95,49 +164,14 @@ struct TripTodoView: View {
         .padding(16)
         .background(Color.white)
         .cornerRadius(14)
-        .shadow(color: Color.black.opacity(0.04), radius: 6, x: 0, y: 2)
+        .shadow(color: Color(hex: "B4BCC9").opacity(0.30), radius: 10, x: 0, y: 2)
     }
 
-    // MARK: - 카테고리 칩
+    // MARK: - 가이드 할일 행 (토글만)
 
-    private var categoryChip: some View {
-        Text("✈️ 오늘 일정 준비")
-            .font(.system(size: 13, weight: .medium))
-            .foregroundColor(HiTripColor.textBlack)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 7)
-            .background(Color.white)
-            .cornerRadius(20)
-            .shadow(color: Color.black.opacity(0.06), radius: 4, x: 0, y: 1)
-    }
-
-    // MARK: - 플레이스홀더 행
-
-    private var placeholderRow: some View {
-        HStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
-                    .foregroundColor(HiTripColor.gray300)
-                    .frame(width: 24, height: 24)
-            }
-            Text("체크리스트를 추가하세요.")
-                .font(.system(size: 15))
-                .foregroundColor(HiTripColor.gray300)
-            Spacer()
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
-    // MARK: - 체크리스트 행
-
-    private func todoRow(_ todo: TripTodo) -> some View {
-        HStack(alignment: .center, spacing: 12) {
-            // 체크 버튼
-            Button {
-                viewModel.toggleTodo(todo.id)
-            } label: {
+    private func guideTodoRow(_ todo: TripTodo) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            Button { viewModel.toggleTodo(todo.id) } label: {
                 if todo.isCompleted {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 24))
@@ -151,28 +185,100 @@ struct TripTodoView: View {
             .buttonStyle(.plain)
             .frame(width: 24, height: 24)
 
-            // 텍스트
             Text(todo.title)
                 .font(.system(size: 15))
                 .foregroundColor(todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack)
+                .strikethrough(todo.isCompleted, color: HiTripColor.gray300)
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .contentShape(Rectangle())
+        .onTapGesture { viewModel.toggleTodo(todo.id) }
+    }
+
+    // MARK: - 개인 할일 추가 행
+
+    private var addRow: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                    .foregroundColor(HiTripColor.primary800.opacity(0.14))
+            }
+            .frame(width: 24, height: 24)
+
+            if isAddingTodo {
+                TextField("할일을 입력하세요", text: $newTodoText)
+                    .font(.system(size: 15))
+                    .focused($isTextFieldFocused)
+                    .submitLabel(.done)
+                    .onSubmit { commitNewTodo() }
+
+                if !newTodoText.isEmpty {
+                    Button { commitNewTodo() } label: {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 22))
+                            .foregroundColor(HiTripColor.primary800)
+                    }
+                    .buttonStyle(.plain)
+                }
+            } else {
+                Button {
+                    isAddingTodo = true
+                    isTextFieldFocused = true
+                } label: {
+                    Text("할일 추가하기")
+                        .font(.system(size: 15))
+                        .foregroundColor(HiTripColor.gray400)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .animation(.easeInOut(duration: 0.15), value: isAddingTodo)
+    }
+
+    // MARK: - 개인 할일 행 (토글 + 삭제)
+
+    private func personalTodoRow(_ todo: PersonalTodo) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            Button { todo.isCompleted.toggle() } label: {
+                if todo.isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(HiTripColor.primary800)
+                } else {
+                    Circle()
+                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                        .frame(width: 24, height: 24)
+                }
+            }
+            .buttonStyle(.plain)
+            .frame(width: 24, height: 24)
+
+            Text(todo.title)
+                .font(.system(size: 15))
+                .foregroundColor(todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack)
+                .strikethrough(todo.isCompleted, color: HiTripColor.gray300)
 
             Spacer()
 
-            // 더보기 버튼
-            Button {
-                // TODO: 더보기 액션 (여행사 전용 수정/삭제)
-            } label: {
-                Image(systemName: "ellipsis")
-                    .font(.system(size: 14))
-                    .foregroundColor(HiTripColor.gray400)
-                    .rotationEffect(.degrees(90))
+            // 삭제 버튼
+            Button { deleteTodo(todo) } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(HiTripColor.gray300)
             }
             .buttonStyle(.plain)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
         .contentShape(Rectangle())
-        .onTapGesture { viewModel.toggleTodo(todo.id) }
+        .onTapGesture { todo.isCompleted.toggle() }
     }
 
     // MARK: - 빈 상태
@@ -187,12 +293,32 @@ struct TripTodoView: View {
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(HiTripColor.textBlack)
 
-            Text("여행사에서 체크리스트를 등록하면 표시됩니다")
+            Text("가이드가 체크리스트를 등록하거나\n직접 할일을 추가해보세요")
                 .font(.system(size: 14))
                 .foregroundColor(HiTripColor.gray500)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 32)
+    }
+
+    // MARK: - Actions
+
+    private func commitNewTodo() {
+        let text = newTodoText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else {
+            isAddingTodo = false
+            return
+        }
+        let tripId = TripDataStore.shared.currentPackage?.id ?? UUID()
+        let todo = PersonalTodo(title: text, tripId: tripId)
+        modelContext.insert(todo)
+        newTodoText = ""
+        isAddingTodo = false
+        isTextFieldFocused = false
+    }
+
+    private func deleteTodo(_ todo: PersonalTodo) {
+        modelContext.delete(todo)
     }
 }

--- a/HiTrip/Features/Schedule/Views/TripTodoView.swift
+++ b/HiTrip/Features/Schedule/Views/TripTodoView.swift
@@ -33,42 +33,40 @@ struct TripTodoView: View {
 
     private var checklistContent: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // 진행 현황 요약
+            // 진행 현황 요약 카드
             progressSummary
                 .padding(.bottom, 20)
 
-            // 미완료 항목
-            if !viewModel.pendingTodos.isEmpty {
-                sectionHeader(title: "할 일", emoji: "⬜", count: viewModel.pendingTodos.count)
-                    .padding(.bottom, 10)
+            // 카테고리 칩
+            categoryChip
+                .padding(.bottom, 12)
 
-                VStack(spacing: 2) {
-                    ForEach(viewModel.pendingTodos) { todo in
-                        todoRow(todo)
-                    }
+            // 플레이스홀더 행 (비활성)
+            placeholderRow
+                .padding(.bottom, 4)
+
+            // 전체 체크리스트 (미완료 → 완료 순)
+            VStack(spacing: 0) {
+                ForEach(viewModel.pendingTodos) { todo in
+                    todoRow(todo)
+                    Divider().padding(.leading, 40)
                 }
-                .padding(.bottom, 24)
-            }
-
-            // 완료 항목
-            if !viewModel.completedTodos.isEmpty {
-                sectionHeader(title: "완료", emoji: "✅", count: viewModel.completedTodos.count)
-                    .padding(.bottom, 10)
-
-                VStack(spacing: 2) {
-                    ForEach(viewModel.completedTodos) { todo in
-                        todoRow(todo)
-                    }
+                ForEach(viewModel.completedTodos) { todo in
+                    todoRow(todo)
+                    Divider().padding(.leading, 40)
                 }
             }
+            .background(Color.white)
+            .cornerRadius(14)
+            .shadow(color: Color.black.opacity(0.04), radius: 6, x: 0, y: 2)
         }
     }
 
-    // MARK: - 진행 현황
+    // MARK: - 진행 현황 카드
 
     private var progressSummary: some View {
         let total = viewModel.allTodos.count
-        let done = viewModel.completedTodos.count
+        let done  = viewModel.completedTodos.count
         let ratio = total > 0 ? CGFloat(done) / CGFloat(total) : 0
 
         return VStack(alignment: .leading, spacing: 8) {
@@ -100,66 +98,79 @@ struct TripTodoView: View {
         .shadow(color: Color.black.opacity(0.04), radius: 6, x: 0, y: 2)
     }
 
-    // MARK: - 섹션 헤더
+    // MARK: - 카테고리 칩
 
-    private func sectionHeader(title: String, emoji: String, count: Int) -> some View {
-        HStack(spacing: 4) {
-            Text(emoji).font(.system(size: 13))
-            Text(title)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(HiTripColor.textBlack)
-            Text("(\(count))")
-                .font(.system(size: 13))
-                .foregroundColor(HiTripColor.gray400)
+    private var categoryChip: some View {
+        Text("✈️ 오늘 일정 준비")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(HiTripColor.textBlack)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(Color.white)
+            .cornerRadius(20)
+            .shadow(color: Color.black.opacity(0.06), radius: 4, x: 0, y: 1)
+    }
+
+    // MARK: - 플레이스홀더 행
+
+    private var placeholderRow: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                    .foregroundColor(HiTripColor.gray300)
+                    .frame(width: 24, height: 24)
+            }
+            Text("체크리스트를 추가하세요.")
+                .font(.system(size: 15))
+                .foregroundColor(HiTripColor.gray300)
+            Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 7)
-        .background(HiTripColor.sectionTagBackground)
-        .cornerRadius(18)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     // MARK: - 체크리스트 행
 
     private func todoRow(_ todo: TripTodo) -> some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .center, spacing: 12) {
             // 체크 버튼
             Button {
                 viewModel.toggleTodo(todo.id)
             } label: {
-                ZStack {
-                    if todo.isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 22))
-                            .foregroundColor(HiTripColor.primary800)
-                    } else {
-                        Circle()
-                            .stroke(HiTripColor.gray300, lineWidth: 1.5)
-                            .frame(width: 22, height: 22)
-                    }
+                if todo.isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(HiTripColor.primary800)
+                } else {
+                    Circle()
+                        .stroke(HiTripColor.gray300, lineWidth: 1.5)
+                        .frame(width: 24, height: 24)
                 }
-                .frame(width: 22, height: 22)
             }
             .buttonStyle(.plain)
-            .padding(.top, 2)
+            .frame(width: 24, height: 24)
 
             // 텍스트
-            VStack(alignment: .leading, spacing: 3) {
-                Text(todo.title)
-                    .font(.system(size: 15))
-                    .foregroundColor(todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack)
-                    .strikethrough(todo.isCompleted, color: HiTripColor.gray400)
-
-                if let subtitle = todo.subtitle, !subtitle.isEmpty {
-                    Text(subtitle)
-                        .font(.system(size: 12))
-                        .foregroundColor(HiTripColor.gray400)
-                }
-            }
+            Text(todo.title)
+                .font(.system(size: 15))
+                .foregroundColor(todo.isCompleted ? HiTripColor.gray400 : HiTripColor.textBlack)
 
             Spacer()
+
+            // 더보기 버튼
+            Button {
+                // TODO: 더보기 액션 (여행사 전용 수정/삭제)
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 14))
+                    .foregroundColor(HiTripColor.gray400)
+                    .rotationEffect(.degrees(90))
+            }
+            .buttonStyle(.plain)
         }
-        .padding(.vertical, 10)
-        .padding(.horizontal, 4)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
         .contentShape(Rectangle())
         .onTapGesture { viewModel.toggleTodo(todo.id) }
     }

--- a/HiTrip/Features/Spot/Views/KakaoMapView.swift
+++ b/HiTrip/Features/Spot/Views/KakaoMapView.swift
@@ -17,6 +17,7 @@ struct KakaoMapView: UIViewControllerRepresentable {
     var userLocation: CLLocationCoordinate2D?
     var radiusMeters: Double = 0
     var cameraTarget: MapViewModel.CameraTarget?
+    var zoomTrigger: MapViewModel.ZoomTrigger?
     var onMarkerTapped: ((MapPlaceItem) -> Void)?
 
     func makeUIViewController(context: Context) -> KakaoMapViewController {
@@ -49,6 +50,10 @@ struct KakaoMapView: UIViewControllerRepresentable {
             vc.lastCameraTarget = target
             vc.moveCamera(to: target.coordinate)
         }
+        if let zoom = zoomTrigger, zoom != vc.lastZoomTrigger {
+            vc.lastZoomTrigger = zoom
+            vc.zoom(delta: zoom.delta)
+        }
     }
 
     static func dismantleUIViewController(_ vc: KakaoMapViewController, coordinator: ()) {
@@ -67,6 +72,8 @@ final class KakaoMapViewController: UIViewController, MapControllerDelegate {
 
     var isMapReady = false
     var lastCameraTarget: MapViewModel.CameraTarget?
+    var lastZoomTrigger: MapViewModel.ZoomTrigger?
+    private var currentZoomLevel: Int = 15
     private var markerLookup: [String: MapPlaceItem] = [:]
 
     init(latitude: Double, longitude: Double, onMarkerTapped: ((MapPlaceItem) -> Void)?) {
@@ -270,7 +277,14 @@ final class KakaoMapViewController: UIViewController, MapControllerDelegate {
     func moveCamera(to coordinate: CLLocationCoordinate2D) {
         guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
         let pt     = MapPoint(longitude: coordinate.longitude, latitude: coordinate.latitude)
-        let update = CameraUpdate.make(target: pt, zoomLevel: 15, mapView: mapView)
+        let update = CameraUpdate.make(target: pt, zoomLevel: currentZoomLevel, mapView: mapView)
+        mapView.moveCamera(update)
+    }
+
+    func zoom(delta: Int) {
+        guard let mapView = controller?.getView("mapView") as? KakaoMap else { return }
+        currentZoomLevel = max(1, min(21, currentZoomLevel + delta))
+        let update = CameraUpdate.make(zoomLevel: currentZoomLevel, mapView: mapView)
         mapView.moveCamera(update)
     }
 }

--- a/HiTrip/Features/Spot/Views/TravelerSpotDetailView.swift
+++ b/HiTrip/Features/Spot/Views/TravelerSpotDetailView.swift
@@ -130,7 +130,7 @@ struct TravelerSpotDetailView: View {
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(HiTripColor.screenBackground)
+        .background(Color.white)
         .cornerRadius(12)
     }
 


### PR DESCRIPTION
## 📋 PR 개요

이번 PR은 여행객 앱의 전반적인 UI 완성도를 높이고, 개인 할일 추가 기능을 구현한 내용을 담고 있습니다.

---

## ✅ 변경 사항 목록

### 1. 🆕 개인 할일 추가 기능 (SwiftData)

**어떤 기능인가요?**
기존에는 가이드(여행사)가 등록한 체크리스트만 볼 수 있었습니다. 이제 여행객이 직접 자신만의 할 일을 추가하고, 완료 체크 및 삭제할 수 있습니다.

**어떻게 구현했나요?**
- `SwiftData`를 사용했습니다. SwiftData는 Apple이 iOS 17에서 새로 발표한 로컬 데이터 저장 기술로, 간단한 코드로 앱 내부 DB(데이터베이스)를 만들 수 있습니다.
- `PersonalTodo.swift` 파일을 새로 만들어 "개인 할일" 데이터 구조를 정의했습니다.
- `할 일` 탭이 두 섹션으로 나뉩니다:
  - ✈️ **가이드 체크리스트**: 서버에서 내려오는 항목, 체크만 가능
  - 📝 **내 할일**: 로컬 저장, 직접 추가·체크·삭제 가능

**관련 파일:** `PersonalTodo.swift`, `TripTodoView.swift`, `HiTripApp.swift`

---

### 2. 🔧 iOS 배포 타겟 16.6 → 17.0 상향

**왜 변경했나요?**
SwiftData는 iOS 17 이상에서만 동작하는 기능입니다. 기존 설정(16.6)에서는 빌드 오류가 발생하여 17.0으로 올렸습니다. 2026년 기준 iOS 17 이상 사용자 비율은 80% 이상으로 실제 사용자 제약이 크지 않습니다.

**관련 파일:** `project.pbxproj`

---

### 3. 🎨 앱 전체 배경색 흰색 통일 + 카드 그림자 강화

**어떤 문제가 있었나요?**
- 일부 화면은 `#F9F9F9`(연회색), 일부는 `#FFFFFF`(흰색)으로 배경색이 제각각이었습니다.
- 배경이 흰색으로 바뀌면서 카드 그림자가 너무 연해 카드 구분이 어려웠습니다.

**어떻게 수정했나요?**
- 앱 전체 배경색을 `#FFFFFF`로 통일 (17개 파일)
- 카드 그림자를 `Color(hex: "B4BCC9").opacity(0.30)`으로 통일
  - B4BCC9: 파란빛이 도는 회색으로, 흰 배경에서 자연스럽게 어울림
  - `View+CardStyle.swift`의 공통 modifier 수정으로 전체 카드에 일괄 적용

**관련 파일:** `View+CardStyle.swift`, Auth/Chat/Map/Profile/Schedule 등 전체 화면 파일

---

### 4. 🗓️ 오늘의 일정 → 전체 여행 일정 뷰로 개편

**어떤 기능인가요?**
기존에는 "오늘의 일정"을 누르면 오늘 하루 일정만 타임라인으로 보여줬습니다. 이제 패키지 여행 전체 일정(1일차~N일차)을 탭으로 전환하며 볼 수 있습니다.

**UI 구성:**
- 상단 일차 탭 (가로 스크롤): 오늘 일차에 "오늘" 뱃지 + 날짜(월/일 요일) 표시
- 앱 실행 시 자동으로 오늘 일차 탭 선택
- 카드 개선: 이모지 박스, 파란색 시간 표시, 이동수단 뱃지

**관련 파일:** `TodayScheduleView.swift`, `TripListViewModel.swift`

---

### 5. 🏠 홈 화면 UI 개선

**변경 내용:**
- **진행률 카드**: 버스 이모지 왼쪽 배치, "여행 진행률 · N일 남음" 레이블 추가, 그라데이션 배경 제거 → 단색으로 통일, 날씨 제거(서버 미연동), 보조 텍스트 가독성 개선
- **홈 화면 정리**: "오늘의 일정" +N개 더 보기 버튼 제거, "내일의 일정" 섹션 제거 (전체 일정 뷰로 통합)
- **번역 기본 데이터 추가**: "화장실 어디예요?", "얼마예요?" 등 여행 필수 7개 문장 기본 탑재 (서버 API 연동 전까지 기본값 표시)

**관련 파일:** `TripListView.swift`, `TripDataStore.swift`

---

### 6. 📅 캘린더 탭 오늘 날짜 자동 선택

**어떤 문제가 있었나요?**
캘린더 탭을 열 때마다 항상 여행 첫째 날(1일차)로 초기화됐습니다.

**어떻게 수정했나요?**
- 오늘이 여행 기간 중이면 → 오늘 날짜 자동 선택
- 여행 시작 전이면 → 여행 시작일 선택
- 여행 종료 후이면 → 여행 마지막 날 선택

**관련 파일:** `TripDetailViewModel.swift`

---

## 🧪 테스트 방법

1. 앱 실행 → 홈 화면에서 진행률 카드, 번역 카드 확인
2. "전체 보기 >" 탭 → 일차별 탭 전환으로 전체 여행 일정 확인
3. 캘린더 탭 진입 → 오늘 날짜가 자동 선택되는지 확인
4. 일정 탭 → 할 일 → "할일 추가하기" 탭해서 개인 할일 추가/삭제 확인
5. 앱 재시작 후에도 개인 할일이 유지되는지 확인 (SwiftData 로컬 저장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)