### PR TITLE
feat: 기획서 동작 명세 정합 및 주변 스팟(지도) 서버 연결

### DIFF
--- a/HiTrip/Core/Network/APIEndpoint+Traveler.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Traveler.swift
@@ -327,6 +327,28 @@ extension APIEndpoint {
         APIEndpoint(path: "/api/v1/tourist/feedback/", method: .post, body: body)
     }
 
+    // MARK: - Nearby Spots (상황별 검색)
+
+    /// 주변 스팟 — 카테고리별
+    /// GET /api/v1/tourist/nearby-spots/
+    /// - Parameter category: restaurant | accessibility | pet | convenience | mart (필수)
+    static func travelerNearbySpots(
+        category: String,
+        lat: Double,
+        lng: Double,
+        radius: Int? = nil,
+        size: Int? = nil
+    ) -> APIEndpoint {
+        var items = [
+            URLQueryItem(name: "category", value: category),
+            URLQueryItem(name: "lat", value: String(lat)),
+            URLQueryItem(name: "lng", value: String(lng)),
+        ]
+        if let radius { items.append(URLQueryItem(name: "radius", value: String(radius))) }
+        if let size   { items.append(URLQueryItem(name: "size", value: String(size))) }
+        return APIEndpoint(path: "/api/v1/tourist/nearby-spots/", queryItems: items)
+    }
+
     // MARK: - Nearby Tours
 
     /// 주변 관광지

--- a/HiTrip/Core/Network/APIEndpoint+Traveler.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Traveler.swift
@@ -327,6 +327,14 @@ extension APIEndpoint {
         APIEndpoint(path: "/api/v1/tourist/feedback/", method: .post, body: body)
     }
 
+    // MARK: - Chat 첨부 업로드
+
+    /// 업로드 사전 승인 — 여기서 받은 upload_url로 파일 본문을 PUT 합니다.
+    /// POST /api/v1/chat/uploads/presign/
+    static func chatUploadPresign(body: [String: Any]) -> APIEndpoint {
+        APIEndpoint(path: "/api/v1/chat/uploads/presign/", method: .post, body: body)
+    }
+
     // MARK: - Nearby Spots (상황별 검색)
 
     /// 주변 스팟 — 카테고리별

--- a/HiTrip/Core/Network/APIEnvironment.swift
+++ b/HiTrip/Core/Network/APIEnvironment.swift
@@ -21,7 +21,7 @@ enum APIEnvironment {
 
     // MARK: - 현재 환경 (여기서 전환)
 
-    static let current: APIEnvironment = .remote
+    static let current: APIEnvironment = .mock
 
     // MARK: - Base URL
 

--- a/HiTrip/Core/Network/APIEnvironment.swift
+++ b/HiTrip/Core/Network/APIEnvironment.swift
@@ -21,7 +21,7 @@ enum APIEnvironment {
 
     // MARK: - 현재 환경 (여기서 전환)
 
-    static let current: APIEnvironment = .mock
+    static let current: APIEnvironment = .remote
 
     // MARK: - Base URL
 

--- a/HiTrip/Core/Network/DTOs/TravelerDTO.swift
+++ b/HiTrip/Core/Network/DTOs/TravelerDTO.swift
@@ -667,3 +667,66 @@ extension ChatMessageV1DTO {
         )
     }
 }
+
+
+// MARK: - 주변 스팟 (상황별 검색)
+
+/// GET /api/v1/tourist/nearby-spots/
+struct TravelerNearbySpotsResponseDTO: Decodable {
+    let category: String?
+    let categoryLabel: String?
+    let totalCount: Int?
+    let count: Int?
+    let results: [TravelerNearbySpotDTO]
+}
+
+struct TravelerNearbySpotDTO: Decodable, Identifiable, Hashable {
+    /// 외부 제공자(카카오) 장소 id — 목록 식별자로 씁니다
+    let providerObjectId: String
+    let name: String
+    let categoryName: String?
+    let categoryGroupCode: String?
+    let categoryGroupName: String?
+    let phone: String?
+    let address: String?
+    let roadAddress: String?
+    let placeUrl: String?
+    let distanceM: Int?
+    let lat: String?
+    let lng: String?
+    let isSponsored: Bool?
+    let imageUrl: String?
+    let description: String?
+
+    var id: String { providerObjectId }
+
+    var latitude: Double? { lat.flatMap(Double.init) }
+    var longitude: Double? { lng.flatMap(Double.init) }
+
+    /// "0.4km" — 1km 미만은 m로 보여줍니다
+    var distanceText: String? {
+        guard let distanceM else { return nil }
+        if distanceM < 1000 { return "\(distanceM)m" }
+        return String(format: "%.1fkm", Double(distanceM) / 1000)
+    }
+}
+
+// MARK: - 안전(지오펜스)
+
+/// GET /api/v1/tourist/safety/summary/ — 필요한 부분만 받습니다
+struct TravelerSafetySummaryDTO: Decodable {
+    let tripId: Int?
+    let dayNumber: Int?
+    let geofence: TravelerGeofenceDTO?
+}
+
+struct TravelerGeofenceDTO: Decodable {
+    let centerLat: String?
+    let centerLng: String?
+    let radiusKm: String?
+
+    var latitude: Double? { centerLat.flatMap(Double.init) }
+    var longitude: Double? { centerLng.flatMap(Double.init) }
+    /// 미터
+    var radiusM: Double? { radiusKm.flatMap(Double.init).map { $0 * 1000 } }
+}

--- a/HiTrip/Core/Network/DTOs/TravelerDTO.swift
+++ b/HiTrip/Core/Network/DTOs/TravelerDTO.swift
@@ -567,9 +567,40 @@ struct ChatMessageV1DTO: Decodable {
 
 struct ChatAttachmentDTO: Decodable {
     let id: Int
+    let mediaType: String?
     let downloadUrl: String?
     let originalName: String?
     let mimeType: String?
+    let duration: Int?
+
+    func toAttachment() -> MessageAttachment {
+        MessageAttachment(
+            id: id,
+            mediaType: mediaType ?? "photo",
+            downloadUrl: downloadUrl,
+            originalName: originalName,
+            duration: duration
+        )
+    }
+}
+
+// MARK: - 첨부 업로드
+
+/// POST /api/v1/chat/uploads/presign/
+struct ChatUploadIntentDTO: Decodable {
+    let attachmentId: Int
+    /// 항상 "PUT"
+    let method: String?
+    let uploadUrl: String
+    let expiresAt: String?
+    /// 업로드 PUT에 반드시 실어야 하는 헤더 (Content-Type 등)
+    let requiredHeaders: [String: String]?
+}
+
+struct ChatUploadCompleteDTO: Decodable {
+    let attachmentId: Int
+    let status: String?
+    let size: Int?
 }
 
 struct ChatMessagePageDTO: Decodable {
@@ -663,7 +694,8 @@ extension ChatMessageV1DTO {
             senderName: name,
             content: body,
             sentAt: sentAt,
-            sendStatus: .sent
+            sendStatus: .sent,
+            attachments: (attachments ?? []).map { $0.toAttachment() }
         )
     }
 }

--- a/HiTrip/Core/Network/DTOs/TravelerDTO.swift
+++ b/HiTrip/Core/Network/DTOs/TravelerDTO.swift
@@ -337,6 +337,8 @@ struct TravelerNoticeDTO: Decodable, Identifiable {
     let updatedAt: String?
     /// 읽음 여부 — 홈의 안 읽음 뱃지 계산에 사용
     let isRead: Bool?
+    /// 활성 여부 — 홈에는 활성 공지만 노출합니다
+    let isActive: Bool?
 }
 
 // MARK: - Messages (Thread 기반)

--- a/HiTrip/Core/Utils/NetworkMonitor.swift
+++ b/HiTrip/Core/Utils/NetworkMonitor.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Network
+
+// MARK: - NetworkMonitor
+/// 연결 상태 감시 — 오프라인 전송 대기 큐를 다시 굴리는 신호로 씁니다.
+
+final class NetworkMonitor: ObservableObject {
+
+    static let shared = NetworkMonitor()
+
+    @Published private(set) var isConnected = true
+
+    /// 끊겼다가 다시 붙었을 때만 부릅니다
+    var onReconnect: (() -> Void)?
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "hitrip.network.monitor")
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let connected = path.status == .satisfied
+            DispatchQueue.main.async {
+                let wasOffline = !self.isConnected
+                self.isConnected = connected
+                if connected && wasOffline { self.onReconnect?() }
+            }
+        }
+        monitor.start(queue: queue)
+    }
+}

--- a/HiTrip/Data/Repositories/ChatRepository.swift
+++ b/HiTrip/Data/Repositories/ChatRepository.swift
@@ -77,6 +77,17 @@ final class ChatRepository: ChatRepositoryProtocol {
         fetchMessages(chatRoomId: chatRoomId, before: nil).map(\.messages)
     }
 
+    func fetchMessages(
+        chatRoomId: UUID,
+        before: Int?,
+        limit: Int
+    ) -> Single<(messages: [Message], nextCursor: Int?)> {
+        // 서버는 페이지 크기를 인자로 받지 않고 고정 크기로 돌려줍니다.
+        // limit은 앱이 한 번에 붙이는 양의 상한으로만 씁니다.
+        fetchMessages(chatRoomId: chatRoomId, before: before)
+            .map { page in (Array(page.messages.suffix(limit)), page.nextCursor) }
+    }
+
     /// 커서 페이징 — `before`보다 id가 작은(= 더 오래된) 메시지를 불러옵니다.
     /// - Returns: 메시지와 다음 페이지 커서. `nextCursor`가 nil이면 더 없음.
     func fetchMessages(

--- a/HiTrip/Data/Repositories/ChatRepository.swift
+++ b/HiTrip/Data/Repositories/ChatRepository.swift
@@ -120,6 +120,10 @@ final class ChatRepository: ChatRepositoryProtocol {
     }
 
     func sendMessage(message: Message) -> Single<Message> {
+        sendMessage(message: message, attachmentIds: [])
+    }
+
+    func sendMessage(message: Message, attachmentIds: [Int]) -> Single<Message> {
         guard let serverId = resolveServerId(for: message.chatRoomId) else {
             return .error(ChatError.roomNotFound)
         }
@@ -129,11 +133,12 @@ final class ChatRepository: ChatRepositoryProtocol {
         // client_message_id는 서버 필수값이자 멱등키입니다.
         // 재전송 시 같은 값을 유지해야 메시지가 중복 생성되지 않으므로
         // Message.id(로컬 UUID)를 그대로 씁니다.
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "client_message_id": message.id.uuidString,
-            "message_type": "text",
+            "message_type": attachmentIds.isEmpty ? "text" : "attachment",
             "body": message.content,
         ]
+        if !attachmentIds.isEmpty { body["attachment_ids"] = attachmentIds }
 
         return networkService.request(
             .chatMessageSend(roomId: String(serverId), body: body),
@@ -141,6 +146,64 @@ final class ChatRepository: ChatRepositoryProtocol {
         )
         .map { dto in
             dto.toMessage(chatRoomId: message.chatRoomId, currentUserId: userId, currentRole: role)
+        }
+    }
+
+    // MARK: - 첨부 업로드
+
+    /// 1) presign으로 업로드 주소를 받고 2) 그 주소에 파일 본문을 PUT 합니다.
+    /// 서버가 요구하는 헤더(required_headers)를 그대로 실어야 업로드가 통과합니다.
+    func uploadAttachment(
+        chatRoomId: UUID,
+        data: Data,
+        mediaType: String,
+        fileName: String,
+        mimeType: String,
+        duration: Int?
+    ) -> Single<Int> {
+        guard let roomId = resolveServerId(for: chatRoomId) else {
+            return .error(ChatError.roomNotFound)
+        }
+
+        var body: [String: Any] = [
+            "room_id": roomId,
+            "media_type": mediaType,
+            "original_name": fileName,
+            "mime_type": mimeType,
+            "size": data.count,
+        ]
+        if let duration { body["duration"] = duration }
+
+        return networkService.request(.chatUploadPresign(body: body), type: ChatUploadIntentDTO.self)
+            .flatMap { intent in Self.put(data: data, to: intent).map { _ in intent.attachmentId } }
+    }
+
+    /// presign이 알려준 주소로 파일 본문을 올립니다.
+    private static func put(data: Data, to intent: ChatUploadIntentDTO) -> Single<Void> {
+        guard let url = URL(string: intent.uploadUrl)
+            ?? URL(string: APIEnvironment.current.baseURL + intent.uploadUrl) else {
+            return .error(HiTripError.networkFailure("업로드 주소가 올바르지 않습니다"))
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = intent.method ?? "PUT"
+        intent.requiredHeaders?.forEach { request.setValue($1, forHTTPHeaderField: $0) }
+        if let token = KeychainManager.shared.getToken() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        return Single.create { single in
+            let task = URLSession.shared.uploadTask(with: request, from: data) { _, response, error in
+                if let error { single(.failure(error)); return }
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                if (200..<300).contains(code) {
+                    single(.success(()))
+                } else {
+                    single(.failure(HiTripError.networkFailure("업로드에 실패했습니다 (\(code))")))
+                }
+            }
+            task.resume()
+            return Disposables.create { task.cancel() }
         }
     }
 

--- a/HiTrip/Data/Repositories/MockChatRepository.swift
+++ b/HiTrip/Data/Repositories/MockChatRepository.swift
@@ -139,6 +139,30 @@ final class MockChatRepository: ChatRepositoryProtocol {
         return .just(saved)
     }
 
+    // MARK: - 첨부
+
+    private static var nextAttachmentId = 500
+
+    func uploadAttachment(
+        chatRoomId: UUID,
+        data: Data,
+        mediaType: String,
+        fileName: String,
+        mimeType: String,
+        duration: Int?
+    ) -> Single<Int> {
+        Self.nextAttachmentId += 1
+        return .just(Self.nextAttachmentId)
+    }
+
+    func sendMessage(message: Message, attachmentIds: [Int]) -> Single<Message> {
+        var withAttachments = message
+        withAttachments.attachments = attachmentIds.map {
+            MessageAttachment(id: $0, mediaType: "photo", downloadUrl: nil, originalName: nil, duration: nil)
+        }
+        return sendMessage(message: withAttachments)
+    }
+
     func markAsRead(chatRoomId: UUID) -> Single<Void> {
         if let idx = Self.rooms.firstIndex(where: { $0.id == chatRoomId }) {
             Self.rooms[idx].unreadCount = 0

--- a/HiTrip/Data/Repositories/MockChatRepository.swift
+++ b/HiTrip/Data/Repositories/MockChatRepository.swift
@@ -109,6 +109,16 @@ final class MockChatRepository: ChatRepositoryProtocol {
         .just((Self.messages[chatRoomId] ?? []).sorted { $0.sentAt < $1.sentAt })
     }
 
+    /// 목에는 과거 메시지가 없어 항상 "더 없음"으로 답합니다.
+    func fetchMessages(
+        chatRoomId: UUID,
+        before: Int?,
+        limit: Int
+    ) -> Single<(messages: [Message], nextCursor: Int?)> {
+        guard before == nil else { return .just(([], nil)) }
+        return fetchMessages(chatRoomId: chatRoomId).map { ($0, nil) }
+    }
+
     func sendMessage(message: Message) -> Single<Message> {
         // 전송 실패 화면을 확인할 수 있게 남겨둔 통로
         if message.content.hasPrefix("실패") || message.content.lowercased().hasPrefix("fail") {

--- a/HiTrip/Data/Repositories/MockTravelerRepository.swift
+++ b/HiTrip/Data/Repositories/MockTravelerRepository.swift
@@ -234,6 +234,11 @@ final class MockTravelerRepository: TravelerRepositoryProtocol {
         .just(mockNotices)
     }
 
+    func markNoticeRead(id: Int) -> Single<Void> {
+        Self.readNoticeIds.insert(id)
+        return .just(())
+    }
+
     func fetchNotice(id: Int) -> Single<TravelerNoticeDTO> {
         if let found = mockNotices.first(where: { $0.id == id }) {
             return .just(found)
@@ -418,25 +423,39 @@ private extension MockTravelerRepository {
 
     // MARK: Notices
 
+    /// 읽음 처리한 공지 id — 목 환경에서도 빨간 점이 사라지는 걸 확인할 수 있게 유지합니다
+    private static var readNoticeIds: Set<Int> = []
+
     var mockNotices: [TravelerNoticeDTO] {
+        raw.map { n in
+            Self.readNoticeIds.contains(n.id)
+                ? TravelerNoticeDTO(id: n.id, title: n.title, content: n.content,
+                                    priority: n.priority, publishedAt: n.publishedAt,
+                                    createdAt: n.createdAt, updatedAt: n.updatedAt,
+                                    isRead: true, isActive: n.isActive)
+                : n
+        }
+    }
+
+    private var raw: [TravelerNoticeDTO] {
         [
             TravelerNoticeDTO(id: 1, title: "⚠️ 한라산 등반 안전 수칙",
                 content: "내일 한라산 등반 시 반드시 등산화를 착용해 주세요. 기상 변화가 심하므로 방수 재킷도 필수입니다. 오전 9시 30분 호텔 로비에서 집결합니다.",
                 priority: "important", publishedAt: "2026-07-19T18:00:00.000000Z",
                 createdAt: "2026-07-19T18:00:00.000000Z", updatedAt: "2026-07-19T18:00:00.000000Z",
-                isRead: false),
+                isRead: false, isActive: true),
 
             TravelerNoticeDTO(id: 2, title: "우도 스노클링 장비 신청 마감",
                 content: "내일 우도 스노클링 체험을 원하시는 분은 오늘 밤 10시까지 담당자에게 연락 주시기 바랍니다. 장비는 현장에서 제공됩니다.",
                 priority: "normal", publishedAt: "2026-07-19T20:00:00.000000Z",
                 createdAt: "2026-07-19T20:00:00.000000Z", updatedAt: "2026-07-19T20:00:00.000000Z",
-                isRead: false),
+                isRead: false, isActive: true),
 
             TravelerNoticeDTO(id: 3, title: "내일 조식 시간 변경 안내",
                 content: "7월 20일(일) 조식이 08:00으로 변경되었습니다. 한라산 등반 일정이 앞당겨진 관계로 시간을 엄수해 주시기 바랍니다.",
                 priority: "normal", publishedAt: "2026-07-19T21:00:00.000000Z",
                 createdAt: "2026-07-19T21:00:00.000000Z", updatedAt: "2026-07-19T21:00:00.000000Z",
-                isRead: true),
+                isRead: true, isActive: true),
         ]
     }
 

--- a/HiTrip/Data/Repositories/MockTravelerRepository.swift
+++ b/HiTrip/Data/Repositories/MockTravelerRepository.swift
@@ -456,6 +456,12 @@ private extension MockTravelerRepository {
                 priority: "normal", publishedAt: "2026-07-19T21:00:00.000000Z",
                 createdAt: "2026-07-19T21:00:00.000000Z", updatedAt: "2026-07-19T21:00:00.000000Z",
                 isRead: true, isActive: true),
+
+            TravelerNoticeDTO(id: 4, title: "1일차 집합 안내",
+                content: "공항 3번 게이트 앞에서 09:00에 집합합니다. 늦으시는 분은 담당자에게 연락 주세요.",
+                priority: "normal", publishedAt: "2026-07-18T09:00:00.000000Z",
+                createdAt: "2026-07-18T09:00:00.000000Z", updatedAt: "2026-07-18T09:00:00.000000Z",
+                isRead: true, isActive: false),
         ]
     }
 

--- a/HiTrip/Data/Repositories/MockTravelerRepository.swift
+++ b/HiTrip/Data/Repositories/MockTravelerRepository.swift
@@ -293,6 +293,67 @@ final class MockTravelerRepository: TravelerRepositoryProtocol {
         .just(TravelerManagerContactDTO(manager: ["phone": "010-1234-5678", "name": "김담당 매니저"]))
     }
 
+    // MARK: - 주변 스팟 / 안전
+
+    func fetchNearbySpots(
+        category: String,
+        lat: Double,
+        lng: Double,
+        radius: Int?
+    ) -> Single<[TravelerNearbySpotDTO]> {
+        .just(Self.mockNearbySpots(category: category, lat: lat, lng: lng))
+    }
+
+    func fetchSafetySummary() -> Single<TravelerSafetySummaryDTO> {
+        // 목에서는 현재 위치를 모르므로 제주 시내를 중심으로 잡습니다
+        .just(TravelerSafetySummaryDTO(
+            tripId: 1,
+            dayNumber: 2,
+            geofence: TravelerGeofenceDTO(
+                centerLat: "33.499621",
+                centerLng: "126.531188",
+                radiusKm: "3.0"
+            )
+        ))
+    }
+
+    func sendLocationSnapshot(latitude: Double, longitude: Double, accuracyM: Double?) -> Single<Void> {
+        .just(())
+    }
+
+    /// 카테고리별로 좌표를 조금씩 흩어 놓아 지도 마커를 확인할 수 있게 합니다.
+    private static func mockNearbySpots(category: String, lat: Double, lng: Double) -> [TravelerNearbySpotDTO] {
+        let names: [String]
+        switch category {
+        case "restaurant":    names = ["흑돼지 명가", "해녀의 집", "올레 국수"]
+        case "accessibility": names = ["제주도립미술관", "한라수목원"]
+        case "pet":           names = ["반려동물 동반 카페", "애월 펫파크"]
+        case "convenience":   names = ["GS25 동문점", "CU 칠성로점", "세븐일레븐 관덕정"]
+        case "mart":          names = ["이마트 제주점", "하나로마트"]
+        default:              names = []
+        }
+
+        return names.enumerated().map { index, name in
+            TravelerNearbySpotDTO(
+                providerObjectId: "\(category)_\(index)",
+                name: name,
+                categoryName: category,
+                categoryGroupCode: nil,
+                categoryGroupName: nil,
+                phone: nil,
+                address: "제주특별자치도 제주시",
+                roadAddress: nil,
+                placeUrl: nil,
+                distanceM: 300 + index * 250,
+                lat: String(lat + Double(index + 1) * 0.004),
+                lng: String(lng + Double(index % 2 == 0 ? 1 : -1) * 0.005),
+                isSponsored: index == 0,
+                imageUrl: nil,
+                description: "목 데이터"
+            )
+        }
+    }
+
     func sendEmergencyRequest(message: String, latitude: String?, longitude: String?, accuracyM: String?) -> Single<TravelerEmergencyRequestDTO> {
         .just(TravelerEmergencyRequestDTO(
             id: 1,

--- a/HiTrip/Data/Repositories/TravelerRepository.swift
+++ b/HiTrip/Data/Repositories/TravelerRepository.swift
@@ -164,6 +164,42 @@ final class TravelerRepository: TravelerRepositoryProtocol {
         networkService.request(.travelerManagerContact(), type: TravelerManagerContactDTO.self)
     }
 
+    // MARK: - 주변 스팟 / 안전
+
+    func fetchNearbySpots(
+        category: String,
+        lat: Double,
+        lng: Double,
+        radius: Int?
+    ) -> Single<[TravelerNearbySpotDTO]> {
+        networkService.request(
+            .travelerNearbySpots(category: category, lat: lat, lng: lng, radius: radius),
+            type: TravelerNearbySpotsResponseDTO.self
+        )
+        .map(\.results)
+    }
+
+    func fetchSafetySummary() -> Single<TravelerSafetySummaryDTO> {
+        networkService.request(.travelerSafetySummary(), type: TravelerSafetySummaryDTO.self)
+    }
+
+    func sendLocationSnapshot(
+        latitude: Double,
+        longitude: Double,
+        accuracyM: Double?
+    ) -> Single<Void> {
+        let iso = ISO8601DateFormatter()
+        var body: [String: Any] = [
+            "latitude": String(format: "%.6f", latitude),
+            "longitude": String(format: "%.6f", longitude),
+            "measured_at": iso.string(from: Date()),
+        ]
+        if let accuracyM { body["accuracy_m"] = String(format: "%.2f", accuracyM) }
+
+        return networkService.request(.travelerSafetyLocation(body: body), type: EmptyResponse.self)
+            .map { _ in () }
+    }
+
     func sendEmergencyRequest(
         message: String,
         latitude: String?,

--- a/HiTrip/Data/Repositories/TravelerRepository.swift
+++ b/HiTrip/Data/Repositories/TravelerRepository.swift
@@ -122,6 +122,11 @@ final class TravelerRepository: TravelerRepositoryProtocol {
         networkService.request(.travelerNotice(id: id), type: TravelerNoticeDTO.self)
     }
 
+    func markNoticeRead(id: Int) -> Single<Void> {
+        networkService.request(.travelerNoticeRead(id: id), type: EmptyResponse.self)
+            .map { _ in () }
+    }
+
     // MARK: - Checklist
 
     func fetchChecklists() -> Single<[TravelerChecklistItemDTO]> {

--- a/HiTrip/Domain/Entities/Message.swift
+++ b/HiTrip/Domain/Entities/Message.swift
@@ -25,6 +25,9 @@ struct Message: Identifiable, Codable, Equatable {
     /// 전송 상태 — 서버에서 받은 메시지는 항상 .sent
     var sendStatus: MessageSendStatus
 
+    /// 첨부 파일 — 사진·동영상·음성
+    var attachments: [MessageAttachment]
+
     init(
         id: UUID = UUID(),
         serverId: Int? = nil,
@@ -34,7 +37,8 @@ struct Message: Identifiable, Codable, Equatable {
         senderName: String,
         content: String,
         sentAt: Date = Date(),
-        sendStatus: MessageSendStatus = .sent
+        sendStatus: MessageSendStatus = .sent,
+        attachments: [MessageAttachment] = []
     ) {
         self.id = id
         self.serverId = serverId
@@ -45,6 +49,7 @@ struct Message: Identifiable, Codable, Equatable {
         self.content = content
         self.sentAt = sentAt
         self.sendStatus = sendStatus
+        self.attachments = attachments
     }
 
     /// 내가 보낸 메시지인지
@@ -63,9 +68,27 @@ struct Message: Identifiable, Codable, Equatable {
             content: content,
             isMine: isMyMessage(currentUserId: currentUserId),
             sendStatus: sendStatus,
-            sentAt: sentAt
+            sentAt: sentAt,
+            attachments: attachments
         )
     }
+}
+
+// MARK: - 첨부
+
+/// 서버 ChatAttachment — 사진·동영상·음성
+struct MessageAttachment: Identifiable, Codable, Equatable {
+    let id: Int
+    /// "photo" | "video" | "audio"
+    let mediaType: String
+    let downloadUrl: String?
+    let originalName: String?
+    /// 음성 길이(초)
+    let duration: Int?
+
+    var isPhoto: Bool { mediaType == "photo" }
+    var isVideo: Bool { mediaType == "video" }
+    var isAudio: Bool { mediaType == "audio" }
 }
 
 // MARK: - 전송 상태
@@ -89,6 +112,7 @@ struct ChatMessage: Identifiable {
     let isMine: Bool
     var sendStatus: MessageSendStatus
     let sentAt: Date
+    var attachments: [MessageAttachment] = []
 
     var sendFailed: Bool { sendStatus == .failed }
     var isSending: Bool { sendStatus == .sending }

--- a/HiTrip/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -43,4 +43,20 @@ protocol ChatRepositoryProtocol {
 
     /// 메시지 읽음 처리 — 특정 채팅방의 모든 메시지를 읽음으로
     func markAsRead(chatRoomId: UUID) -> Single<Void>
+
+    // MARK: - 첨부
+
+    /// 파일을 업로드하고 attachment_id를 돌려줍니다.
+    /// presign → PUT 업로드 두 단계를 저장소가 감춥니다.
+    func uploadAttachment(
+        chatRoomId: UUID,
+        data: Data,
+        mediaType: String,
+        fileName: String,
+        mimeType: String,
+        duration: Int?
+    ) -> Single<Int>
+
+    /// 첨부가 붙은 메시지 전송
+    func sendMessage(message: Message, attachmentIds: [Int]) -> Single<Message>
 }

--- a/HiTrip/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -33,6 +33,14 @@ protocol ChatRepositoryProtocol {
     /// 메시지 조회 — 특정 채팅방의 모든 메시지 (시간순)
     func fetchMessages(chatRoomId: UUID) -> Single<[Message]>
 
+    /// 과거 메시지 페이지 — `before`보다 오래된 것부터 최대 limit개.
+    /// nextCursor가 nil이면 더 불러올 게 없습니다.
+    func fetchMessages(
+        chatRoomId: UUID,
+        before: Int?,
+        limit: Int
+    ) -> Single<(messages: [Message], nextCursor: Int?)>
+
     /// 메시지 읽음 처리 — 특정 채팅방의 모든 메시지를 읽음으로
     func markAsRead(chatRoomId: UUID) -> Single<Void>
 }

--- a/HiTrip/Domain/Repositories/TravelerRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/TravelerRepositoryProtocol.swift
@@ -73,6 +73,26 @@ protocol TravelerRepositoryProtocol {
     // MARK: - Map & Manager
     func fetchMapPlaces() -> Single<[TravelerMapPlaceDTO]>
     func fetchManagerContact() -> Single<TravelerManagerContactDTO>
+    // MARK: - 주변 스팟 / 안전
+
+    /// 상황별 검색 — 카테고리는 서버 enum (restaurant/accessibility/pet/convenience/mart)
+    func fetchNearbySpots(
+        category: String,
+        lat: Double,
+        lng: Double,
+        radius: Int?
+    ) -> Single<[TravelerNearbySpotDTO]>
+
+    /// 안전 요약 — 지도에 그릴 지오펜스(허용 반경)를 포함합니다
+    func fetchSafetySummary() -> Single<TravelerSafetySummaryDTO>
+
+    /// 위치 스냅샷 전송 — 이탈 판정은 서버가 합니다
+    func sendLocationSnapshot(
+        latitude: Double,
+        longitude: Double,
+        accuracyM: Double?
+    ) -> Single<Void>
+
     func sendEmergencyRequest(
         message: String,
         latitude: String?,

--- a/HiTrip/Domain/Repositories/TravelerRepositoryProtocol.swift
+++ b/HiTrip/Domain/Repositories/TravelerRepositoryProtocol.swift
@@ -58,6 +58,9 @@ protocol TravelerRepositoryProtocol {
     func fetchNotices() -> Single<[TravelerNoticeDTO]>
     func fetchNotice(id: Int) -> Single<TravelerNoticeDTO>
 
+    /// 공지 읽음 처리 — 홈의 빨간 점을 없애는 기준
+    func markNoticeRead(id: Int) -> Single<Void>
+
     // MARK: - Checklist
     func fetchChecklists() -> Single<[TravelerChecklistItemDTO]>
     func toggleChecklist(itemId: Int, isChecked: Bool) -> Single<TravelerChecklistItemDTO>

--- a/HiTrip/Domain/UseCases/ChatUseCase.swift
+++ b/HiTrip/Domain/UseCases/ChatUseCase.swift
@@ -68,6 +68,15 @@ final class ChatUseCase {
 
     /// 메시지 읽음 처리
     /// - 검증 불필요 → 바로 Repository 호출
+    /// 과거 메시지 페이지 — 상단 스크롤 시 30개씩 불러옵니다.
+    func fetchOlderMessages(
+        chatRoomId: UUID,
+        before: Int?,
+        limit: Int = 30
+    ) -> Single<(messages: [Message], nextCursor: Int?)> {
+        return repository.fetchMessages(chatRoomId: chatRoomId, before: before, limit: limit)
+    }
+
     func markAsRead(chatRoomId: UUID) -> Single<Void> {
         return repository.markAsRead(chatRoomId: chatRoomId)
     }

--- a/HiTrip/Domain/UseCases/ChatUseCase.swift
+++ b/HiTrip/Domain/UseCases/ChatUseCase.swift
@@ -77,6 +77,26 @@ final class ChatUseCase {
         return repository.fetchMessages(chatRoomId: chatRoomId, before: before, limit: limit)
     }
 
+    /// 첨부 업로드 — attachment_id를 돌려줍니다
+    func uploadAttachment(
+        chatRoomId: UUID,
+        data: Data,
+        mediaType: String,
+        fileName: String,
+        mimeType: String,
+        duration: Int?
+    ) -> Single<Int> {
+        return repository.uploadAttachment(
+            chatRoomId: chatRoomId, data: data, mediaType: mediaType,
+            fileName: fileName, mimeType: mimeType, duration: duration
+        )
+    }
+
+    /// 첨부가 붙은 메시지 전송
+    func sendMessage(message: Message, attachmentIds: [Int]) -> Single<Message> {
+        return repository.sendMessage(message: message, attachmentIds: attachmentIds)
+    }
+
     func markAsRead(chatRoomId: UUID) -> Single<Void> {
         return repository.markAsRead(chatRoomId: chatRoomId)
     }

--- a/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
@@ -35,6 +35,18 @@ final class ChatViewModel: ObservableObject {
     /// 입력 중에 잘라내면 한국어·일본어·중국어 조합이 깨지므로 자르지 않습니다.
     var isOverMessageLimit: Bool { messageText.count > messageLimit }
 
+    /// 첨부 업로드 중 — 진행 표시
+    @Published private(set) var isUploading = false
+
+    /// 첨부 관련 안내 (용량 초과·권한 등)
+    @Published var toast: String?
+
+    /// 오프라인 상태 — 상단 배너
+    @Published private(set) var isOffline = false
+
+    /// 파일당 최대 용량 (서버 제한과 동일)
+    let attachmentSizeLimit = 50 * 1024 * 1024
+
     /// 과거 메시지 커서 — nil이면 더 불러올 게 없습니다
     @Published private(set) var olderCursor: Int?
     @Published private(set) var isLoadingOlder = false
@@ -70,12 +82,41 @@ final class ChatViewModel: ObservableObject {
     /// 현재 로그인한 사용자 이름
     private(set) var currentUserName: String
 
+    /// 오프라인일 때 쌓아 두는 전송 대기 큐 — 재연결되면 순서대로 보냅니다
+    private var pendingQueue: [(message: Message, attachmentIds: [Int])] = []
+
     init(chatUseCase: ChatUseCase) {
         self.chatUseCase = chatUseCase
         // Keychain에서 현재 로그인 유저 정보 가져오기
         let keychain = KeychainManager.shared
         self.currentUserId = keychain.getUserId() ?? "guest"
         self.currentUserName = keychain.getUserName() ?? keychain.getUserId() ?? "사용자"
+
+        isOffline = !NetworkMonitor.shared.isConnected
+        NetworkMonitor.shared.onReconnect = { [weak self] in
+            self?.isOffline = false
+            self?.flushPendingQueue()
+        }
+    }
+
+    // MARK: - 오프라인 전송 큐
+
+    /// 연결이 없으면 서버로 보내지 않고 큐에 담아 둡니다.
+    /// 메시지는 .sending 상태로 화면에 남아 있다가 재연결 시 전송됩니다.
+    private func enqueueOrDeliver(_ message: Message, attachmentIds: [Int] = []) {
+        guard NetworkMonitor.shared.isConnected else {
+            isOffline = true
+            pendingQueue.append((message, attachmentIds))
+            return
+        }
+        deliver(message, attachmentIds: attachmentIds)
+    }
+
+    /// 재연결되면 쌓인 것을 순서대로 내보냅니다
+    private func flushPendingQueue() {
+        let queued = pendingQueue
+        pendingQueue.removeAll()
+        queued.forEach { deliver($0.message, attachmentIds: $0.attachmentIds) }
     }
 
     // MARK: - ChatRoom (채팅방)
@@ -214,7 +255,63 @@ final class ChatViewModel: ObservableObject {
         messages.append(pending)
         messageText = ""
 
-        deliver(pending)
+        enqueueOrDeliver(pending)
+    }
+
+    // MARK: - 첨부
+
+    /// 사진·동영상·음성을 올리고 첨부 메시지로 보냅니다.
+    /// - Parameter duration: 음성일 때 초 단위 길이 (서버 최대 180초)
+    func sendAttachment(
+        chatRoomId: UUID,
+        data: Data,
+        mediaType: String,
+        fileName: String,
+        mimeType: String,
+        duration: Int? = nil
+    ) {
+        guard data.count <= attachmentSizeLimit else {
+            toast = "50MB 이하 파일만 첨부할 수 있어요"
+            return
+        }
+        guard NetworkMonitor.shared.isConnected else {
+            // 업로드는 연결이 있어야 시작할 수 있습니다
+            isOffline = true
+            toast = "연결되면 다시 시도해주세요"
+            return
+        }
+
+        isUploading = true
+        chatUseCase.uploadAttachment(
+            chatRoomId: chatRoomId, data: data, mediaType: mediaType,
+            fileName: fileName, mimeType: mimeType, duration: duration
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] attachmentId in
+                guard let self else { return }
+                self.isUploading = false
+
+                let pending = Message(
+                    chatRoomId: chatRoomId,
+                    senderId: self.currentUserId,
+                    senderName: self.currentUserName,
+                    content: "",
+                    sendStatus: .sending,
+                    attachments: [MessageAttachment(
+                        id: attachmentId, mediaType: mediaType,
+                        downloadUrl: nil, originalName: fileName, duration: duration
+                    )]
+                )
+                self.messages.append(pending)
+                self.enqueueOrDeliver(pending, attachmentIds: [attachmentId])
+            },
+            onFailure: { [weak self] _ in
+                self?.isUploading = false
+                self?.toast = "첨부하지 못했어요"
+            }
+        )
+        .disposed(by: disposeBag)
     }
 
     /// 실패한 메시지 재전송
@@ -226,7 +323,8 @@ final class ChatViewModel: ObservableObject {
               messages[idx].sendStatus == .failed else { return }
 
         messages[idx].sendStatus = .sending
-        deliver(messages[idx])
+        let attachmentIds = messages[idx].attachments.map(\.id)
+        enqueueOrDeliver(messages[idx], attachmentIds: attachmentIds)
     }
 
     /// 실패한 메시지 삭제 (로컬)
@@ -234,8 +332,8 @@ final class ChatViewModel: ObservableObject {
         messages.removeAll { $0.id == messageId && $0.sendStatus == .failed }
     }
 
-    private func deliver(_ message: Message) {
-        chatUseCase.sendMessage(message: message)
+    private func deliver(_ message: Message, attachmentIds: [Int] = []) {
+        chatUseCase.sendMessage(message: message, attachmentIds: attachmentIds)
             .observe(on: MainScheduler.instance)
             .subscribe(
                 onSuccess: { [weak self] saved in
@@ -249,6 +347,12 @@ final class ChatViewModel: ObservableObject {
                 onFailure: { [weak self] error in
                     guard let self,
                           let idx = self.messages.firstIndex(where: { $0.id == message.id }) else { return }
+                    // 연결이 끊긴 것이면 실패로 두지 않고 큐에 넣어 재연결 때 보냅니다
+                    if !NetworkMonitor.shared.isConnected {
+                        self.isOffline = true
+                        self.pendingQueue.append((message, attachmentIds))
+                        return
+                    }
                     self.messages[idx].sendStatus = .failed
                     self.errorMessage = error.localizedDescription
                 }

--- a/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/HiTrip/Features/Chat/ViewModels/ChatViewModel.swift
@@ -28,6 +28,18 @@ final class ChatViewModel: ObservableObject {
     /// 메시지 입력 — TextField와 바인딩
     @Published var messageText: String = ""
 
+    /// 입력 상한 (자)
+    let messageLimit = 1_000
+
+    /// 상한을 넘겼는지 — 넘기면 전송을 막습니다.
+    /// 입력 중에 잘라내면 한국어·일본어·중국어 조합이 깨지므로 자르지 않습니다.
+    var isOverMessageLimit: Bool { messageText.count > messageLimit }
+
+    /// 과거 메시지 커서 — nil이면 더 불러올 게 없습니다
+    @Published private(set) var olderCursor: Int?
+    @Published private(set) var isLoadingOlder = false
+    var hasOlderMessages: Bool { olderCursor != nil }
+
     // MARK: - 채팅방 생성 폼
 
     /// 상대방 이름 입력
@@ -146,6 +158,8 @@ final class ChatViewModel: ObservableObject {
                 onSuccess: { [weak self] messages in
                     self?.isLoading = false
                     self?.messages = messages
+                    // 가장 오래된 메시지를 다음 페이지 커서로 잡아둡니다
+                    self?.olderCursor = messages.first?.serverId
                 },
                 onFailure: { [weak self] error in
                     self?.isLoading = false
@@ -157,13 +171,36 @@ final class ChatViewModel: ObservableObject {
 
     /// 메시지 전송
     /// - 입력창의 텍스트로 Message 생성 후 전송
+    /// 위로 스크롤했을 때 과거 메시지 30개를 앞에 붙입니다.
+    func loadOlderMessages(chatRoomId: UUID) {
+        guard !isLoadingOlder, let cursor = olderCursor else { return }
+        isLoadingOlder = true
+
+        chatUseCase.fetchOlderMessages(chatRoomId: chatRoomId, before: cursor)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] page in
+                    guard let self else { return }
+                    self.isLoadingOlder = false
+                    guard !page.messages.isEmpty else {
+                        self.olderCursor = nil
+                        return
+                    }
+                    self.messages.insert(contentsOf: page.messages, at: 0)
+                    self.olderCursor = page.nextCursor
+                },
+                onFailure: { [weak self] _ in self?.isLoadingOlder = false }
+            )
+            .disposed(by: disposeBag)
+    }
+
     /// 메시지 전송
     ///
     /// 화면에 먼저 붙이고(.sending) 결과에 따라 .sent / .failed 로 바꿉니다.
     /// 실패한 메시지를 목록에서 지우지 않아야 사용자가 재전송할 수 있습니다.
     func sendMessage(chatRoomId: UUID) {
         let text = messageText.trimmed
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty, !isOverMessageLimit else { return }
 
         let pending = Message(
             chatRoomId: chatRoomId,

--- a/HiTrip/Features/Chat/ViewModels/VoiceRecorder.swift
+++ b/HiTrip/Features/Chat/ViewModels/VoiceRecorder.swift
@@ -1,0 +1,102 @@
+import Foundation
+import AVFoundation
+
+// MARK: - VoiceRecorder
+/// 꾹 눌러 녹음 — 떼면 파일을 돌려줍니다.
+///
+/// 서버 제한과 동일하게 최대 3분에서 스스로 멈춥니다.
+/// 마이크 권한이 없으면 시작하지 않고 이유를 알려줍니다.
+
+@MainActor
+final class VoiceRecorder: NSObject, ObservableObject {
+
+    enum StartResult {
+        case started
+        case permissionDenied
+        case failed
+    }
+
+    @Published private(set) var isRecording = false
+    @Published private(set) var elapsed: TimeInterval = 0
+
+    /// 서버 duration 상한과 같습니다
+    let maxDuration: TimeInterval = 180
+
+    private var recorder: AVAudioRecorder?
+    private var timer: Timer?
+    private var fileURL: URL?
+
+    /// 권한을 확인하고 녹음을 시작합니다.
+    func start() async -> StartResult {
+        let granted = await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { continuation.resume(returning: $0) }
+        }
+        guard granted else { return .permissionDenied }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice_\(UUID().uuidString).m4a")
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+        ]
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .default)
+            try session.setActive(true)
+
+            let recorder = try AVAudioRecorder(url: url, settings: settings)
+            recorder.record(forDuration: maxDuration)
+
+            self.recorder = recorder
+            self.fileURL = url
+            self.isRecording = true
+            self.elapsed = 0
+            startTimer()
+            return .started
+        } catch {
+            return .failed
+        }
+    }
+
+    /// 녹음을 멈추고 (파일, 길이)를 돌려줍니다. 너무 짧으면 nil입니다.
+    func stop() -> (data: Data, duration: Int)? {
+        defer { cleanUp() }
+
+        guard let recorder, let fileURL else { return nil }
+        let duration = Int(recorder.currentTime.rounded())
+        recorder.stop()
+
+        // 손이 스친 정도(1초 미만)는 보내지 않습니다
+        guard duration >= 1, let data = try? Data(contentsOf: fileURL) else { return nil }
+        return (data, min(duration, Int(maxDuration)))
+    }
+
+    func cancel() {
+        recorder?.stop()
+        cleanUp()
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, let recorder = self.recorder else { return }
+                self.elapsed = recorder.currentTime
+            }
+        }
+    }
+
+    private func cleanUp() {
+        timer?.invalidate()
+        timer = nil
+        recorder = nil
+        fileURL = nil
+        isRecording = false
+        elapsed = 0
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/HiTrip/Features/Chat/Views/ChatBubbleView.swift
+++ b/HiTrip/Features/Chat/Views/ChatBubbleView.swift
@@ -57,12 +57,21 @@ struct ChatBubbleView: View {
     }
 
     private var bubble: some View {
-        Text(message.content)
-            .font(.system(size: 14))
-            .lineSpacing(6)
-            .foregroundColor(textColor)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(message.attachments) { attachment in
+                attachmentView(attachment)
+            }
+
+            if !message.content.isEmpty {
+                Text(message.content)
+                    .font(.system(size: 14))
+                    .lineSpacing(6)
+                    .foregroundColor(textColor)
+            }
+        }
+            // 사진만 보낸 메시지는 여백을 줄여 사진이 말풍선을 채우게 합니다
+            .padding(.horizontal, isPhotoOnly ? 4 : 12)
+            .padding(.vertical, isPhotoOnly ? 4 : 10)
             .background(bubbleColor)
             .clipShape(bubbleShape)
             .opacity(message.isSending ? 0.6 : 1)
@@ -78,6 +87,43 @@ struct ChatBubbleView: View {
             bottomTrailingRadius: 0,
             topTrailingRadius: 12
         )
+    }
+
+    /// 사진은 그대로, 동영상·음성은 아이콘 줄로 보여줍니다.
+    @ViewBuilder
+    private func attachmentView(_ attachment: MessageAttachment) -> some View {
+        if attachment.isPhoto {
+            AsyncImage(url: attachment.downloadUrl.flatMap(URL.init)) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                Rectangle().fill(Color(hex: "#E5E7EB"))
+            }
+            .frame(width: 180, height: 180)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        } else {
+            HStack(spacing: 8) {
+                Image(systemName: attachment.isVideo ? "play.rectangle.fill" : "waveform")
+                    .font(.system(size: 16))
+                Text(attachmentLabel(attachment))
+                    .font(.system(size: 13))
+            }
+            .foregroundColor(textColor)
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func attachmentLabel(_ attachment: MessageAttachment) -> String {
+        if attachment.isAudio {
+            let seconds = attachment.duration ?? 0
+            return String(format: "음성 %d:%02d", seconds / 60, seconds % 60)
+        }
+        return attachment.originalName ?? "동영상"
+    }
+
+    /// 사진 한 장만 있고 본문이 없는 메시지
+    private var isPhotoOnly: Bool {
+        message.content.isEmpty && message.attachments.allSatisfy(\.isPhoto)
+            && !message.attachments.isEmpty
     }
 
     private var bubbleColor: Color {

--- a/HiTrip/Features/Chat/Views/ChatRoomView.swift
+++ b/HiTrip/Features/Chat/Views/ChatRoomView.swift
@@ -18,6 +18,12 @@ struct ChatRoomView: View {
     /// 입력창 포커스 — 대화 영역을 누르면 키보드를 내립니다
     @FocusState private var isInputFocused: Bool
 
+    /// 전송 실패 메시지를 탭했을 때 뜨는 선택 시트
+    @State private var failedMessageId: UUID?
+
+    /// 상대 연락처 — 없으면 전화 버튼을 숨깁니다 (서버가 아직 주지 않습니다)
+    var peerPhoneNumber: String?
+
     private var chatMessages: [ChatMessage] {
         viewModel.messages.map { $0.toChatMessage(currentUserId: viewModel.currentUserId) }
     }
@@ -33,6 +39,24 @@ struct ChatRoomView: View {
         .background(Color.white)
         .navigationBarHidden(true)
         .onTapGesture { isInputFocused = false }
+        .confirmationDialog(
+            "전송하지 못한 메시지",
+            isPresented: Binding(
+                get: { failedMessageId != nil },
+                set: { if !$0 { failedMessageId = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("재전송") {
+                if let id = failedMessageId { viewModel.retry(messageId: id) }
+                failedMessageId = nil
+            }
+            Button("삭제", role: .destructive) {
+                if let id = failedMessageId { viewModel.discard(messageId: id) }
+                failedMessageId = nil
+            }
+            Button("취소", role: .cancel) { failedMessageId = nil }
+        }
         .onAppear {
             viewModel.fetchMessages(chatRoomId: chatRoom.id)
             viewModel.markAsRead(chatRoomId: chatRoom.id)
@@ -74,9 +98,9 @@ struct ChatRoomView: View {
 
             Spacer(minLength: 8)
 
-            // 전화 버튼 (개인톡만)
-            if !chatRoom.isGroupChat {
-                Button { } label: {
+            // 전화 버튼 — 개인톡이면서 번호가 등록돼 있을 때만 노출합니다
+            if !chatRoom.isGroupChat, let phone = peerPhoneNumber, !phone.isEmpty {
+                Button { dial(phone) } label: {
                     Image(systemName: "phone")
                         .font(.system(size: 17))
                         .foregroundColor(Color(hex: "#1B1E28"))
@@ -94,6 +118,13 @@ struct ChatRoomView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 14) {
+                    // 맨 위에 닿으면 과거 30개를 더 불러옵니다
+                    if viewModel.hasOlderMessages {
+                        ProgressView()
+                            .padding(.vertical, 8)
+                            .onAppear { viewModel.loadOlderMessages(chatRoomId: chatRoom.id) }
+                    }
+
                     ForEach(Array(chatMessages.enumerated()), id: \.element.id) { index, msg in
                         // 날짜가 바뀌는 지점마다 구분선을 넣습니다.
                         if let label = dateSeparator(at: index) {
@@ -102,7 +133,7 @@ struct ChatRoomView: View {
                         }
 
                         ChatBubbleView(message: msg) {
-                            viewModel.retry(messageId: UUID(uuidString: msg.id) ?? UUID())
+                            failedMessageId = UUID(uuidString: msg.id)
                         }
                         .id(msg.id)
                     }
@@ -137,6 +168,14 @@ struct ChatRoomView: View {
         return f.string(from: current)
     }
 
+    /// OS 다이얼러로 넘깁니다 (인앱 통화가 아닙니다)
+    private func dial(_ number: String) {
+        let digits = number.filter { $0.isNumber || $0 == "+" }
+        guard let url = URL(string: "tel://\(digits)"),
+              UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url)
+    }
+
     // MARK: - Input Bar
 
     private var inputBar: some View {
@@ -150,19 +189,35 @@ struct ChatRoomView: View {
             .padding(.leading, 18)
 
             // 텍스트 입력
-            TextField("메시지를 입력하세요", text: $viewModel.messageText)
-                .focused($isInputFocused)
-                .font(.system(size: 16))
-                .foregroundColor(Color(hex: "#1B1E28"))
-                .padding(.horizontal, 14)
-                .frame(height: 48)
-                .background(Color(hex: "#F7F7F9"))
-                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                .padding(.leading, 11)
+            //
+            // 입력 중에 잘라내면 조합형 문자(한/일/중) 입력이 깨지므로
+            // 자르지 않고 초과분을 빨간 카운터로 알리고 전송만 막습니다.
+            VStack(alignment: .trailing, spacing: 2) {
+                TextField("메시지를 입력하세요", text: $viewModel.messageText)
+                    .focused($isInputFocused)
+                    .font(.system(size: 16))
+                    .foregroundColor(Color(hex: "#1B1E28"))
+                    .padding(.horizontal, 14)
+                    .frame(height: 48)
+                    .background(Color(hex: "#F7F7F9"))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(viewModel.isOverMessageLimit ? Color(hex: "#EF4444") : .clear, lineWidth: 1)
+                    )
+
+                if viewModel.messageText.count > viewModel.messageLimit - 100 {
+                    Text("\(viewModel.messageText.count)/\(viewModel.messageLimit)")
+                        .font(.system(size: 11, weight: viewModel.isOverMessageLimit ? .bold : .regular))
+                        .foregroundColor(viewModel.isOverMessageLimit
+                                         ? Color(hex: "#EF4444") : Color(hex: "#7D848D"))
+                }
+            }
+            .padding(.leading, 11)
 
             // 전송 / 마이크 버튼
             Button {
-                if !viewModel.messageText.isEmpty {
+                if !viewModel.messageText.isEmpty, !viewModel.isOverMessageLimit {
                     viewModel.sendMessage(chatRoomId: chatRoom.id)
                 }
             } label: {
@@ -170,9 +225,11 @@ struct ChatRoomView: View {
                     .font(.system(size: viewModel.messageText.isEmpty ? 18 : 16, weight: .semibold))
                     .foregroundColor(.white)
                     .frame(width: 48, height: 48)
-                    .background(Color(hex: "#0C46C0"))
+                    .background(viewModel.isOverMessageLimit
+                                ? Color(hex: "#C3CDDA") : Color(hex: "#0C46C0"))
                     .clipShape(Circle())
             }
+            .disabled(viewModel.isOverMessageLimit)
             .padding(.leading, 14)
             .padding(.trailing, 21)
         }

--- a/HiTrip/Features/Chat/Views/ChatRoomView.swift
+++ b/HiTrip/Features/Chat/Views/ChatRoomView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import PhotosUI
+import AVFoundation
 
 // MARK: - ChatRoomView
 /// 채팅방 내부 화면
@@ -24,6 +26,15 @@ struct ChatRoomView: View {
     /// 상대 연락처 — 없으면 전화 버튼을 숨깁니다 (서버가 아직 주지 않습니다)
     var peerPhoneNumber: String?
 
+    /// 첨부
+    @State private var showAttachmentOptions = false
+    @State private var photoItem: PhotosPickerItem?
+    @State private var showPhotoPicker = false
+    @State private var showPermissionGuide = false
+
+    /// 음성 녹음
+    @StateObject private var recorder = VoiceRecorder()
+
     private var chatMessages: [ChatMessage] {
         viewModel.messages.map { $0.toChatMessage(currentUserId: viewModel.currentUserId) }
     }
@@ -39,6 +50,27 @@ struct ChatRoomView: View {
         .background(Color.white)
         .navigationBarHidden(true)
         .onTapGesture { isInputFocused = false }
+        .confirmationDialog("첨부", isPresented: $showAttachmentOptions, titleVisibility: .visible) {
+            Button("사진·동영상") { showPhotoPicker = true }
+            Button("취소", role: .cancel) { }
+        }
+        .photosPicker(isPresented: $showPhotoPicker, selection: $photoItem, matching: .any(of: [.images, .videos]))
+        .onChange(of: photoItem) { _, item in
+            guard let item else { return }
+            Task { await attach(item) }
+        }
+        .alert("권한이 필요해요", isPresented: $showPermissionGuide) {
+            Button("설정 이동") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("닫기", role: .cancel) { }
+        } message: {
+            Text("설정에서 사진·마이크 접근을 허용해주세요")
+        }
+        .overlay(alignment: .bottom) { toastView }
+        .overlay(alignment: .top) { offlineBanner }
         .confirmationDialog(
             "전송하지 못한 메시지",
             isPresented: Binding(
@@ -168,6 +200,81 @@ struct ChatRoomView: View {
         return f.string(from: current)
     }
 
+    // MARK: - 첨부 / 녹음
+
+    /// 고른 사진·동영상을 올립니다. 용량 초과는 ViewModel이 걸러 안내합니다.
+    private func attach(_ item: PhotosPickerItem) async {
+        defer { photoItem = nil }
+
+        guard let data = try? await item.loadTransferable(type: Data.self) else {
+            viewModel.toast = "첨부하지 못했어요"
+            return
+        }
+
+        let isVideo = item.supportedContentTypes.contains { $0.conforms(to: .movie) }
+        viewModel.sendAttachment(
+            chatRoomId: chatRoom.id,
+            data: data,
+            mediaType: isVideo ? "video" : "photo",
+            fileName: isVideo ? "video.mp4" : "photo.jpg",
+            mimeType: isVideo ? "video/mp4" : "image/jpeg"
+        )
+    }
+
+    private func beginRecording() async {
+        switch await recorder.start() {
+        case .started:          break
+        case .permissionDenied: showPermissionGuide = true
+        case .failed:           viewModel.toast = "녹음을 시작하지 못했어요"
+        }
+    }
+
+    private func finishRecording() {
+        guard recorder.isRecording else { return }
+        guard let result = recorder.stop() else { return }
+
+        viewModel.sendAttachment(
+            chatRoomId: chatRoom.id,
+            data: result.data,
+            mediaType: "audio",
+            fileName: "voice.m4a",
+            mimeType: "audio/mp4",
+            duration: result.duration
+        )
+    }
+
+    // MARK: - 배너 / 토스트
+
+    @ViewBuilder
+    private var offlineBanner: some View {
+        if viewModel.isOffline {
+            Text("연결이 끊겼어요. 다시 연결되면 보낼게요")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 32)
+                .background(Color(hex: "#6B7280"))
+        }
+    }
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 90)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
+        }
+    }
+
     /// OS 다이얼러로 넘깁니다 (인앱 통화가 아닙니다)
     private func dial(_ number: String) {
         let digits = number.filter { $0.isNumber || $0 == "+" }
@@ -181,11 +288,19 @@ struct ChatRoomView: View {
     private var inputBar: some View {
         HStack(spacing: 0) {
             // + 첨부 버튼
-            Button { } label: {
-                Text("＋")
-                    .font(.system(size: 22))
-                    .foregroundColor(Color(hex: "#6B7280"))
+            Button { showAttachmentOptions = true } label: {
+                Group {
+                    if viewModel.isUploading {
+                        ProgressView()
+                    } else {
+                        Text("＋")
+                            .font(.system(size: 22))
+                            .foregroundColor(Color(hex: "#6B7280"))
+                    }
+                }
+                .frame(width: 22, height: 22)
             }
+            .disabled(viewModel.isUploading)
             .padding(.leading, 18)
 
             // 텍스트 입력
@@ -221,15 +336,31 @@ struct ChatRoomView: View {
                     viewModel.sendMessage(chatRoomId: chatRoom.id)
                 }
             } label: {
-                Image(systemName: viewModel.messageText.isEmpty ? "mic.fill" : "arrow.up")
+                Image(systemName: recorder.isRecording
+                      ? "stop.fill"
+                      : (viewModel.messageText.isEmpty ? "mic.fill" : "arrow.up"))
                     .font(.system(size: viewModel.messageText.isEmpty ? 18 : 16, weight: .semibold))
                     .foregroundColor(.white)
                     .frame(width: 48, height: 48)
-                    .background(viewModel.isOverMessageLimit
-                                ? Color(hex: "#C3CDDA") : Color(hex: "#0C46C0"))
+                    .background(recorder.isRecording
+                                ? Color(hex: "#EF4444")
+                                : (viewModel.isOverMessageLimit
+                                   ? Color(hex: "#C3CDDA") : Color(hex: "#0C46C0")))
                     .clipShape(Circle())
             }
             .disabled(viewModel.isOverMessageLimit)
+            // 입력이 비어 있을 때만 꾹 눌러 녹음합니다 (떼면 전송)
+            .simultaneousGesture(
+                LongPressGesture(minimumDuration: 0.3)
+                    .onEnded { _ in
+                        guard viewModel.messageText.isEmpty else { return }
+                        Task { await beginRecording() }
+                    }
+            )
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onEnded { _ in finishRecording() }
+            )
             .padding(.leading, 14)
             .padding(.trailing, 21)
         }

--- a/HiTrip/Features/Chat/Views/ChatRoomView.swift
+++ b/HiTrip/Features/Chat/Views/ChatRoomView.swift
@@ -42,9 +42,9 @@ struct ChatRoomView: View {
     var body: some View {
         VStack(spacing: 0) {
             navigationBar
-            Divider()
+            separator
             messageList
-            Divider()
+            separator
             inputBar
         }
         .background(Color.white)
@@ -93,6 +93,14 @@ struct ChatRoomView: View {
             viewModel.fetchMessages(chatRoomId: chatRoom.id)
             viewModel.markAsRead(chatRoomId: chatRoom.id)
         }
+    }
+
+    /// 구분선 — Figma는 #F7F7F9 1.5pt입니다.
+    /// SwiftUI 기본 Divider는 시스템 separator라 훨씬 진하게 보입니다.
+    private var separator: some View {
+        Rectangle()
+            .fill(Color(hex: "#F7F7F9"))
+            .frame(height: 1.5)
     }
 
     // MARK: - Navigation Bar

--- a/HiTrip/Features/Chat/Views/TouristChatListView.swift
+++ b/HiTrip/Features/Chat/Views/TouristChatListView.swift
@@ -19,9 +19,17 @@ struct TouristChatListView: View {
     /// 검색창 포커스 — 목록을 누르면 키보드를 내립니다
     @FocusState private var isSearchFocused: Bool
 
+    /// 단체톡방을 맨 위에 고정하고, 나머지는 마지막 메시지 최신순입니다.
+    private var sortedRooms: [ChatRoom] {
+        viewModel.chatRooms.sorted { a, b in
+            if a.isGroupChat != b.isGroupChat { return a.isGroupChat }
+            return a.lastMessageDate > b.lastMessageDate
+        }
+    }
+
     private var filteredRooms: [ChatRoom] {
-        guard !searchText.isEmpty else { return viewModel.chatRooms }
-        return viewModel.chatRooms.filter {
+        guard !searchText.isEmpty else { return sortedRooms }
+        return sortedRooms.filter {
             $0.participantName.localizedCaseInsensitiveContains(searchText) ||
             $0.lastMessage.localizedCaseInsensitiveContains(searchText)
         }
@@ -148,9 +156,10 @@ struct TouristChatListView: View {
                     .foregroundColor(Color(hex: "#6B7280"))
 
                 if room.unreadCount > 0 {
-                    Text("\(room.unreadCount)")
+                    Text(room.unreadCount > 99 ? "99+" : "\(room.unreadCount)")
                         .font(.system(size: 12, weight: .bold))
                         .foregroundColor(.white)
+                        .padding(.horizontal, 6)
                         .frame(minWidth: 22, minHeight: 22)
                         .background(Color(hex: "#EF4444"))
                         .clipShape(Capsule())
@@ -173,7 +182,7 @@ struct TouristChatListView: View {
             Image(systemName: isSearching ? "magnifyingglass" : "bubble.left.and.bubble.right")
                 .font(.system(size: 40))
                 .foregroundColor(Color(hex: "#D1D5DB"))
-            Text(isSearching ? "검색 결과가 없습니다" : "메시지가 없습니다")
+            Text(isSearching ? "검색 결과가 없어요" : "메시지가 없어요")
                 .font(.system(size: 15, weight: .medium))
                 .foregroundColor(Color(hex: "#111827"))
             Text(isSearching
@@ -188,14 +197,14 @@ struct TouristChatListView: View {
         .frame(maxWidth: .infinity)
     }
 
-    /// 오늘이면 시각, 어제면 "어제", 그 이전은 날짜
+    /// 오늘=HH:mm, 어제="어제", 그 이전=M.D
     private func formatTime(_ date: Date) -> String {
         let cal = Calendar.current
         if cal.isDateInYesterday(date) { return "어제" }
 
         let f = DateFormatter()
         f.locale = Locale(identifier: "ko_KR")
-        f.dateFormat = cal.isDateInToday(date) ? "a h:mm" : "M/d"
+        f.dateFormat = cal.isDateInToday(date) ? "HH:mm" : "M.d"
         return f.string(from: date)
     }
 }

--- a/HiTrip/Features/Chat/Views/TouristChatListView.swift
+++ b/HiTrip/Features/Chat/Views/TouristChatListView.swift
@@ -118,7 +118,10 @@ struct TouristChatListView: View {
                     }
                     .buttonStyle(.plain)
 
-                    Divider()
+                    // Figma 구분선 #E5E7EB 1pt — 기본 Divider는 시스템 색이라 더 진합니다
+                    Rectangle()
+                        .fill(Color(hex: "#E5E7EB"))
+                        .frame(height: 1)
                         .padding(.horizontal, 24)
                 }
             }

--- a/HiTrip/Features/Emergency/Views/EmergencyCallDialog.swift
+++ b/HiTrip/Features/Emergency/Views/EmergencyCallDialog.swift
@@ -1,10 +1,18 @@
 import SwiftUI
+import RxSwift
 
 // MARK: - EmergencyCallDialog
 /// 긴급 통역 연결 — 홈의 "긴급 즉시 연락" 버튼으로 뜨는 팝업
 ///
 /// 별도 화면이 아니라 홈 위에 겹쳐 띄웁니다.
-/// 전화번호는 홈 응답의 manager_contact에서 받아 tel: 링크로 겁니다.
+/// 긴급 버튼이라 한 번 탭에 바로 걸지 않고 이 확인 단계를 거칩니다 (오발신 방지).
+///
+/// 전화하기를 누르면
+/// 1) POST /api/v1/tourist/emergency-requests/ 로 담당 안내사에게 요청을 남기고
+/// 2) OS 다이얼러로 넘깁니다 (인앱 통화가 아닙니다)
+///
+/// 통역 센터 번호와 운영시간은 아직 확정 전이라, 번호는 홈 응답의
+/// manager_contact를, 운영시간은 아래 기본값을 씁니다.
 
 struct EmergencyCallDialog: View {
 
@@ -12,7 +20,28 @@ struct EmergencyCallDialog: View {
 
     /// 연결할 전화번호. 없으면 "전화하기"를 누를 수 없습니다.
     var phoneNumber: String?
-    var operatingHours: String = "09:00 - 22:00"
+    /// 운영 시작·종료 시각 (현지 기준, 24시간)
+    var openHour: Int = 9
+    var closeHour: Int = 22
+    /// "안내사에게 메시지" — 메시지 목록으로 보냅니다
+    var onMessageGuide: (() -> Void)?
+
+    @State private var isSending = false
+    private let disposeBag = DisposeBag()
+
+    private var repository: TravelerRepositoryProtocol {
+        AppDIContainer.shared.travelerRepositoryForHome
+    }
+
+    /// 운영시간 안이면 전화 안내, 밖이면 대체 동선을 보여줍니다
+    private var isWithinOperatingHours: Bool {
+        let hour = Calendar.current.component(.hour, from: Date())
+        return hour >= openHour && hour < closeHour
+    }
+
+    private var operatingHoursText: String {
+        String(format: "%02d:00 - %02d:00", openHour, closeHour)
+    }
 
     var body: some View {
         ZStack {
@@ -31,16 +60,20 @@ struct EmergencyCallDialog: View {
                 .foregroundColor(Color(hex: "#EF4444"))
                 .padding(.top, 24)
 
-            Text("긴급 통역 연결")
+            Text(isWithinOperatingHours ? "긴급 통역 연결" : "지금은 연결이 어려워요")
                 .font(.system(size: 18, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
                 .padding(.top, 16)
 
             VStack(spacing: 2) {
-                Text(canCall
-                     ? "통역사에게 바로 전화를 연결할까요?"
-                     : "연결할 수 있는 번호가 없습니다")
-                Text("운영시간 \(operatingHours) (현지 기준)")
+                if !isWithinOperatingHours {
+                    Text("통역 센터 운영시간이 아닙니다")
+                } else if canCall {
+                    Text("통역사에게 바로 전화를 연결할까요?")
+                } else {
+                    Text("연결할 수 있는 번호가 없습니다")
+                }
+                Text("운영시간 \(operatingHoursText) (현지 기준)")
             }
             .font(.system(size: 13))
             .foregroundColor(Color(hex: "#333840"))
@@ -59,17 +92,40 @@ struct EmergencyCallDialog: View {
                 }
                 .buttonStyle(.plain)
 
-                Button { call() } label: {
-                    Text("전화하기")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundColor(.white)
+                if isWithinOperatingHours {
+                    Button { call() } label: {
+                        Group {
+                            if isSending {
+                                ProgressView().tint(.white)
+                            } else {
+                                Text("전화하기")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundColor(.white)
+                            }
+                        }
                         .frame(maxWidth: .infinity)
                         .frame(height: 48)
                         .background(canCall ? Color(hex: "#EF4444") : Color(hex: "#C3CDDA"))
                         .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!canCall || isSending)
+                } else {
+                    // 운영시간 밖에는 담당 안내사에게 메시지를 보내도록 유도합니다
+                    Button {
+                        isPresented = false
+                        onMessageGuide?()
+                    } label: {
+                        Text("안내사에게 메시지")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(Color(hex: "#2563EB"))
+                            .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
-                .disabled(!canCall)
             }
             .padding(.horizontal, 20)
             .padding(.top, 22)
@@ -85,15 +141,32 @@ struct EmergencyCallDialog: View {
         return !phoneNumber.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    /// 전화 앱으로 넘깁니다. 시뮬레이터에는 전화 앱이 없어 동작하지 않습니다.
+    /// 안내사에게 요청을 남기고 전화 앱으로 넘깁니다.
+    /// 요청 전송이 실패해도 전화는 겁니다 — 긴급 상황에서 발신이 막히면 안 됩니다.
     private func call() {
         guard let phoneNumber else { return }
-        let digits = phoneNumber.filter { $0.isNumber || $0 == "+" }
-        guard let url = URL(string: "tel://\(digits)"), UIApplication.shared.canOpenURL(url) else {
-            isPresented = false
-            return
+        isSending = true
+
+        repository.sendEmergencyRequest(
+            message: "긴급 통역을 요청했습니다",
+            latitude: nil,
+            longitude: nil,
+            accuracyM: nil
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { _ in dial(phoneNumber) },
+            onFailure: { _ in dial(phoneNumber) }
+        )
+        .disposed(by: disposeBag)
+    }
+
+    private func dial(_ number: String) {
+        isSending = false
+        let digits = number.filter { $0.isNumber || $0 == "+" }
+        if let url = URL(string: "tel://\(digits)"), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
         }
-        UIApplication.shared.open(url)
         isPresented = false
     }
 }

--- a/HiTrip/Features/Schedule/ViewModels/LocalLanguageViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/LocalLanguageViewModel.swift
@@ -24,6 +24,9 @@ final class LocalLanguageViewModel: NSObject, ObservableObject {
     /// 지금 읽고 있는 표현 id — 버튼 모양(▶/■) 전환에 사용
     @Published private(set) var speakingId: Int?
 
+    /// 재생 실패 안내 — "재생할 수 없어요"
+    @Published var toast: String?
+
     private let repository: TravelerRepositoryProtocol
     private let disposeBag = DisposeBag()
     private let synthesizer = AVSpeechSynthesizer()
@@ -81,11 +84,20 @@ final class LocalLanguageViewModel: NSObject, ObservableObject {
     }
 
     private func speak(_ phrase: LocalPhraseDTO) {
+        // 읽을 문장이 없거나 해당 언어 음성이 기기에 없으면 소리 없이 끝나므로,
+        // 시도하기 전에 걸러서 안내합니다.
+        let text = phrase.translatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, let voice = Self.voice(for: data?.languageCode) else {
+            speakingId = nil
+            toast = "재생할 수 없어요"
+            return
+        }
+
         configureAudioSession()
         synthesizer.stopSpeaking(at: .immediate)
 
-        let utterance = AVSpeechUtterance(string: phrase.translatedText)
-        utterance.voice = Self.voice(for: data?.languageCode)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = voice
         utterance.rate = 0.45
 
         speakingId = phrase.id

--- a/HiTrip/Features/Schedule/ViewModels/NearbySpotViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/NearbySpotViewModel.swift
@@ -1,0 +1,250 @@
+import Foundation
+import CoreLocation
+import RxSwift
+
+// MARK: - NearbySpotViewModel
+/// 주변 인기 스팟 (지도)
+///
+/// - GET /api/v1/tourist/nearby-spots/?category=&lat=&lng=  상황별 검색
+/// - GET /api/v1/tourist/safety/summary/                    지오펜스(허용 반경)
+/// - POST /api/v1/tourist/safety/location/                  위치 스냅샷 전송
+///
+/// 이탈 판정은 앱이 직접 합니다. 경계 밖에 연속 60초 머무르면 배너를 띄우고,
+/// 안내사 알림은 서버가 위치 스냅샷을 받아 처리합니다.
+
+@MainActor
+final class NearbySpotViewModel: NSObject, ObservableObject {
+
+    // MARK: - 카테고리
+
+    /// 서버 enum과 화면 문구를 짝지어 둡니다.
+    /// 기획의 6종 중 "할랄"은 서버 enum에 없어 빠져 있습니다.
+    enum Category: String, CaseIterable, Identifiable {
+        case restaurant    = "restaurant"
+        case accessibility = "accessibility"
+        case pet           = "pet"
+        case convenience   = "convenience"
+        case mart          = "mart"
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .restaurant:    return "음식점"
+            case .accessibility: return "무장애"
+            case .pet:           return "반려동물"
+            case .convenience:   return "편의점"
+            case .mart:          return "마트"
+            }
+        }
+    }
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var spots: [TravelerNearbySpotDTO] = []
+    @Published var selectedCategory: Category = .restaurant
+    @Published var focusedSpotId: String?
+
+    /// 지오펜스(허용 반경) — 없으면 지도에 원을 그리지 않습니다
+    @Published private(set) var geofence: TravelerGeofenceDTO?
+
+    /// 현재 위치와 수평 오차(m)
+    @Published private(set) var currentLocation: CLLocationCoordinate2D?
+    @Published private(set) var accuracyM: Double?
+    @Published private(set) var authorizationDenied = false
+
+    /// 안전 구역을 벗어난 상태 — 상단 경고 배너
+    @Published private(set) var isOutsideGeofence = false
+
+    /// GPS 오차가 큰 상태 — "정확도 낮음" 칩
+    var isAccuracyLow: Bool { (accuracyM ?? 0) > 50 }
+
+    // MARK: - Dependencies
+
+    private let repository: TravelerRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private let locationManager = CLLocationManager()
+
+    /// 경계 밖에서 머물기 시작한 시각 — 연속 60초를 재기 위한 기준
+    private var outsideSince: Date?
+    /// 위치 스냅샷을 서버로 보낸 마지막 시각 (30초 간격)
+    private var lastSnapshotAt: Date?
+
+    private let outsideThreshold: TimeInterval = 60
+    private let snapshotInterval: TimeInterval = 30
+
+    init(repository: TravelerRepositoryProtocol = AppDIContainer.shared.travelerRepositoryForHome) {
+        self.repository = repository
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.distanceFilter = 10
+    }
+
+    // MARK: - Load
+
+    func onAppear() {
+        requestLocationPermission()
+        loadGeofence()
+    }
+
+    func onDisappear() {
+        locationManager.stopUpdatingLocation()
+    }
+
+    private func requestLocationPermission() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .denied, .restricted:
+            authorizationDenied = true
+        default:
+            authorizationDenied = false
+            locationManager.startUpdatingLocation()
+        }
+    }
+
+    private func loadGeofence() {
+        repository.fetchSafetySummary()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] summary in self?.geofence = summary.geofence },
+                       onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    /// 선택한 카테고리로 주변 스팟을 불러옵니다.
+    func loadSpots() {
+        guard let center = currentLocation ?? geofenceCenter else { return }
+        state = .loading
+
+        repository.fetchNearbySpots(
+            category: selectedCategory.rawValue,
+            lat: center.latitude,
+            lng: center.longitude,
+            radius: nil
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] spots in
+                guard let self else { return }
+                // 안내사 설정(광고) 스팟이 1순위, 그다음 거리순입니다.
+                self.spots = spots.sorted { a, b in
+                    if (a.isSponsored == true) != (b.isSponsored == true) { return a.isSponsored == true }
+                    return (a.distanceM ?? .max) < (b.distanceM ?? .max)
+                }
+                self.focusedSpotId = self.spots.first?.id
+                self.state = .loaded
+            },
+            onFailure: { [weak self] error in
+                self?.state = .failed(Self.message(for: error))
+            }
+        )
+        .disposed(by: disposeBag)
+    }
+
+    /// 칩 재탭이면 해제 대신 같은 카테고리를 유지합니다.
+    /// 서버가 category를 필수로 받아 "전체" 조회가 없기 때문입니다.
+    func select(_ category: Category) {
+        guard selectedCategory != category else { return }
+        selectedCategory = category
+        loadSpots()
+    }
+
+    // MARK: - 지오펜스
+
+    private var geofenceCenter: CLLocationCoordinate2D? {
+        guard let lat = geofence?.latitude, let lng = geofence?.longitude else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    }
+
+    /// 경계 밖에 연속 60초 이상 머물렀는지 판정합니다.
+    /// GPS 오차만큼은 봐줍니다 (오차 버퍼 가산).
+    private func evaluateGeofence(for location: CLLocation) {
+        guard let center = geofenceCenter, let radius = geofence?.radiusM else {
+            isOutsideGeofence = false
+            outsideSince = nil
+            return
+        }
+
+        let distance = location.distance(from: CLLocation(latitude: center.latitude, longitude: center.longitude))
+        let buffer = max(location.horizontalAccuracy, 0)
+
+        if distance > radius + buffer {
+            if let since = outsideSince {
+                if Date().timeIntervalSince(since) >= outsideThreshold { isOutsideGeofence = true }
+            } else {
+                outsideSince = Date()
+            }
+        } else {
+            // 복귀하면 바로 해제합니다
+            outsideSince = nil
+            isOutsideGeofence = false
+        }
+    }
+
+    /// 서버에도 위치를 남깁니다 (안내사 알림·이탈 이력은 서버가 처리)
+    private func sendSnapshotIfNeeded(_ location: CLLocation) {
+        if let last = lastSnapshotAt, Date().timeIntervalSince(last) < snapshotInterval { return }
+        lastSnapshotAt = Date()
+
+        repository.sendLocationSnapshot(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            accuracyM: location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : nil
+        )
+        .subscribe(onSuccess: { _ in }, onFailure: { _ in })
+        .disposed(by: disposeBag)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .noConnection: return "연결을 확인해주세요"
+            case .timeout:      return "서버 응답이 없습니다"
+            default:            break
+            }
+        }
+        return "정보를 불러오지 못했어요"
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension NearbySpotViewModel: CLLocationManagerDelegate {
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        Task { @MainActor in
+            let isFirstFix = self.currentLocation == nil
+            self.currentLocation = location.coordinate
+            self.accuracyM = location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : nil
+            self.evaluateGeofence(for: location)
+            self.sendSnapshotIfNeeded(location)
+            // 첫 위치를 잡은 뒤에 주변 스팟을 부릅니다
+            if isFirstFix { self.loadSpots() }
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            switch status {
+            case .authorizedWhenInUse, .authorizedAlways:
+                self.authorizationDenied = false
+                manager.startUpdatingLocation()
+            case .denied, .restricted:
+                self.authorizationDenied = true
+            default:
+                break
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) { }
+}

--- a/HiTrip/Features/Schedule/ViewModels/TravelerHomeViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TravelerHomeViewModel.swift
@@ -44,6 +44,18 @@ final class TravelerHomeViewModel: ObservableObject {
 
     // MARK: - Load
 
+    /// 당겨서 새로고침 — 로딩 화면으로 되돌아가지 않고 값만 갱신합니다
+    func refresh() {
+        repository.fetchHome()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] dto in
+                self?.home = dto
+                self?.state = .loaded
+                self?.loadSecondary()
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
     func load() {
         guard state != .loading else { return }
         state = .loading
@@ -88,11 +100,16 @@ final class TravelerHomeViewModel: ObservableObject {
 
     var hasUnreadMessage: Bool { unreadMessageCount > 0 }
 
+    /// 뱃지 표기 — 세 자리부터는 99+로 줄입니다
+    var unreadMessageBadgeText: String {
+        unreadMessageCount > 99 ? "99+" : "\(unreadMessageCount)"
+    }
+
     private static func message(for error: Error) -> String {
         if let e = error as? HiTripError {
             switch e {
             case .unauthorized, .forbidden:  return "로그인이 필요합니다"
-            case .noConnection:              return "네트워크에 연결되어 있지 않습니다"
+            case .noConnection:              return "연결을 확인해주세요"
             case .timeout:                   return "서버 응답이 없습니다"
             case .notFound:                  return "배정된 여행이 없습니다"
             default:                         break
@@ -106,19 +123,56 @@ final class TravelerHomeViewModel: ObservableObject {
     var tripTitle: String { home?.trip.title ?? "" }
 
     /// 안 읽은 공지 수 — 0이면 뱃지를 숨깁니다.
-    var unreadNoticeCount: Int { notices.filter { $0.isRead != true }.count }
+    var unreadNoticeCount: Int { activeNotices.filter { $0.isRead != true }.count }
 
-    // MARK: - 여행 시작 전 / 진행 중
+    // MARK: - 여행 단계
 
-    /// 출발까지 남은 일수. 0 이하면 여행 중.
+    /// 홈이 어떤 형태로 보일지 결정합니다.
+    enum TripPhase: Equatable {
+        /// 출발 전 — D-day 카드만, 진행바·일정 카드 비노출
+        case before
+        /// 여행 중
+        case during
+        /// 종료 후 — 종료 안내와 계정 파기 예정일
+        case finished
+    }
+
+    /// 출발까지 남은 일수. 0 이하면 여행이 시작된 상태.
     var dDay: Int { home?.trip.dDay ?? 0 }
 
-    var isBeforeTrip: Bool { dDay > 0 }
+    var phase: TripPhase {
+        if dDay > 0 { return .before }
+        if let end = Self.date(from: home?.trip.endDate),
+           Calendar.current.startOfDay(for: Date()) > end {
+            return .finished
+        }
+        return .during
+    }
+
+    var isBeforeTrip: Bool { phase == .before }
 
     /// "D-3 · 2025.04.24 출발"
     var departureText: String {
         guard let trip = home?.trip else { return "" }
         return "D-\(trip.dDay) · \(Self.displayDate(trip.startDate)) 출발"
+    }
+
+    /// 여행 종료 후 계정이 파기되는 날 (종료일 + 3일)
+    var dataPurgeDateText: String {
+        guard let end = Self.date(from: home?.trip.endDate),
+              let purge = Calendar.current.date(byAdding: .day, value: 3, to: end) else { return "" }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "yyyy.MM.dd"
+        return f.string(from: purge)
+    }
+
+    private static func date(from string: String?) -> Date? {
+        guard let string else { return nil }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: string)
     }
 
     // MARK: - 오늘의 일정
@@ -199,19 +253,53 @@ final class TravelerHomeViewModel: ObservableObject {
     /// 기상청 API는 개인 키가 필요해 배포용으로 쓸 수 없어, 서버가 내려줄 때까지 목적지만 표시합니다.
     var destinationText: String { home?.trip.destination ?? "" }
 
-    /// 오늘 일정의 진행률 (0...1) — 진행률 바
-    var progress: Double {
-        let times = todaySchedules.compactMap { Self.minutes($0.startTime) }
-        let ends  = todaySchedules.compactMap { Self.minutes($0.endTime) }
-        guard let first = times.min(), let last = ends.max(), last > first else { return 0 }
+    /// 오늘 일정의 진행률 (0...1) — 진행 인디케이터
+    ///
+    /// 기획: 당일 첫 일정 시작 ~ 마지막 일정 종료 시각 대비 현재 시각 비율.
+    /// 시작 전 0%, 종료 후 100%로 고정합니다.
+    ///
+    /// 여행지 현지 시각이 기준이어야 하지만 API가 여행의 시간대를 주지 않아
+    /// 기기 시각으로 계산합니다 (국내 여행은 동일).
+    var todayProgress: Double {
+        let starts = todaySchedules.compactMap { Self.minutes($0.startTime) }
+        let ends   = todaySchedules.compactMap { Self.minutes($0.endTime) }
+        guard let first = starts.min(), let last = ends.max(), last > first else { return 0 }
         let now = Self.minutesNow()
         return min(max(Double(now - first) / Double(last - first), 0), 1)
     }
 
     // MARK: - 공지
 
-    /// 홈에 표시할 대표 공지 — 가장 최근 게시분
-    var representativeNotice: TravelerNoticeDTO? { notices.first }
+    /// 홈에 표시할 대표 공지 — 활성 공지 중 가장 최근 게시분
+    var representativeNotice: TravelerNoticeDTO? {
+        activeNotices.first
+    }
+
+    /// 대표 공지를 뺀 나머지 활성 공지 — 팝업의 "이전 공지 보기"
+    var previousNotices: [TravelerNoticeDTO] { Array(activeNotices.dropFirst()) }
+
+    /// 활성 공지만 — 홈 미리보기와 안 읽음 뱃지의 기준
+    private var activeNotices: [TravelerNoticeDTO] {
+        notices.filter { $0.isActive != false }
+    }
+
+    /// 공지를 열어봤을 때 — 서버에 읽음을 보내고 빨간 점을 지웁니다
+    func markNoticeRead(_ notice: TravelerNoticeDTO) {
+        guard notice.isRead != true else { return }
+        repository.markNoticeRead(id: notice.id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.reloadNotices() },
+                       onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    private func reloadNotices() {
+        repository.fetchNotices()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.notices = $0 },
+                       onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
 
     var hasUnreadNotice: Bool { unreadNoticeCount > 0 }
 

--- a/HiTrip/Features/Schedule/ViewModels/TravelerHomeViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TravelerHomeViewModel.swift
@@ -275,8 +275,12 @@ final class TravelerHomeViewModel: ObservableObject {
         activeNotices.first
     }
 
-    /// 대표 공지를 뺀 나머지 활성 공지 — 팝업의 "이전 공지 보기"
-    var previousNotices: [TravelerNoticeDTO] { Array(activeNotices.dropFirst()) }
+    /// 지난 공지 — 팝업의 "이전 공지 보기"
+    ///
+    /// 기획상 "비활성(과거) 공지 최신순"입니다. 활성 공지는 대표 1건으로만 보여줍니다.
+    var previousNotices: [TravelerNoticeDTO] {
+        notices.filter { $0.isActive == false }
+    }
 
     /// 활성 공지만 — 홈 미리보기와 안 읽음 뱃지의 기준
     private var activeNotices: [TravelerNoticeDTO] {

--- a/HiTrip/Features/Schedule/ViewModels/TripScheduleViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TripScheduleViewModel.swift
@@ -65,6 +65,9 @@ final class TripScheduleViewModel: ObservableObject {
     /// 방금 저장한 일정이 공용 일정과 겹쳤을 때 안내
     @Published var overlapNotice: String?
 
+    /// 저장 성공 토스트 문구
+    @Published var toast: String?
+
     private let repository: TravelerRepositoryProtocol
     private let disposeBag = DisposeBag()
 
@@ -137,7 +140,14 @@ final class TripScheduleViewModel: ObservableObject {
 
     /// - Parameters:
     ///   - start/end: "HH:mm" 형식
-    func addPersonalSchedule(dayNumber: Int, title: String, start: String, end: String, memo: String?) {
+    func addPersonalSchedule(
+        dayNumber: Int,
+        title: String,
+        start: String,
+        end: String,
+        memo: String?,
+        onSuccess: @escaping () -> Void
+    ) {
         guard let date = days.first(where: { $0.dayNumber == dayNumber })?.date, !date.isEmpty else {
             saveError = "일정을 추가할 날짜를 찾지 못했습니다"
             return
@@ -161,9 +171,56 @@ final class TripScheduleViewModel: ObservableObject {
                     self.isSaving = false
                     self.personal.append(created)
                     self.rebuild()
-                    if created.overlapWarning {
-                        self.overlapNotice = Self.overlapMessage(for: created, shared: self.shared)
+                    self.expandedDay = dayNumber
+                    self.toast = "일정이 추가되었어요"
+                    onSuccess()
+                },
+                onFailure: { [weak self] error in
+                    // 실패하면 시트를 닫지 않습니다. 입력값을 그대로 두고 재시도할 수 있어야 합니다.
+                    self?.isSaving = false
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 개인 일정 수정 — 스와이프 > 수정
+    func updatePersonalSchedule(
+        id: Int,
+        dayNumber: Int,
+        title: String,
+        start: String,
+        end: String,
+        memo: String?,
+        onSuccess: @escaping () -> Void
+    ) {
+        guard let date = days.first(where: { $0.dayNumber == dayNumber })?.date, !date.isEmpty else {
+            saveError = "일정을 수정할 날짜를 찾지 못했습니다"
+            return
+        }
+        isSaving = true
+
+        let request = TravelerPersonalScheduleRequest(
+            dayNumber: dayNumber,
+            scheduleDate: date,
+            title: title,
+            startTime: Self.withSeconds(start),
+            endTime: Self.withSeconds(end),
+            memo: memo
+        )
+
+        repository.updatePersonalSchedule(id: id, request)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] updated in
+                    guard let self else { return }
+                    self.isSaving = false
+                    if let idx = self.personal.firstIndex(where: { $0.id == id }) {
+                        self.personal[idx] = updated
                     }
+                    self.rebuild()
+                    self.toast = "일정이 수정되었어요"
+                    onSuccess()
                 },
                 onFailure: { [weak self] error in
                     self?.isSaving = false
@@ -171,6 +228,18 @@ final class TripScheduleViewModel: ObservableObject {
                 }
             )
             .disposed(by: disposeBag)
+    }
+
+    /// 입력 중 겹침 경고 — 저장 전에 공용 일정과 시간이 겹치는지 미리 봅니다.
+    /// 서버도 저장 시 overlap_warning을 돌려주지만, 기획상 경고는 입력 중에 떠야 합니다.
+    func overlapsSharedSchedule(dayNumber: Int, start: String, end: String) -> Bool {
+        guard let s = Self.minutes(start), let e = Self.minutes(end), s < e else { return false }
+        return shared
+            .filter { $0.dayNumber == dayNumber }
+            .contains { item in
+                guard let ss = Self.minutes(item.startTime), let se = Self.minutes(item.endTime) else { return false }
+                return s < se && ss < e
+            }
     }
 
     func deletePersonalSchedule(id: Int) {

--- a/HiTrip/Features/Schedule/Views/LocalLanguageView.swift
+++ b/HiTrip/Features/Schedule/Views/LocalLanguageView.swift
@@ -24,9 +24,32 @@ struct LocalLanguageView: View {
             }
         }
         .background(Color.white)
+        .overlay(alignment: .bottom) { toastView }
+        .animation(.easeInOut(duration: 0.2), value: viewModel.toast)
         .navigationBarHidden(true)
         .task { viewModel.load() }
         .onDisappear { viewModel.stop() }
+    }
+
+    // MARK: - 토스트
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 40)
+                .transition(.opacity)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
+        }
     }
 
     // MARK: - Header
@@ -146,10 +169,10 @@ struct LocalLanguageView: View {
             Image(systemName: "text.bubble")
                 .font(.system(size: 40))
                 .foregroundColor(Color(hex: "#D1D5DB"))
-            Text("등록된 표현이 없습니다")
+            Text("등록된 문구가 없어요")
                 .font(.system(size: 15, weight: .medium))
                 .foregroundColor(Color(hex: "#111827"))
-            Text("안내사가 현지 표현을 등록하면\n여기에 표시됩니다")
+            Text("안내사가 현지 문구를 등록하면\n여기에 표시됩니다")
                 .font(.system(size: 13))
                 .foregroundColor(Color(hex: "#6B7280"))
                 .multilineTextAlignment(.center)

--- a/HiTrip/Features/Schedule/Views/NearbySpotDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/NearbySpotDetailView.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 import MapKit
+import UIKit
+
+// MARK: - NearbySpotDetailView
+/// 스팟 상세
+///
+/// 서버가 주지 않는 값(별점·영업시간·거리)은 nil이면 해당 UI를 숨깁니다.
+/// 어드벤티지(혜택)는 API 자체가 없어 아직 표시하지 못합니다.
 
 struct NearbySpotDetailView: View {
 
@@ -14,6 +21,10 @@ struct NearbySpotDetailView: View {
     var rating: Double?
     var reviewCount: Int?
     var imageUrl: String?
+    /// 사진 여러 장 — 서버는 아직 image_url 한 장만 줍니다
+    var imageUrls: [String] = []
+    /// 광고 뱃지 — 전 지면 공통으로 is_sponsored 하나만 봅니다
+    var isSponsored: Bool = false
     var latitude: Double?
     var longitude: Double?
     var tags: [String] = []
@@ -24,6 +35,17 @@ struct NearbySpotDetailView: View {
     private var coordinate: CLLocationCoordinate2D? {
         guard let latitude, let longitude else { return nil }
         return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    @State private var photoIndex = 0
+    @State private var toast: String?
+    @State private var showRouteOptions = false
+
+    /// 표시할 사진들 — 없으면 대체 썸네일 1장
+    private var photos: [String] {
+        if !imageUrls.isEmpty { return imageUrls }
+        if let imageUrl, !imageUrl.isEmpty { return [imageUrl] }
+        return []
     }
 
     @State private var region = MKCoordinateRegion(
@@ -59,7 +81,14 @@ struct NearbySpotDetailView: View {
             bottomButton
         }
         .background(Color.white)
+        .overlay(alignment: .bottom) { toastView }
+        .animation(.easeInOut(duration: 0.2), value: toast)
         .navigationBarHidden(true)
+        .confirmationDialog("길찾기", isPresented: $showRouteOptions, titleVisibility: .visible) {
+            Button("카카오맵") { openRoute(.kakao) }
+            Button("구글 지도") { openRoute(.google) }
+            Button("취소", role: .cancel) { }
+        }
     }
 
     // MARK: - 헤더
@@ -77,11 +106,6 @@ struct NearbySpotDetailView: View {
                         .foregroundColor(.black)
                 }
                 Spacer()
-                Button { } label: {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 16))
-                        .foregroundColor(Color(hex: "#6B7280"))
-                }
             }
             .padding(.horizontal, 16)
         }
@@ -92,8 +116,34 @@ struct NearbySpotDetailView: View {
     // MARK: - 썸네일
 
     private var thumbnailSection: some View {
-        SpotImageView(imageUrl: imageUrl, categoryName: categoryName, iconSize: 52)
-            .frame(height: 200)
+        ZStack(alignment: .topLeading) {
+            if photos.count > 1 {
+                TabView(selection: $photoIndex) {
+                    ForEach(Array(photos.enumerated()), id: \.offset) { index, url in
+                        SpotImageView(imageUrl: url, categoryName: categoryName, iconSize: 52)
+                            .tag(index)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .always))
+                .indexViewStyle(.page(backgroundDisplayMode: .always))
+                .frame(height: 200)
+            } else {
+                // 사진이 없으면 카테고리 기본 썸네일 한 장
+                SpotImageView(imageUrl: photos.first, categoryName: categoryName, iconSize: 52)
+                    .frame(height: 200)
+            }
+
+            if isSponsored {
+                Text("광고")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .frame(height: 20)
+                    .background(Color(hex: "#1A1A1A"))
+                    .cornerRadius(4)
+                    .padding(12)
+            }
+        }
     }
 
     // MARK: - 기본 정보
@@ -128,6 +178,20 @@ struct NearbySpotDetailView: View {
                     Text(address)
                         .font(.system(size: 12))
                         .foregroundColor(Color(hex: "#6B7280"))
+
+                    Button {
+                        UIPasteboard.general.string = address
+                        toast = "주소가 복사되었어요"
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "doc.on.doc")
+                                .font(.system(size: 10))
+                            Text("복사")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .foregroundColor(Color(hex: "#2563EB"))
+                    }
+                    .buttonStyle(.plain)
                 }
             }
 
@@ -238,31 +302,72 @@ struct NearbySpotDetailView: View {
     // MARK: - 하단 버튼
 
     private var bottomButton: some View {
-        HStack(spacing: 12) {
-            Button { } label: {
-                Image(systemName: "heart")
-                    .font(.system(size: 18))
-                    .foregroundColor(Color(hex: "#6B7280"))
-                    .frame(width: 52, height: 52)
-                    .background(Color(hex: "#F3F4F6"))
-                    .cornerRadius(12)
-            }
-            .buttonStyle(.plain)
-
-            Button { } label: {
-                Text("길찾기")
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 52)
-                    .background(Color(hex: "#2563EB"))
-                    .cornerRadius(12)
-            }
-            .buttonStyle(.plain)
+        Button { showRouteOptions = true } label: {
+            Text("길찾기")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(coordinate == nil ? Color(hex: "#C3CDDA") : Color(hex: "#2563EB"))
+                .cornerRadius(12)
         }
+        .buttonStyle(.plain)
+        .disabled(coordinate == nil)
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(Color.white)
+    }
+
+    // MARK: - 길찾기
+
+    /// 카카오맵 → 구글맵 순으로 설치된 앱을 띄우고, 없으면 웹 지도로 넘깁니다.
+    private func openRoute(_ app: MapApp) {
+        guard let coordinate else { return }
+        let lat = coordinate.latitude
+        let lng = coordinate.longitude
+        let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        let appURL: URL?
+        let webURL: URL?
+        switch app {
+        case .kakao:
+            appURL = URL(string: "kakaomap://route?ep=\(lat),\(lng)&by=CAR")
+            webURL = URL(string: "https://map.kakao.com/link/to/\(encodedName),\(lat),\(lng)")
+        case .google:
+            appURL = URL(string: "comgooglemaps://?daddr=\(lat),\(lng)&directionsmode=driving")
+            webURL = URL(string: "https://www.google.com/maps/dir/?api=1&destination=\(lat),\(lng)")
+        }
+
+        if let appURL, UIApplication.shared.canOpenURL(appURL) {
+            UIApplication.shared.open(appURL)
+        } else if let webURL {
+            UIApplication.shared.open(webURL)
+        } else {
+            toast = "길찾기를 열 수 없어요"
+        }
+    }
+
+    private enum MapApp { case kakao, google }
+
+    // MARK: - 토스트
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 90)
+                .transition(.opacity)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    self.toast = nil
+                }
+        }
     }
 }
 

--- a/HiTrip/Features/Schedule/Views/NearbySpotView.swift
+++ b/HiTrip/Features/Schedule/Views/NearbySpotView.swift
@@ -1,224 +1,369 @@
 import SwiftUI
 import MapKit
 
+// MARK: - NearbySpotView
+/// 주변 인기 스팟 (지도) — 피그마 12380:1095
+///
+/// 지도 위에 상황별 검색 칩·상태 칩·내 위치 버튼·스팟 카드가 겹칩니다.
+/// 서버가 카테고리를 필수로 받아 "전체" 조회가 없으므로 칩은 항상 하나가 선택됩니다.
+
 struct NearbySpotView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @State private var selectedFilter = "음식점"
-    @State private var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 35.1588, longitude: 129.1603),
-        span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
-    )
+    @StateObject private var viewModel = NearbySpotViewModel()
 
-    private let filters = ["음식점", "무장애", "반려동물", "편의점", "마트"]
-
-    private let spots: [NearbySpot] = [
-        NearbySpot(name: "해운대 해수욕장",
-                   distance: "0.4km",
-                   isOpen: true,
-                   hours: "09:00 - 18:00",
-                   address: "부산 해운대구 우동 해운대해변로 264",
-                   description: "부산 대표 해변, 여름 축제 진행 중",
-                   coordinate: CLLocationCoordinate2D(latitude: 35.1588, longitude: 129.1603)),
-    ]
+    @State private var camera: MapCameraPosition = .automatic
+    @State private var selectedSpot: TravelerNearbySpotDTO?
 
     var body: some View {
-        VStack(spacing: 0) {
-            headerSection
+        ZStack(alignment: .top) {
+            mapLayer
+                .ignoresSafeArea(edges: .bottom)
 
-            // 필터 칩
-            filterRow
-                .padding(.horizontal, 20)
-                .padding(.bottom, 8)
+            VStack(spacing: 0) {
+                headerSection
+                categoryChips
+                    .padding(.top, 8)
+                statusChips
+                    .padding(.top, 16)
+                Spacer()
+            }
 
-            ZStack(alignment: .bottom) {
-                // 지도
-                mapView
+            VStack(spacing: 0) {
+                Spacer()
+                myLocationButton
+                    .padding(.trailing, 24)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.bottom, 12)
+                spotCards
+                    .padding(.bottom, 24)
+            }
 
-                // 오버레이 배지
-                VStack {
-                    HStack(spacing: 8) {
-                        Text("⚠ GPS 정확도 낮음")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 10)
-                            .frame(height: 26)
-                            .background(Color(hex: "#4F4F4F"))
-                            .cornerRadius(13)
-
-                        Text("빨간 선 = 안전 구역 경계")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 10)
-                            .frame(height: 26)
-                            .background(Color(hex: "#E46059"))
-                            .cornerRadius(13)
-
-                        Spacer()
-                    }
-                    .padding(.horizontal, 20)
-                    Spacer()
-                }
-                .padding(.top, 8)
-
-                // 내 위치 버튼
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        Button {
-                            region.center = CLLocationCoordinate2D(latitude: 35.1588, longitude: 129.1603)
-                        } label: {
-                            Image(systemName: "location.circle.fill")
-                                .font(.system(size: 24))
-                                .foregroundColor(Color(hex: "#2563EB"))
-                                .frame(width: 44, height: 44)
-                                .background(Color.white)
-                                .clipShape(Circle())
-                                .shadow(radius: 4)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.trailing, 16)
-                        .padding(.bottom, 130)
-                    }
-                }
-
-                // 하단 스팟 카드
-                NavigationLink(destination: NearbySpotDetailView(
-                    name: spots[0].name,
-                    address: spots[0].address,
-                    description: spots[0].description,
-                    distance: spots[0].distance,
-                    hours: spots[0].hours
-                )) {
-                    spotCard(spots[0])
-                }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 14)
-                .padding(.bottom, 16)
+            if viewModel.isOutsideGeofence {
+                outsideBanner
             }
         }
-        .background(Color.white)
+        .background(Color(hex: "#E0EAE0"))
         .navigationBarHidden(true)
+        .onAppear { viewModel.onAppear() }
+        .onDisappear { viewModel.onDisappear() }
+        .onChange(of: viewModel.currentLocation?.latitude) { _, _ in moveToCurrentLocation() }
+        .navigationDestination(item: $selectedSpot) { spot in
+            NearbySpotDetailView(
+                name: spot.name,
+                address: spot.roadAddress ?? spot.address,
+                description: spot.description,
+                imageUrl: spot.imageUrl,
+                isSponsored: spot.isSponsored == true,
+                latitude: spot.latitude,
+                longitude: spot.longitude,
+                categoryName: spot.categoryName
+            )
+        }
     }
 
-    // MARK: - Header
+    // MARK: - 지도
+
+    private var mapLayer: some View {
+        Map(position: $camera, selection: $viewModel.focusedSpotId) {
+            UserAnnotation()
+
+            // 안내사가 설정한 허용 반경 — 빨간 경계선
+            if let lat = viewModel.geofence?.latitude,
+               let lng = viewModel.geofence?.longitude,
+               let radius = viewModel.geofence?.radiusM {
+                MapCircle(
+                    center: CLLocationCoordinate2D(latitude: lat, longitude: lng),
+                    radius: radius
+                )
+                .foregroundStyle(Color(hex: "#E46059").opacity(0.08))
+                .stroke(Color(hex: "#E46059"), style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+            }
+
+            ForEach(viewModel.spots) { spot in
+                if let lat = spot.latitude, let lng = spot.longitude {
+                    Marker(spot.name, coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng))
+                        .tint(spot.id == viewModel.focusedSpotId
+                              ? Color(hex: "#2563EB") : Color(hex: "#6B7280"))
+                        .tag(spot.id)
+                }
+            }
+        }
+        .mapControls { MapCompass() }
+    }
+
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("주변 인기 스팟")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
+
             HStack {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
             }
-            .padding(.horizontal, 12)
+            .padding(.leading, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
-    // MARK: - 필터
+    // MARK: - 상황별 검색 칩
 
-    private var filterRow: some View {
+    private var categoryChips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(filters, id: \.self) { f in
-                    Button { selectedFilter = f } label: {
-                        Text(f)
-                            .font(.system(size: 12, weight: selectedFilter == f ? .semibold : .medium))
-                            .foregroundColor(selectedFilter == f ? Color(hex: "#2563EB") : Color(hex: "#333840"))
-                            .padding(.horizontal, 14)
-                            .frame(height: 34)
+            HStack(spacing: 7) {
+                ForEach(NearbySpotViewModel.Category.allCases) { category in
+                    let isSelected = viewModel.selectedCategory == category
+                    Button { viewModel.select(category) } label: {
+                        Text(category.label)
+                            .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                            .foregroundColor(isSelected ? Color(hex: "#2563EB") : Color(hex: "#333840"))
+                            .frame(width: 63, height: 34)
                             .background(Color.white)
-                            .cornerRadius(15)
+                            .clipShape(RoundedRectangle(cornerRadius: 15))
                     }
                     .buttonStyle(.plain)
                 }
             }
+            .padding(.horizontal, 26)
         }
     }
 
-    // MARK: - 지도
+    // MARK: - 상태 칩
 
-    private var mapView: some View {
-        Map(coordinateRegion: $region, annotationItems: spots) { spot in
-            MapAnnotation(coordinate: spot.coordinate) {
-                Image(systemName: "mappin.circle.fill")
-                    .font(.system(size: 24))
-                    .foregroundColor(Color(hex: "#2563EB"))
+    private var statusChips: some View {
+        HStack(spacing: 7) {
+            if viewModel.isAccuracyLow {
+                statusChip("⚠ GPS 정확도 낮음", background: Color(hex: "#4F4F4F"))
             }
+            if viewModel.geofence != nil {
+                statusChip("빨간 선 = 안전 구역 경계", background: Color(hex: "#E46059"))
+            }
+            Spacer()
         }
-        .overlay(
-            // 허용 범위 경계 원
-            Circle()
-                .stroke(Color.red.opacity(0.7), style: StrokeStyle(lineWidth: 2, dash: [6]))
-                .padding(60)
-                .allowsHitTesting(false)
-        )
-        .background(Color(hex: "#E0EAE0"))
+        .padding(.horizontal, 26)
+    }
+
+    private func statusChip(_ text: String, background: Color) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(.white)
+            .padding(.horizontal, 11)
+            .frame(height: 26)
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 13))
+    }
+
+    // MARK: - 안전 구역 이탈 배너
+
+    private var outsideBanner: some View {
+        VStack {
+            Text("안전 구역을 벗어났어요")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .background(Color(hex: "#E46059"))
+            Spacer()
+        }
+        .ignoresSafeArea(edges: .top)
+        .transition(.move(edge: .top))
+    }
+
+    // MARK: - 내 위치 버튼
+
+    private var myLocationButton: some View {
+        Button { moveToCurrentLocation() } label: {
+            Image(systemName: "location.fill")
+                .font(.system(size: 17))
+                .foregroundColor(Color(hex: "#2563EB"))
+                .frame(width: 44, height: 44)
+                .background(Color.white)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func moveToCurrentLocation() {
+        guard let coordinate = viewModel.currentLocation else { return }
+        withAnimation {
+            camera = .region(MKCoordinateRegion(
+                center: coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
+            ))
+        }
     }
 
     // MARK: - 스팟 카드
 
-    private func spotCard(_ spot: NearbySpot) -> some View {
-        HStack(spacing: 12) {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color(hex: "#E5E7EB"))
-                .frame(width: 86, height: 86)
-                .overlay(
-                    Image(systemName: "photo")
-                        .foregroundColor(Color(hex: "#9CA3AF"))
-                )
+    @ViewBuilder
+    private var spotCards: some View {
+        switch viewModel.state {
+        case .failed(let message):
+            messageCard(message, actionTitle: "재시도") { viewModel.loadSpots() }
 
-            VStack(alignment: .leading, spacing: 4) {
+        case .loading, .idle:
+            if viewModel.authorizationDenied {
+                permissionCard
+            } else {
+                EmptyView()
+            }
+
+        case .loaded:
+            if viewModel.spots.isEmpty {
+                messageCard("주변에 결과가 없어요", actionTitle: nil, action: nil)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.spots) { spot in
+                            spotCard(spot)
+                                .onTapGesture { selectedSpot = spot }
+                        }
+                    }
+                    .padding(.horizontal, 14)
+                    .scrollTargetLayout()
+                }
+                .scrollTargetBehavior(.viewAligned)
+                .scrollPosition(id: $viewModel.focusedSpotId)
+            }
+        }
+    }
+
+    private func spotCard(_ spot: TravelerNearbySpotDTO) -> some View {
+        HStack(alignment: .top, spacing: 20) {
+            ZStack(alignment: .topLeading) {
+                SpotImageView(
+                    imageUrl: spot.imageUrl,
+                    categoryName: spot.categoryName,
+                    iconSize: 24
+                )
+                .frame(width: 86, height: 86)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                if spot.isSponsored == true {
+                    Text("광고")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 5)
+                        .frame(height: 16)
+                        .background(Color(hex: "#1A1A1A"))
+                        .cornerRadius(4)
+                        .padding(4)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
                 Text(spot.name)
                     .font(.system(size: 13, weight: .bold))
                     .foregroundColor(Color(hex: "#111827"))
+                    .lineLimit(1)
 
-                HStack(spacing: 4) {
-                    Text(spot.distance)
-                        .font(.system(size: 11))
-                        .foregroundColor(.black)
-                    Text("·")
-                    Text("영업중")
-                        .font(.system(size: 11))
-                        .foregroundColor(Color(hex: "#2E9B67"))
-                    Text(spot.hours)
+                if let distance = spot.distanceText {
+                    Text(distance)
                         .font(.system(size: 11))
                         .foregroundColor(.black)
                 }
 
-                Text(spot.address)
-                    .font(.system(size: 11))
-                    .foregroundColor(.black)
+                if let address = spot.roadAddress ?? spot.address {
+                    Text(address)
+                        .font(.system(size: 11))
+                        .foregroundColor(.black)
+                        .lineLimit(2)
+                }
 
-                Text(spot.description)
-                    .font(.system(size: 11))
-                    .foregroundColor(.black)
+                if let description = spot.description, !description.isEmpty {
+                    Text(description)
+                        .font(.system(size: 11))
+                        .foregroundColor(.black)
+                        .lineLimit(1)
+                }
             }
 
-            Spacer()
+            Spacer(minLength: 0)
         }
         .padding(12)
+        .frame(width: 326, height: 113, alignment: .topLeading)
         .background(Color.white)
-        .cornerRadius(12)
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color(hex: "#E5E7EB"), lineWidth: 1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
+        )
+        .id(spot.id)
     }
-}
 
-private struct NearbySpot: Identifiable {
-    let id = UUID()
-    let name: String
-    let distance: String
-    let isOpen: Bool
-    let hours: String
-    let address: String
-    let description: String
-    let coordinate: CLLocationCoordinate2D
+    // MARK: - 위치 권한 / 안내 카드
+
+    private var permissionCard: some View {
+        VStack(spacing: 10) {
+            Text("위치 권한을 허용해주세요")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(Color(hex: "#111827"))
+            Text("주변 스팟과 안전 구역을 보여드리려면 위치 정보가 필요해요")
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "#6B7280"))
+                .multilineTextAlignment(.center)
+
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                Text("설정 이동")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 20)
+                    .frame(height: 40)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(16)
+        .frame(width: 326)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
+        )
+    }
+
+    private func messageCard(_ text: String, actionTitle: String?, action: (() -> Void)?) -> some View {
+        VStack(spacing: 10) {
+            Text(text)
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+
+            if let actionTitle, let action {
+                Button(action: action) {
+                    Text(actionTitle)
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 20)
+                        .frame(height: 40)
+                        .background(Color(hex: "#2563EB"))
+                        .cornerRadius(10)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(16)
+        .frame(width: 326)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
+        )
+    }
 }

--- a/HiTrip/Features/Schedule/Views/NoticePopupView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticePopupView.swift
@@ -10,15 +10,32 @@ struct NoticePopupView: View {
 
     @Binding var isPresented: Bool
 
-    var date: String = "2025.04.24 10:20"
-    var author: String = "김안내 가이드"
-    var paragraphs: [String] = [
-        "오늘 자유 일정은 우천이 예상됩니다. 우산을 꼭 챙겨주세요.",
-        "집합 시간은 18:00, 집합 장소는 호텔 1층 로비입니다.\n늦으시는 분은 단체톡방에 꼭 남겨주세요.",
-        "안전한 여행 되세요!",
-    ]
+    let notice: TravelerNoticeDTO
+    /// 접어둔 이전 공지들 — 없으면 "이전 공지 보기" 버튼을 숨깁니다
+    var previousNotices: [TravelerNoticeDTO] = []
 
     @State private var showPrevious = false
+
+    /// "2025.04.24 10:20"
+    private var dateText: String {
+        guard let raw = notice.publishedAt ?? notice.createdAt else { return "" }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = iso.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) else { return "" }
+
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "yyyy.MM.dd HH:mm"
+        return f.string(from: date)
+    }
+
+    /// 본문을 빈 줄 기준으로 문단으로 나눕니다
+    private var paragraphs: [String] {
+        notice.content
+            .components(separatedBy: "\n\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
 
     var body: some View {
         ZStack {
@@ -35,10 +52,11 @@ struct NoticePopupView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("공지사항")
+                    Text(notice.title.isEmpty ? "공지사항" : notice.title)
                         .font(.system(size: 17, weight: .bold))
                         .foregroundColor(Color(hex: "#111827"))
-                    Text("\(date) · \(author)")
+                    // 작성자명은 여행객 공지 API에 없어 날짜만 표시합니다 (백엔드 요청 중)
+                    Text(dateText)
                         .font(.system(size: 11))
                         .foregroundColor(Color(hex: "#6B7280"))
                 }
@@ -66,8 +84,28 @@ struct NoticePopupView: View {
             .padding(.horizontal, 20)
             .padding(.bottom, 24)
 
+            if !previousNotices.isEmpty {
             Divider()
                 .padding(.horizontal, 20)
+
+            if showPrevious {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(previousNotices) { prev in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(prev.title)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(Color(hex: "#111827"))
+                            Text(prev.content)
+                                .font(.system(size: 12))
+                                .foregroundColor(Color(hex: "#6B7280"))
+                                .lineLimit(2)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+            }
 
             Button { showPrevious.toggle() } label: {
                 HStack(spacing: 4) {
@@ -81,6 +119,7 @@ struct NoticePopupView: View {
             .buttonStyle(.plain)
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
+            }
         }
         .background(Color.white)
         .cornerRadius(16)

--- a/HiTrip/Features/Schedule/Views/NoticePopupView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticePopupView.swift
@@ -11,7 +11,7 @@ struct NoticePopupView: View {
     @Binding var isPresented: Bool
 
     let notice: TravelerNoticeDTO
-    /// 접어둔 이전 공지들 — 없으면 "이전 공지 보기" 버튼을 숨깁니다
+    /// 지난 공지(비활성) — 없으면 "이전 공지 보기" 버튼을 숨깁니다
     var previousNotices: [TravelerNoticeDTO] = []
 
     @State private var showPrevious = false
@@ -72,6 +72,7 @@ struct NoticePopupView: View {
             .padding(.top, 20)
             .padding(.bottom, 20)
 
+            ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 ForEach(paragraphs, id: \.self) { p in
                     Text(p)
@@ -83,6 +84,9 @@ struct NoticePopupView: View {
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 24)
+            }
+            // 긴 공지도 팝업 안에서 읽을 수 있게 본문만 스크롤합니다
+            .frame(maxHeight: 320)
 
             if !previousNotices.isEmpty {
             Divider()

--- a/HiTrip/Features/Schedule/Views/TripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/TripDetailView.swift
@@ -9,8 +9,37 @@ struct TripDetailView: View {
     @State private var addDayNumber: Int?
     @State private var addTitle = ""
     @State private var addMemo = ""
-    @State private var addStart = "20:00"
-    @State private var addEnd = "21:00"
+    /// 휠 피커가 다루는 값. 문자열 addStart/addEnd는 여기서 파생됩니다.
+    @State private var startDate = TripDetailView.defaultTime(hour: 20)
+    @State private var endDate   = TripDetailView.defaultTime(hour: 21)
+    /// 수정 중인 개인 일정 id — nil이면 새로 추가
+    @State private var editingId: Int?
+
+    /// 어떤 시간 피커를 펼쳐 두었는지
+    @State private var openPicker: TimeField?
+    /// 스와이프로 열려 있는 개인 일정 id
+    @State private var swipedId: Int?
+    /// 설명을 펼친 공용 일정 id
+    @State private var expandedDescriptions: Set<Int> = []
+    /// 작성 중 닫기 확인
+    @State private var showDiscardConfirm = false
+    /// 일정 카드 탭 → 스팟 상세
+    @State private var selectedSchedule: SchedulePlace?
+    /// 삭제 확인 대기 중인 개인 일정
+    @State private var pendingDelete: TravelerPersonalScheduleDTO?
+
+    private enum TimeField { case start, end }
+
+    /// 일정 카드에서 스팟 상세로 넘길 장소 정보
+    private struct SchedulePlace: Identifiable, Hashable {
+        let id: Int
+        let name: String
+        let address: String?
+        let description: String?
+        let latitude: Double?
+        let longitude: Double?
+        let categoryName: String?
+    }
 
     private let titleLimit = 20
     private let memoLimit = 100
@@ -34,26 +63,62 @@ struct TripDetailView: View {
             if showAddSheet {
                 Color.black.opacity(0.45)
                     .ignoresSafeArea()
-                    .onTapGesture { closeSheet() }
+                    .onTapGesture { requestCloseSheet() }
 
                 VStack(spacing: 0) {
                     Spacer()
                     addScheduleSheet
                         .transition(.move(edge: .bottom))
+                        .gesture(
+                            DragGesture()
+                                .onEnded { value in
+                                    if value.translation.height > 80 { requestCloseSheet() }
+                                }
+                        )
                 }
                 .ignoresSafeArea(edges: .bottom)
             }
         }
+        .overlay(alignment: .bottom) { toastView }
         .animation(.easeInOut(duration: 0.25), value: showAddSheet)
         .navigationBarHidden(true)
         .task { viewModel.load() }
-        .alert("저장하지 못했습니다", isPresented: Binding(
+        .navigationDestination(item: $selectedSchedule) { place in
+            NearbySpotDetailView(
+                name: place.name,
+                address: place.address,
+                description: place.description,
+                imageUrl: nil,
+                latitude: place.latitude,
+                longitude: place.longitude,
+                categoryName: place.categoryName
+            )
+        }
+        .alert("저장하지 못했어요", isPresented: Binding(
             get: { viewModel.saveError != nil },
             set: { if !$0 { viewModel.saveError = nil } }
         )) {
-            Button("확인", role: .cancel) { viewModel.saveError = nil }
+            // 입력값은 그대로 두고 다시 저장을 시도할 수 있게 합니다.
+            Button("재시도") { viewModel.saveError = nil; save() }
+            Button("닫기", role: .cancel) { viewModel.saveError = nil }
         } message: {
             Text(viewModel.saveError ?? "")
+        }
+        .confirmationDialog(
+            "이 일정을 삭제할까요?",
+            isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("삭제", role: .destructive) {
+                if let target = pendingDelete { viewModel.deletePersonalSchedule(id: target.id) }
+                pendingDelete = nil
+                swipedId = nil
+            }
+            Button("취소", role: .cancel) { pendingDelete = nil }
+        }
+        .confirmationDialog("작성을 취소할까요?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
+            Button("작성 취소", role: .destructive) { closeSheet() }
+            Button("계속 작성", role: .cancel) { }
         }
         .alert("일정이 겹칩니다", isPresented: Binding(
             get: { viewModel.overlapNotice != nil },
@@ -62,6 +127,27 @@ struct TripDetailView: View {
             Button("확인", role: .cancel) { viewModel.overlapNotice = nil }
         } message: {
             Text(viewModel.overlapNotice ?? "")
+        }
+    }
+
+    // MARK: - 토스트
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 40)
+                .transition(.opacity)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
         }
     }
 
@@ -277,10 +363,20 @@ struct TripDetailView: View {
 
             if isExpanded {
                 VStack(spacing: 12) {
+                    if day.items.isEmpty {
+                        Text("등록된 일정이 없어요")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(hex: "#6B7280"))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 60)
+                            .background(Color(hex: "#F9FAFB"))
+                            .cornerRadius(12)
+                    }
+
                     ForEach(day.items) { item in
                         switch item {
                         case .shared(let s):   sharedRow(s)
-                        case .personal(let p): personalRow(p)
+                        case .personal(let p): personalRow(p, dayNumber: day.dayNumber)
                         }
                     }
 
@@ -317,11 +413,26 @@ struct TripDetailView: View {
                     .foregroundColor(Color(hex: "#6B7280"))
 
                 if let content = s.mainContent, !content.isEmpty, content != s.placeName {
+                    let isOpen = expandedDescriptions.contains(s.id)
                     Text(content)
                         .font(.system(size: 12))
                         .foregroundColor(Color(hex: "#374151"))
-                        .lineLimit(2)
+                        .lineLimit(isOpen ? nil : 2)
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 2)
+
+                    // 2줄을 넘길 만한 설명에만 더보기를 답니다
+                    if content.count > 40 {
+                        Button {
+                            if isOpen { expandedDescriptions.remove(s.id) }
+                            else      { expandedDescriptions.insert(s.id) }
+                        } label: {
+                            Text(isOpen ? "접기" : "더보기")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(Color(hex: "#2563EB"))
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
 
@@ -339,11 +450,69 @@ struct TripDetailView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
         )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // 장소 정보가 있는 일정만 스팟 상세로 갑니다
+            if s.placeName != nil || s.placeAddress != nil {
+                selectedSchedule = SchedulePlace(
+                    id: s.id,
+                    name: s.placeName ?? s.mainContent ?? "일정",
+                    address: s.placeAddress,
+                    description: s.mainContent,
+                    latitude: s.placeLatitude.flatMap(Double.init),
+                    longitude: s.placeLongitude.flatMap(Double.init),
+                    categoryName: s.transport
+                )
+            }
+        }
     }
 
     // MARK: - 개인 일정 행
 
-    private func personalRow(_ p: TravelerPersonalScheduleDTO) -> some View {
+    /// 왼쪽으로 밀면 수정·삭제가 나옵니다.
+    private func personalRow(_ p: TravelerPersonalScheduleDTO, dayNumber: Int) -> some View {
+        let isSwiped = swipedId == p.id
+        let actionWidth: CGFloat = 132
+
+        return ZStack(alignment: .trailing) {
+            HStack(spacing: 8) {
+                Button { beginEdit(p, dayNumber: dayNumber) } label: {
+                    Text("수정")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#6B7280"))
+                        .cornerRadius(12)
+                }
+                .buttonStyle(.plain)
+
+                Button { pendingDelete = p } label: {
+                    Text("삭제")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#EF4444"))
+                        .cornerRadius(12)
+                }
+                .buttonStyle(.plain)
+            }
+            .opacity(isSwiped ? 1 : 0)
+
+            personalRowContent(p)
+                .offset(x: isSwiped ? -actionWidth : 0)
+                .gesture(
+                    DragGesture(minimumDistance: 12)
+                        .onEnded { value in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                if value.translation.width < -40      { swipedId = p.id }
+                                else if value.translation.width > 40  { swipedId = nil }
+                            }
+                        }
+                )
+        }
+    }
+
+    private func personalRowContent(_ p: TravelerPersonalScheduleDTO) -> some View {
         HStack(spacing: 10) {
             Text("내 일정")
                 .font(.system(size: 11, weight: .bold))
@@ -386,13 +555,6 @@ struct TripDetailView: View {
             RoundedRectangle(cornerRadius: 12)
                 .strokeBorder(Color(hex: "#2563EB"), style: StrokeStyle(lineWidth: 1, dash: [4]))
         )
-        .contextMenu {
-            Button(role: .destructive) {
-                viewModel.deletePersonalSchedule(id: p.id)
-            } label: {
-                Label("삭제", systemImage: "trash")
-            }
-        }
     }
 
     // MARK: - 개인 일정 추가 버튼
@@ -430,7 +592,7 @@ struct TripDetailView: View {
             }
             .padding(.top, 10)
 
-            Text("개인 일정 추가")
+            Text(editingId == nil ? "개인 일정 추가" : "개인 일정 수정")
                 .font(.system(size: 16, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
                 .padding(.horizontal, 24)
@@ -479,10 +641,36 @@ struct TripDetailView: View {
                     .padding(.horizontal, 24)
 
                 HStack(spacing: 12) {
-                    timeField(prefix: "시작", value: $addStart)
-                    timeField(prefix: "종료", value: $addEnd)
+                    timeField(prefix: "시작", value: addStart, field: .start)
+                    timeField(prefix: "종료", value: addEnd,   field: .end)
                 }
                 .padding(.horizontal, 24)
+
+                // 탭한 쪽만 휠 피커를 펼칩니다
+                if let field = openPicker {
+                    DatePicker(
+                        "",
+                        selection: field == .start ? $startDate : $endDate,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .frame(height: 140)
+                    .padding(.horizontal, 24)
+                }
+
+                if isEndBeforeStart {
+                    Text("종료 시간이 시작 시간보다 빠릅니다")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(hex: "#EF4444"))
+                        .padding(.horizontal, 24)
+                } else if overlapsShared {
+                    // 겹쳐도 저장은 허용합니다 (개인 책임)
+                    Text("안내사 공용 일정과 시간이 겹칩니다")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(hex: "#EB8C0D"))
+                        .padding(.horizontal, 24)
+                }
             }
             .padding(.bottom, 12)
 
@@ -537,24 +725,63 @@ struct TripDetailView: View {
         .cornerRadius(24, corners: [.topLeft, .topRight])
     }
 
-    private func timeField(prefix: String, value: Binding<String>) -> some View {
-        HStack(spacing: 8) {
-            Text(prefix)
-                .font(.system(size: 12))
-                .foregroundColor(Color(hex: "#6B7280"))
-            TextField("00:00", text: value)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(Color(hex: "#111827"))
-                .keyboardType(.numbersAndPunctuation)
+    private func timeField(prefix: String, value: String, field: TimeField) -> some View {
+        Button {
+            openPicker = (openPicker == field) ? nil : field
+        } label: {
+            HStack(spacing: 8) {
+                Text(prefix)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(hex: "#6B7280"))
+                Text(value)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(Color(hex: "#111827"))
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Color(hex: "#F3F4F6"))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(openPicker == field ? Color(hex: "#2563EB") : .clear, lineWidth: 1)
+            )
         }
-        .padding(.horizontal, 14)
-        .frame(maxWidth: .infinity)
-        .frame(height: 48)
-        .background(Color(hex: "#F3F4F6"))
-        .cornerRadius(12)
+        .buttonStyle(.plain)
     }
 
     // MARK: - 동작
+
+    /// "HH:mm"
+    private var addStart: String { Self.hhmm(startDate) }
+    private var addEnd:   String { Self.hhmm(endDate) }
+
+    private var isEndBeforeStart: Bool { addEnd <= addStart }
+
+    /// 입력 중 공용 일정과 겹치는지 — 경고만 하고 저장은 막지 않습니다
+    private var overlapsShared: Bool {
+        guard let day = addDayNumber, !isEndBeforeStart else { return false }
+        return viewModel.overlapsSharedSchedule(dayNumber: day, start: addStart, end: addEnd)
+    }
+
+    private static func defaultTime(hour: Int) -> Date {
+        Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date()) ?? Date()
+    }
+
+    private static func hhmm(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
+    }
+
+    private static func date(fromHHmm text: String) -> Date {
+        let parts = text.split(separator: ":")
+        let h = parts.count == 2 ? Int(parts[0]) ?? 0 : 0
+        let m = parts.count == 2 ? Int(parts[1]) ?? 0 : 0
+        return Calendar.current.date(bySettingHour: h, minute: m, second: 0, of: Date()) ?? Date()
+    }
 
     private var isTitleOverLimit: Bool { addTitle.count > titleLimit }
     private var isMemoOverLimit: Bool { addMemo.count > memoLimit }
@@ -563,38 +790,57 @@ struct TripDetailView: View {
         !addTitle.trimmingCharacters(in: .whitespaces).isEmpty
             && !isTitleOverLimit
             && !isMemoOverLimit
-            && isValidTime(addStart)
-            && isValidTime(addEnd)
-            && addStart < addEnd
-    }
-
-    /// "HH:mm" 형식이고 실제 시각인지
-    private func isValidTime(_ text: String) -> Bool {
-        let parts = text.split(separator: ":")
-        guard parts.count == 2,
-              let h = Int(parts[0]), let m = Int(parts[1]),
-              (0...23).contains(h), (0...59).contains(m) else { return false }
-        return true
+            && !isEndBeforeStart
     }
 
     private func save() {
-        guard let day = addDayNumber else { return }
-        viewModel.addPersonalSchedule(
-            dayNumber: day,
-            title: addTitle.trimmingCharacters(in: .whitespaces),
-            start: addStart,
-            end: addEnd,
-            memo: addMemo.isEmpty ? nil : addMemo
-        )
-        closeSheet()
+        guard let day = addDayNumber, canSave else { return }
+        let title = addTitle.trimmingCharacters(in: .whitespaces)
+        let memo = addMemo.isEmpty ? nil : addMemo
+
+        // 성공했을 때만 시트를 닫습니다. 실패하면 입력값이 그대로 남습니다.
+        if let editingId {
+            viewModel.updatePersonalSchedule(
+                id: editingId, dayNumber: day, title: title,
+                start: addStart, end: addEnd, memo: memo
+            ) { closeSheet() }
+        } else {
+            viewModel.addPersonalSchedule(
+                dayNumber: day, title: title,
+                start: addStart, end: addEnd, memo: memo
+            ) { closeSheet() }
+        }
+    }
+
+    /// 스와이프 > 수정 — 기존 값을 시트에 채워 엽니다
+    private func beginEdit(_ p: TravelerPersonalScheduleDTO, dayNumber: Int) {
+        editingId = p.id
+        addDayNumber = dayNumber
+        addTitle = p.title
+        addMemo = p.memo ?? ""
+        startDate = Self.date(fromHHmm: TripScheduleViewModel.hhmm(p.startTime))
+        endDate   = Self.date(fromHHmm: TripScheduleViewModel.hhmm(p.endTime))
+        swipedId = nil
+        showAddSheet = true
+    }
+
+    /// 딤 탭·아래로 드래그 — 작성 중이면 한 번 물어봅니다
+    private func requestCloseSheet() {
+        if addTitle.isEmpty && addMemo.isEmpty {
+            closeSheet()
+        } else {
+            showDiscardConfirm = true
+        }
     }
 
     private func closeSheet() {
         showAddSheet = false
+        editingId = nil
+        openPicker = nil
         addTitle = ""
         addMemo = ""
-        addStart = "20:00"
-        addEnd = "21:00"
+        startDate = Self.defaultTime(hour: 20)
+        endDate = Self.defaultTime(hour: 21)
     }
 }
 

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -77,6 +77,7 @@ struct TripListView: View {
                     address: spot.place.address,
                     description: spot.description,
                     imageUrl: spot.imageUrl,
+                    isSponsored: spot.isSponsored == true,
                     latitude: spot.place.latitude.flatMap(Double.init),
                     longitude: spot.place.longitude.flatMap(Double.init),
                     categoryName: spot.place.categoryName

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -40,10 +40,15 @@ struct TripListView: View {
                                 .padding(.bottom, 32)
                         }
                     }
+                    .refreshable { viewModel.refresh() }
                 }
 
-                if showNotice {
-                    NoticePopupView(isPresented: $showNotice)
+                if showNotice, let notice = viewModel.representativeNotice {
+                    NoticePopupView(
+                        isPresented: $showNotice,
+                        notice: notice,
+                        previousNotices: viewModel.previousNotices
+                    )
                 }
 
                 // 긴급 즉시 연락 — 별도 화면이 아니라 홈 위에 겹칩니다
@@ -155,10 +160,10 @@ struct TripListView: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 16)
 
-            if viewModel.isBeforeTrip {
-                beforeTripCard
-            } else {
-                inTripSchedule
+            switch viewModel.phase {
+            case .before:   beforeTripCard
+            case .finished: finishedTripCard
+            case .during:   inTripSchedule
             }
 
             // 전체일정 링크
@@ -192,14 +197,33 @@ struct TripListView: View {
         .padding(.horizontal, 24)
     }
 
+    // MARK: - 여행 종료 후
+
+    private var finishedTripCard: some View {
+        VStack(spacing: 6) {
+            Text("여행이 종료되었습니다")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Color(hex: "#111827"))
+            Text("여행 정보와 계정은 \(viewModel.dataPurgeDateText)에 파기됩니다")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 92)
+        .background(Color(hex: "#F3F4F6"))
+        .cornerRadius(12)
+        .padding(.horizontal, 24)
+    }
+
     // MARK: - 여행 중
 
     private var inTripSchedule: some View {
         VStack(alignment: .leading, spacing: 0) {
             // 여행 진행률 카드
             TripProgressCard(
-                dayNumber: viewModel.todayDayNumber,
-                totalDays: viewModel.tripTotalDays,
+                progress: viewModel.todayProgress,
+                remainingDays: viewModel.tripTotalDays - viewModel.todayDayNumber,
                 destination: viewModel.destinationText
             )            .padding(.horizontal, 21)
             .padding(.bottom, 16)
@@ -220,10 +244,12 @@ struct TripListView: View {
                 .background(Color(hex: "#F3F4F6"))
                 .cornerRadius(12)
                 .padding(.horizontal, 24)
+                .contentShape(Rectangle())
+                .onTapGesture { showTripDetail = true }
             } else {
                 Text(viewModel.todayState == .finished
                      ? "오늘 일정이 모두 끝났어요"
-                     : "오늘은 예정된 일정이 없어요")
+                     : "오늘은 등록된 일정이 없어요")
                     .font(.system(size: 14))
                     .foregroundColor(Color(hex: "#6B7280"))
                     .frame(maxWidth: .infinity)
@@ -255,6 +281,8 @@ struct TripListView: View {
                 .frame(height: 48)
                 .background(Color(hex: "#F3F4F6"))
                 .cornerRadius(12)
+                .contentShape(Rectangle())
+                .onTapGesture { showTripDetail = true }
                 .padding(.horizontal, 24)
             }
         }
@@ -262,7 +290,10 @@ struct TripListView: View {
 
     // MARK: - 주변 인기 스팟
 
+    @ViewBuilder
     private var nearbySpotSection: some View {
+        // 스팟이 없으면 섹션째 숨깁니다
+        if !viewModel.popularSpots.isEmpty {
         VStack(alignment: .leading, spacing: 12) {
             Text("주변 인기 스팟")
                 .font(.system(size: 16, weight: .bold))
@@ -288,6 +319,7 @@ struct TripListView: View {
             .padding(.horizontal, 24)
             .padding(.top, 2)
             .padding(.bottom, 20)
+        }
         }
     }
 
@@ -355,9 +387,23 @@ struct TripListView: View {
             }
         }
         .contentShape(Rectangle())
-        .onTapGesture { showNotice = true }
+        .onTapGesture {
+            viewModel.markNoticeRead(notice)
+            showNotice = true
+        }
         .padding(.horizontal, 24)
         .padding(.bottom, 10)
+        } else {
+            Text("등록된 공지가 없어요")
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "#6B7280"))
+                .padding(.horizontal, 14)
+                .frame(minHeight: 58)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(hex: "#F3F4F6"))
+                .cornerRadius(12)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 10)
         }
     }
 
@@ -413,15 +459,14 @@ struct TripListView: View {
                 .buttonStyle(.plain)
 
                 if viewModel.hasUnreadMessage {
-                    ZStack {
-                        Circle()
-                            .fill(Color(hex: "#EF4444"))
-                            .frame(width: 20, height: 20)
-                        Text("\(viewModel.unreadMessageCount)")
-                            .font(.system(size: 12, weight: .bold))
-                            .foregroundColor(.white)
-                    }
-                    .offset(x: -4, y: -4)
+                    Text(viewModel.unreadMessageBadgeText)
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .frame(minWidth: 20, minHeight: 20)
+                        .background(Color(hex: "#EF4444"))
+                        .clipShape(Capsule())
+                        .offset(x: -4, y: -4)
                 }
             }
         }

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -156,16 +156,17 @@ struct TripListView: View {
 
     private var todayScheduleSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("오늘의 일정")
-                .font(.system(size: 16, weight: .bold))
-                .foregroundColor(Color(hex: "#111827"))
-                .padding(.horizontal, 24)
-                .padding(.bottom, 16)
-
+            // 여행 중에는 진행률 카드가 먼저 오고 그 아래에 제목이 붙습니다.
+            // 시작 전·종료 후에는 카드가 없어 제목이 맨 위입니다.
             switch viewModel.phase {
-            case .before:   beforeTripCard
-            case .finished: finishedTripCard
-            case .during:   inTripSchedule
+            case .before:
+                sectionTitle
+                beforeTripCard
+            case .finished:
+                sectionTitle
+                finishedTripCard
+            case .during:
+                inTripSchedule
             }
 
             // 전체일정 링크
@@ -179,6 +180,14 @@ struct TripListView: View {
             .padding(.top, 14)
             .padding(.bottom, 22)
         }
+    }
+
+    private var sectionTitle: some View {
+        Text("오늘의 일정")
+            .font(.system(size: 16, weight: .bold))
+            .foregroundColor(Color(hex: "#111827"))
+            .padding(.horizontal, 24)
+            .padding(.bottom, 16)
     }
 
     // MARK: - 여행 시작 전
@@ -228,7 +237,9 @@ struct TripListView: View {
                 remainingDays: viewModel.tripTotalDays - viewModel.todayDayNumber,
                 destination: viewModel.destinationText
             )            .padding(.horizontal, 21)
-            .padding(.bottom, 16)
+            .padding(.bottom, 20)
+
+            sectionTitle
 
             // 현재 일정
             if let current = viewModel.currentSchedule {

--- a/HiTrip/Features/Schedule/Views/TripListView.swift
+++ b/HiTrip/Features/Schedule/Views/TripListView.swift
@@ -55,7 +55,8 @@ struct TripListView: View {
                 if showEmergency {
                     EmergencyCallDialog(
                         isPresented: $showEmergency,
-                        phoneNumber: viewModel.managerPhone
+                        phoneNumber: viewModel.managerPhone,
+                        onMessageGuide: { showChat = true }
                     )
                 }
             }

--- a/HiTrip/Features/Schedule/Views/TripProgressCard.swift
+++ b/HiTrip/Features/Schedule/Views/TripProgressCard.swift
@@ -10,18 +10,18 @@ import SwiftUI
 /// - "65% 완료" 자간 -0.38
 /// - 오른쪽에 목적지
 ///
-/// 서버가 주는 값은 오늘 일차와 전체 일수 두 개뿐입니다.
-/// 진행률·남은 일수·퍼센트 문구는 모두 여기서 그 두 값으로 만듭니다.
+/// 인디케이터는 기획대로 "당일 첫 일정 시작 ~ 마지막 일정 종료" 대비 현재 시각 비율입니다.
+/// 남은 일수는 여행 일정에서 계산해 넘겨받고, 퍼센트 문구는 진행률에서 만듭니다.
 ///
 /// 날씨(디자인의 "맑음 22°C")는 API에 없어 표시하지 않습니다.
 /// 스키마 전체에 weather/temperature 필드가 0건입니다.
 
 struct TripProgressCard: View {
 
-    /// 오늘이 며칠째인지 — 서버 today_day_number
-    let dayNumber: Int
-    /// 여행 전체 일수 — 서버 duration_days
-    let totalDays: Int
+    /// 당일 진행률 0...1 — 첫 일정 시작 전 0, 마지막 일정 종료 후 1
+    let progress: Double
+    /// 여행 종료까지 남은 일수
+    let remainingDays: Int
     /// 목적지 — 없으면 숨김
     let destination: String?
 
@@ -32,17 +32,10 @@ struct TripProgressCard: View {
 
     // MARK: - 계산값
 
-    /// 0...1
-    private var progress: Double {
-        guard totalDays > 0 else { return 0 }
-        return min(max(Double(dayNumber) / Double(totalDays), 0), 1)
-    }
-
-    private var remainingDays: Int { totalDays - dayNumber }
+    private var clamped: Double { min(max(progress, 0), 1) }
 
     /// "여행 진행률 · 3일 남음"
     private var headline: String {
-        guard totalDays > 0 else { return "여행 진행률" }
         if remainingDays > 0  { return "여행 진행률 · \(remainingDays)일 남음" }
         if remainingDays == 0 { return "여행 진행률 · 오늘이 마지막 날" }
         return "여행 진행률 · 일정 종료"
@@ -50,7 +43,7 @@ struct TripProgressCard: View {
 
     /// "65% 완료"
     private var percentText: String {
-        "\(Int((progress * 100).rounded()))% 완료"
+        "\(Int((clamped * 100).rounded()))% 완료"
     }
 
     var body: some View {
@@ -108,7 +101,7 @@ struct TripProgressCard: View {
     /// 버스를 점 중앙에 맞춥니다 (아이콘 폭의 절반만큼 왼쪽으로)
     private func busOffset(in width: CGFloat) -> CGFloat {
         let travel = max(width - dotSize, 0)
-        return travel * progress + dotSize / 2 - 13
+        return travel * clamped + dotSize / 2 - 13
     }
 
     // MARK: - 진행 바
@@ -117,7 +110,7 @@ struct TripProgressCard: View {
         GeometryReader { geo in
             // 점이 트랙 밖으로 나가지 않도록 지름만큼 안쪽에서 움직입니다.
             let travel = max(geo.size.width - dotSize, 0)
-            let dotCenter = travel * progress + dotSize / 2
+            let dotCenter = travel * clamped + dotSize / 2
 
             ZStack(alignment: .leading) {
                 Capsule()
@@ -132,7 +125,7 @@ struct TripProgressCard: View {
                 Circle()
                     .fill(Color(hex: "#4F7BFF"))
                     .frame(width: dotSize, height: dotSize)
-                    .offset(x: travel * progress)
+                    .offset(x: travel * clamped)
             }
             .frame(height: geo.size.height, alignment: .center)
         }
@@ -141,9 +134,9 @@ struct TripProgressCard: View {
 
 #Preview {
     VStack(spacing: 12) {
-        TripProgressCard(dayNumber: 1, totalDays: 7, destination: "제주")
-        TripProgressCard(dayNumber: 5, totalDays: 7, destination: "제주")
-        TripProgressCard(dayNumber: 7, totalDays: 7, destination: "제주")
+        TripProgressCard(progress: 0,    remainingDays: 6, destination: "제주")
+        TripProgressCard(progress: 0.65, remainingDays: 3, destination: "제주")
+        TripProgressCard(progress: 1,    remainingDays: 0, destination: "제주")
     }
     .padding(21)
 }

--- a/HiTrip/Info.plist
+++ b/HiTrip/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaomap</string>
+		<string>comgooglemaps</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/HiTrip/Info.plist
+++ b/HiTrip/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>채팅에서 음성 메시지를 녹음하는 데 사용합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>채팅에 사진·동영상을 첨부하는 데 사용합니다.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaomap</string>


### PR DESCRIPTION
## 개요

기획서(홈·여행일정 상세·스팟 상세·현지 언어·긴급 연락·공지 팝업·메시지 목록·채팅방)를 화면별로 대조해 **동작 명세와 어긋난 부분을 고치고**, 마지막 남은 하드코딩 화면인 **주변 인기 스팟(지도)을 서버에 연결**했습니다. 14개 커밋, 30개 파일.

화면 하나씩 진행했습니다: 기획서 대조 → API 확인 → 구현 → Figma 좌표·색상 검증 → 시뮬레이터 확인 → 커밋.

---

## 1. 잡은 버그

**진행 인디케이터가 다른 값을 그리고 있었습니다**
기획은 "당일 첫 일정 시작~마지막 일정 종료 시각 대비 현재 시각"인데 **여행 일차 비율**(3일차/7일)로 계산하고 있었습니다. 당일 시각 기준으로 되돌리고 시작 전 0% / 종료 후 100%로 고정했습니다.

**개인 일정 저장이 실패해도 입력이 사라졌습니다**
저장 버튼이 서버 응답과 무관하게 시트를 닫고 입력값을 지우고 있었습니다. 실패하면 알림창만 뜨고 작성 내용은 이미 없어진 상태였습니다. → 성공했을 때만 닫히고, 실패 시 입력 유지 + [재시도].

**공지 팝업이 통째로 더미였습니다**
"김안내 가이드 / 우천 예상" 하드코딩. 실제 공지 데이터로 교체하고 열람 시 읽음 API를 호출해 홈 빨간 점이 사라지도록 연결했습니다.

**긴급 연락이 안내사에게 전달되지 않았습니다**
`POST /api/v1/tourist/emergency-requests/`가 이미 있는데 화면에 연결이 안 돼 있었습니다. 전화 걸기 전에 요청을 남기도록 붙였습니다(요청이 실패해도 발신은 진행).

**전송 실패 메시지를 지울 수 없었습니다**
탭하면 곧바로 재전송돼 삭제 경로가 없었습니다. → 재전송/삭제 선택 시트.

**채팅 구분선이 디자인보다 진했습니다**
SwiftUI 기본 `Divider()`(시스템 separator) → Figma 값(`#F7F7F9` 1.5pt / `#E5E7EB` 1pt).

**동작하지 않는 버튼들**
스팟 상세의 길찾기·공유·찜, 채팅방의 전화 버튼이 빈 클로저였습니다. 길찾기·전화는 실제 동작으로 채우고, 근거 없는 공유·찜은 제거했습니다.

---

## 2. 화면별 변경

### 홈
- 오늘의 일정 판정을 **서버 `today_day_number`** 기준으로
- 일정 카드 탭 → 여행일정 상세 이동 (탭이 없었음)
- **여행 종료 후 상태 추가** — "여행이 종료되었습니다" + 계정 파기 예정일(종료+3일)
- 스팟 0개면 섹션째 숨김 / 활성 공지(`is_active`)만 노출, 없으면 "등록된 공지가 없어요"
- 메시지 뱃지 99+ 상한, 당겨서 새로고침
- 진행률 카드 신설 (Figma 12152:4224) — `#0C46C0`, 트랙 `#A0BCF8`, 지나온 구간 `#4F7BFF`, Figma의 버스 벡터를 에셋으로 추가해 진행 위치를 따라 이동
- "오늘의 일정" 제목을 진행률 카드 아래로

### 여행일정 상세
- 일정 카드 탭 → 스팟 상세, 설명 2줄 + 더보기
- 개인 일정 **좌측 스와이프 → 수정·삭제** (길게 눌러 삭제만 가능했음), 삭제 확인 팝업
- **수정 기능 신설** — API는 있었으나 화면 연결이 없었음
- 시간 입력을 텍스트 → **휠 피커**, 종료<시작 문구, 공용 일정 겹침을 **입력 중** 주황 경고(저장은 허용)
- 저장 성공 토스트, 아래로 드래그로 닫기, 작성 중 취소 확인
- 일정 0건 일차 "등록된 일정이 없어요"

### 스팟 상세
- 사진 가로 스와이프 + 인디케이터, 광고 뱃지, 주소 복사 + 토스트
- 길찾기 → 카카오맵/구글 지도 선택, 미설치 시 웹 폴백 (`LSApplicationQueriesSchemes` 추가)

### 주변 인기 스팟 (지도) — 하드코딩 1건 → 실서버
- `GET /nearby-spots/` 상황별 검색, `GET /safety/summary/` 지오펜스, `POST /safety/location/` 위치 스냅샷(30초)
- 지오펜스 빨간 점선 원, **경계 밖 연속 60초** 판정 → "안전 구역을 벗어났어요" 배너, 복귀 시 해제, GPS 오차만큼 버퍼 가산
- 오차 50m 초과 시 "GPS 정확도 낮음" 칩 / 권한 거부 시 설정 이동
- 카드 스크롤 ↔ 마커 포커스 연동, 광고 1순위 + 거리순

### 현지 언어
- 재생 불가 시 "재생할 수 없어요" (소리 없이 아무 일도 안 일어났음)

### 메시지 목록 / 채팅방
- 단체톡방 최상단 고정 + 최신순 (정책 통일), 시각 표기 `HH:mm` / `어제` / `M.D`
- 입력 상한 1,000자 (조합형 입력이 깨지지 않게 자르지 않고 카운터·차단)
- 상단 스크롤 시 과거 30개 단위 로드 (`before` 커서 페이징)
- **첨부** — presign → PUT 업로드 → `attachment_ids` 전송, 50MB 제한 안내, 말풍선 렌더링
- **음성 녹음** — 꾹 눌러 녹음/떼면 전송, 최대 3분, 권한 안내
- **오프라인 대기 큐** — 연결이 없으면 실패로 두지 않고 큐에 담아 재연결 시 자동 발송

---

## 확인 방법

`APIEnvironment.current`는 `.remote`로 커밋돼 있습니다. `.remote`에서 여행객 화면을 보려면 여행객 계정 로그인이 필요합니다(디버그 진입 버튼은 토큰이 없어 빈 화면).

시뮬레이터(iPhone 17)에서 화면별로 확인했습니다: 홈 → 진행률 카드 → 일정 상세(스와이프 수정·휠 피커·겹침 경고) → 스팟 상세 → 지도(권한·지오펜스·카드 연동) → 공지 팝업(읽음) → 메시지 목록 → 채팅방(첨부·전송·구분선).

---

## 백엔드 요청 (별도 정리 문서 참조)

앱에서 메울 수 없는 항목이 **12건**입니다. 요약하면:
- 표시할 데이터가 없는 것: 메시지별 읽음, 참여 인원, 공지 작성자명, 스팟 혜택, 날씨, 일정 썸네일, 스팟 사진 배열
- 스펙이 없는 것: WebSocket 이벤트 포맷(typing·수신·읽음)
- 값이 비어 있거나 범위가 부족한 것: `kakao_js_key`, 할랄 카테고리, 여행 시간대, 페이지네이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)
