### PR TITLE
feat: 안내사 화면 8종 기획서 정합 및 스태프 API 연결

### DIFF
--- a/HiTrip/Core/DI/AppDIContainer.swift
+++ b/HiTrip/Core/DI/AppDIContainer.swift
@@ -57,6 +57,17 @@ final class AppDIContainer {
         return ChatRepository(networkService: networkService)
     }()
 
+    /// 안내사(관리자) API — 세션 쿠키 + CSRF 인증
+    private lazy var staffRepository: StaffRepositoryProtocol = {
+        if APIEnvironment.current.useMock {
+            return MockStaffRepository()
+        }
+        return StaffRepository(networkService: networkService)
+    }()
+
+    /// 안내사 화면들이 주입받는 저장소 (기본 인자용)
+    var staffRepositoryForGuide: StaffRepositoryProtocol { staffRepository }
+
     /// 로컬 긴급 연락처 (프리셋 + 개인 저장)
     private lazy var emergencyRepository: EmergencyRepositoryProtocol = {
         EmergencyRepository()

--- a/HiTrip/Core/Network/APIEndpoint+Staff.swift
+++ b/HiTrip/Core/Network/APIEndpoint+Staff.swift
@@ -149,6 +149,12 @@ extension APIEndpoint {
         APIEndpoint(path: "/api/v1/notices/\(id)/", method: .patch, body: body)
     }
 
+    /// 공지 삭제
+    /// DELETE /api/v1/notices/{id}/
+    static func staffNoticeDelete(id: Int) -> APIEndpoint {
+        APIEndpoint(path: "/api/v1/notices/\(id)/", method: .delete)
+    }
+
     /// 공지 게시 — 토글 ON
     /// POST /api/v1/notices/{id}/publish/
     static func staffNoticePublish(id: Int) -> APIEndpoint {

--- a/HiTrip/Core/Network/DTOs/StaffDTO.swift
+++ b/HiTrip/Core/Network/DTOs/StaffDTO.swift
@@ -298,3 +298,45 @@ struct GeofenceDTO: Decodable {
         case updatedAt = "updated_at"
     }
 }
+
+
+// MARK: - 참가자 명부
+
+/// GET /api/v1/trips/{trip_pk}/participants/
+///
+/// 관광객 정보 팝업의 국가·여권번호·전화번호는 여기서 옵니다.
+/// 모니터링 응답(ParticipantLatest)에는 이름만 있어 participant id로 이어 붙입니다.
+struct TripParticipantDTO: Decodable {
+    let id: Int
+    let trip: Int?
+    let traveler: TravelerDetailDTO?
+    let joinedDate: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, trip, traveler
+        case joinedDate = "joined_date"
+    }
+}
+
+struct TravelerDetailDTO: Decodable {
+    let id: Int
+    let fullNameKr: String?
+    let phone: String?
+    let country: String?
+    let passportNumber: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, phone, country
+        case fullNameKr = "full_name_kr"
+        case passportNumber = "passport_number"
+    }
+
+    /// "DND***000" — 중간 3자리를 가립니다
+    var maskedPassport: String? {
+        guard let raw = passportNumber, raw.count >= 6 else { return passportNumber }
+        let chars = Array(raw)
+        let head = String(chars[0..<3])
+        let tail = String(chars[(chars.count - 3)...])
+        return head + "***" + tail
+    }
+}

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -325,6 +325,32 @@ final class MockStaffRepository: StaffRepositoryProtocol {
 
     func fetchGeofences(tripId: Int) -> Single<[GeofenceDTO]> { .just(Self.geofences) }
 
+    func createGeofence(
+        tripId: Int, dayNumber: Int,
+        centerLat: String, centerLng: String, centerAddress: String, radiusKm: Int
+    ) -> Single<GeofenceDTO> {
+        let created = GeofenceDTO(
+            id: (Self.geofences.map(\.id).max() ?? 0) + 1,
+            trip: tripId, dayNumber: dayNumber, revision: 1, isActive: true,
+            centerLat: centerLat, centerLng: centerLng,
+            centerAddress: centerAddress, radiusKm: radiusKm,
+            updatedByName: "김안내", updatedAt: Self.isoNow()
+        )
+        Self.geofences.append(created)
+        return .just(created)
+    }
+
+    func copyPreviousGeofence(tripId: Int, dayNumber: Int, expectedRevision: Int) -> Single<GeofenceDTO> {
+        guard let previous = Self.geofences.last(where: { $0.dayNumber < dayNumber }) else {
+            return .error(HiTripError.notFound(.empty(statusCode: 404)))
+        }
+        return createGeofence(
+            tripId: tripId, dayNumber: dayNumber,
+            centerLat: previous.centerLat, centerLng: previous.centerLng,
+            centerAddress: previous.centerAddress ?? "", radiusKm: previous.radiusKm
+        )
+    }
+
     func updateGeofence(
         tripId: Int, id: Int,
         centerLat: String, centerLng: String, radiusKm: Int,

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -64,6 +64,29 @@ final class MockStaffRepository: StaffRepositoryProtocol {
         )
     }
 
+    func fetchParticipants(tripId: Int) -> Single<[TripParticipantDTO]> {
+        .just([
+            participantProfile(1, "김여행", "010-1111-2222", "대한민국", "M12345678"),
+            participantProfile(2, "이관광", "010-3333-4444", "대한민국", "M23456789"),
+            participantProfile(3, "박구경", nil, "일본", "TK9988776"),
+            participantProfile(4, "최유람", "010-5555-6666", "대한민국", "M34567890"),
+            participantProfile(5, "정나들", "010-7777-8888", "미국", "US4455667"),
+        ])
+    }
+
+    private func participantProfile(
+        _ id: Int, _ name: String, _ phone: String?, _ country: String, _ passport: String
+    ) -> TripParticipantDTO {
+        TripParticipantDTO(
+            id: id, trip: 1,
+            traveler: TravelerDetailDTO(
+                id: id, fullNameKr: name, phone: phone,
+                country: country, passportNumber: passport
+            ),
+            joinedDate: Self.isoNow(minutesAgo: 3000)
+        )
+    }
+
     // MARK: - 일정
 
     func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]> {

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -1,0 +1,256 @@
+import Foundation
+import RxSwift
+
+// MARK: - MockStaffRepository
+/// 서버 없이 안내사 화면을 확인하기 위한 목 구현체
+///
+/// 여행객 목과 같은 기준으로 오늘 날짜에 맞춰 값을 만듭니다.
+/// 안전 상태는 화면에서 위험·경고·이탈·정상이 모두 보이도록 섞어 둡니다.
+
+final class MockStaffRepository: StaffRepositoryProtocol {
+
+    // MARK: - 기준 날짜
+
+    /// 여행 시작일 — 어제 (오늘이 2일차)
+    private static var startDate: Date {
+        Calendar.current.startOfDay(for: Date()).addingTimeInterval(-86_400)
+    }
+
+    private static func ymd(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: date)
+    }
+
+    private static func isoNow(minutesAgo: Int = 0) -> String {
+        let f = ISO8601DateFormatter()
+        return f.string(from: Date().addingTimeInterval(-Double(minutesAgo) * 60))
+    }
+
+    // MARK: - Auth
+
+    func fetchCSRFToken() -> Single<CSRFTokenDTO> { .just(CSRFTokenDTO(csrfToken: "mock")) }
+
+    func login(username: String, password: String) -> Single<StaffProfileDTO> { fetchMe() }
+
+    func logout() -> Single<EmptyResponse> { .just(EmptyResponse()) }
+
+    func fetchMe() -> Single<StaffProfileDTO> {
+        .just(StaffProfileDTO(
+            id: 1, username: "demo_manager1", email: "guide@hitrip.kr", phone: "010-1234-5678",
+            travelAgencyName: "하이트립 투어", fullNameKr: "김안내", fullNameEn: "Kim Annae",
+            roleDisplay: "안내사", isActive: true, isApproved: true
+        ))
+    }
+
+    // MARK: - 담당 여행
+
+    func fetchTrips() -> Single<[StaffTripDTO]> { .just([Self.mockTrip]) }
+
+    func fetchTrip(id: Int) -> Single<StaffTripDTO> { .just(Self.mockTrip) }
+
+    private static var mockTrip: StaffTripDTO {
+        StaffTripDTO(
+            id: 1,
+            title: "뉴진스 바다여행",
+            destination: "제주",
+            startDate: ymd(startDate),
+            endDate: ymd(startDate.addingTimeInterval(86_400 * 3)),
+            managerName: "김안내",
+            participantCount: 12,
+            heartRateMin: 50, heartRateMax: 110, spo2Min: "95",
+            geofenceCenterLat: "33.499621", geofenceCenterLng: "126.531188", geofenceRadiusKm: "3"
+        )
+    }
+
+    // MARK: - 일정
+
+    func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]> {
+        .just([
+            schedule(id: 1, day: 1, "09:00", "10:30", "공항 집결", "미팅 및 이동"),
+            schedule(id: 2, day: 1, "12:00", "13:30", "흑돼지 명가", "점심 식사"),
+            schedule(id: 3, day: 2, "08:00", "09:00", "호텔 식당", "조식"),
+            schedule(id: 4, day: 2, "15:00", "16:00", "숙소로 이동", "버스 이동"),
+            schedule(id: 5, day: 2, "16:00", "23:00", "자유시간", nil),
+            schedule(id: 6, day: 3, "10:00", "12:00", "성산일출봉", "트래킹"),
+        ])
+    }
+
+    private func schedule(
+        id: Int, day: Int, _ start: String, _ end: String,
+        _ place: String, _ content: String?
+    ) -> StaffScheduleDTO {
+        StaffScheduleDTO(
+            id: id, trip: 1, dayNumber: day,
+            startTime: start + ":00", endTime: end + ":00",
+            durationMinutes: 60, placeName: place, durationDisplay: "1시간",
+            transport: "bus", mainContent: content, meetingPoint: nil, order: id
+        )
+    }
+
+    // MARK: - 안전 관리
+
+    func fetchSafetySummary(tripId: Int) -> Single<MonitoringSummaryDTO> {
+        .just(MonitoringSummaryDTO(total: 12, safe: 8, warning: 2, danger: 1, stale: 0, offline: 1, unknown: 0))
+    }
+
+    func fetchParticipantsLatest(tripId: Int) -> Single<[ParticipantLatestDTO]> {
+        .just([
+            participant(1, "김여행", hr: 132, spo2: "88", health: .danger, location: .normal),
+            participant(2, "이관광", hr: 105, spo2: "93", health: .warning, location: .normal),
+            participant(3, "박구경", hr: nil, spo2: nil, health: .offline, location: .offline),
+            participant(4, "최유람", hr: 88, spo2: "97", health: .normal, location: .danger, escaped: true),
+            participant(5, "정나들", hr: 76, spo2: "98", health: .normal, location: .normal),
+        ])
+    }
+
+    private func participant(
+        _ id: Int, _ name: String, hr: Int?, spo2: String?,
+        health: MonitoringStatus, location: MonitoringStatus, escaped: Bool = false
+    ) -> ParticipantLatestDTO {
+        let overall: MonitoringStatus = [health, location].contains(.danger) ? .danger
+            : ([health, location].contains(.warning) ? .warning : health)
+
+        return ParticipantLatestDTO(
+            participantId: id,
+            travelerName: name,
+            tripId: 1,
+            health: HealthSnapshotDTO(heartRate: hr, spo2: spo2, measuredAt: Self.isoNow(minutesAgo: 1)),
+            location: LocationSnapshotDTO(
+                latitude: "33.4996", longitude: "126.5312",
+                accuracyM: "12.0", measuredAt: Self.isoNow(minutesAgo: 1)
+            ),
+            healthStatus: health,
+            locationStatus: location,
+            overallStatus: overall,
+            activeIncidents: escaped ? [IncidentSummaryDTO(
+                id: 90 + id, travelerName: name, incidentType: "geofence",
+                severity: "danger", status: "open", reasonCode: "out_of_geofence",
+                message: "안전 구역에서 1.2km 벗어남",
+                openedAt: Self.isoNow(minutesAgo: 6), acknowledgedAt: nil
+            )] : []
+        )
+    }
+
+    func fetchAlerts(tripId: Int) -> Single<[MonitoringAlertDTO]> {
+        .just([
+            MonitoringAlertDTO(
+                id: 1, travelerName: "김여행", tripId: 1, alertType: "health",
+                severity: "danger", reasonCode: "spo2_low", incident: 91,
+                message: "산소포화도 88% — 위험",
+                snapshotTime: Self.isoNow(minutesAgo: 2), createdAt: Self.isoNow(minutesAgo: 2)
+            ),
+            MonitoringAlertDTO(
+                id: 2, travelerName: "최유람", tripId: 1, alertType: "location",
+                severity: "danger", reasonCode: "out_of_geofence", incident: 94,
+                message: "안전 구역에서 1.2km 벗어남",
+                snapshotTime: Self.isoNow(minutesAgo: 6), createdAt: Self.isoNow(minutesAgo: 6)
+            ),
+            MonitoringAlertDTO(
+                id: 3, travelerName: "이관광", tripId: 1, alertType: "health",
+                severity: "warning", reasonCode: "heart_rate_high", incident: 92,
+                message: "심박수 105bpm — 경고",
+                snapshotTime: Self.isoNow(minutesAgo: 12), createdAt: Self.isoNow(minutesAgo: 12)
+            ),
+        ])
+    }
+
+    func acknowledgeIncident(tripId: Int, incidentId: Int) -> Single<EmptyResponse> {
+        .just(EmptyResponse())
+    }
+
+    // MARK: - 공지
+
+    private static var notices: [StaffNoticeDTO] = [
+        notice(id: 1, "한라산 등반 안전 수칙",
+               "내일 한라산 등반 시 반드시 등산화를 착용해 주세요. 기상 변화가 심하므로 방수 재킷도 필수입니다.",
+               active: true, minutesAgo: 60),
+        notice(id: 2, "조식 시간 변경",
+               "조식이 08:00으로 변경되었습니다. 시간을 엄수해 주세요.",
+               active: false, minutesAgo: 600),
+    ]
+
+    private static func notice(
+        id: Int, _ title: String, _ content: String, active: Bool, minutesAgo: Int
+    ) -> StaffNoticeDTO {
+        StaffNoticeDTO(
+            id: id, scope: "trip", trip: 1, tripTitle: "뉴진스 바다여행",
+            authorName: "김안내", title: title, content: content, priority: "normal",
+            publishedAt: active ? isoNow(minutesAgo: minutesAgo) : nil,
+            isActive: active, readCount: 7, audienceCount: 12, unreadCount: 5,
+            createdAt: isoNow(minutesAgo: minutesAgo)
+        )
+    }
+
+    func fetchNotices() -> Single<[StaffNoticeDTO]> { .just(Self.notices) }
+
+    func createNotice(title: String, content: String, tripId: Int?) -> Single<StaffNoticeDTO> {
+        let created = Self.notice(
+            id: (Self.notices.map(\.id).max() ?? 0) + 1,
+            title, content, active: false, minutesAgo: 0
+        )
+        Self.notices.insert(created, at: 0)
+        return .just(created)
+    }
+
+    /// 활성 공지는 항상 1건 — 다른 공지를 활성화하면 기존 것은 자동으로 내려갑니다
+    func publishNotice(id: Int) -> Single<StaffNoticeDTO> {
+        Self.notices = Self.notices.map { Self.setActive($0, $0.id == id) }
+        return .just(Self.notices.first { $0.id == id } ?? Self.notices[0])
+    }
+
+    func archiveNotice(id: Int) -> Single<StaffNoticeDTO> {
+        Self.notices = Self.notices.map { $0.id == id ? Self.setActive($0, false) : $0 }
+        return .just(Self.notices.first { $0.id == id } ?? Self.notices[0])
+    }
+
+    private static func setActive(_ n: StaffNoticeDTO, _ active: Bool) -> StaffNoticeDTO {
+        StaffNoticeDTO(
+            id: n.id, scope: n.scope, trip: n.trip, tripTitle: n.tripTitle,
+            authorName: n.authorName, title: n.title, content: n.content, priority: n.priority,
+            publishedAt: active ? isoNow() : n.publishedAt, isActive: active,
+            readCount: n.readCount, audienceCount: n.audienceCount, unreadCount: n.unreadCount,
+            createdAt: n.createdAt
+        )
+    }
+
+    // MARK: - 안전 구역
+
+    private static var geofences: [GeofenceDTO] = [
+        GeofenceDTO(
+            id: 1, trip: 1, dayNumber: 1, revision: 1, isActive: true,
+            centerLat: "33.499621", centerLng: "126.531188",
+            centerAddress: "제주특별자치도 제주시 이도이동", radiusKm: 3,
+            updatedByName: "김안내", updatedAt: isoNow(minutesAgo: 600)
+        ),
+        GeofenceDTO(
+            id: 2, trip: 1, dayNumber: 2, revision: 2, isActive: true,
+            centerLat: "33.450701", centerLng: "126.570667",
+            centerAddress: "제주특별자치도 제주시 연동", radiusKm: 5,
+            updatedByName: "김안내", updatedAt: isoNow(minutesAgo: 120)
+        ),
+    ]
+
+    func fetchGeofences(tripId: Int) -> Single<[GeofenceDTO]> { .just(Self.geofences) }
+
+    func updateGeofence(
+        tripId: Int, id: Int,
+        centerLat: String, centerLng: String, radiusKm: Int,
+        expectedRevision: Int
+    ) -> Single<GeofenceDTO> {
+        guard let idx = Self.geofences.firstIndex(where: { $0.id == id }) else {
+            return .error(HiTripError.notFound(.empty(statusCode: 404)))
+        }
+        let old = Self.geofences[idx]
+        let updated = GeofenceDTO(
+            id: old.id, trip: old.trip, dayNumber: old.dayNumber,
+            revision: old.revision + 1, isActive: true,
+            centerLat: centerLat, centerLng: centerLng,
+            centerAddress: old.centerAddress, radiusKm: radiusKm,
+            updatedByName: "김안내", updatedAt: Self.isoNow()
+        )
+        Self.geofences[idx] = updated
+        return .just(updated)
+    }
+}

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -89,15 +89,67 @@ final class MockStaffRepository: StaffRepositoryProtocol {
 
     // MARK: - 일정
 
+    private static var extraSchedules: [StaffScheduleDTO] = []
+    private static var removedScheduleIds: Set<Int> = []
+    private static var edited: [Int: StaffScheduleDTO] = [:]
+
     func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]> {
-        .just([
-            schedule(id: 1, day: 1, "09:00", "10:30", "공항 집결", "미팅 및 이동"),
-            schedule(id: 2, day: 1, "12:00", "13:30", "흑돼지 명가", "점심 식사"),
-            schedule(id: 3, day: 2, "08:00", "09:00", "호텔 식당", "조식"),
-            schedule(id: 4, day: 2, "15:00", "16:00", "숙소로 이동", "버스 이동"),
-            schedule(id: 5, day: 2, "16:00", "23:00", "자유시간", nil),
-            schedule(id: 6, day: 3, "10:00", "12:00", "성산일출봉", "트래킹"),
-        ])
+        let base = Self.baseSchedules(self)
+        let merged = (base + Self.extraSchedules)
+            .filter { !Self.removedScheduleIds.contains($0.id) }
+            .map { Self.edited[$0.id] ?? $0 }
+        return .just(merged.sorted { ($0.dayNumber, $0.startTime) < ($1.dayNumber, $1.startTime) })
+    }
+
+    func createSchedule(
+        tripId: Int, dayNumber: Int,
+        startTime: String, endTime: String, content: String
+    ) -> Single<StaffScheduleDTO> {
+        let created = StaffScheduleDTO(
+            id: (Self.extraSchedules.map(\.id).max() ?? 900) + 1,
+            trip: tripId, dayNumber: dayNumber,
+            startTime: startTime, endTime: endTime,
+            durationMinutes: 60, placeName: content, durationDisplay: "1시간",
+            transport: nil, mainContent: content, meetingPoint: nil, order: 99
+        )
+        Self.extraSchedules.append(created)
+        return .just(created)
+    }
+
+    func updateSchedule(
+        tripId: Int, id: Int,
+        startTime: String?, endTime: String?, content: String?
+    ) -> Single<StaffScheduleDTO> {
+        let all = Self.baseSchedules(self) + Self.extraSchedules
+        guard let old = (Self.edited[id] ?? all.first { $0.id == id }) else {
+            return .error(HiTripError.notFound(.empty(statusCode: 404)))
+        }
+        let updated = StaffScheduleDTO(
+            id: old.id, trip: old.trip, dayNumber: old.dayNumber,
+            startTime: startTime ?? old.startTime, endTime: endTime ?? old.endTime,
+            durationMinutes: old.durationMinutes,
+            placeName: old.placeName, durationDisplay: old.durationDisplay,
+            transport: old.transport, mainContent: content ?? old.mainContent,
+            meetingPoint: old.meetingPoint, order: old.order
+        )
+        Self.edited[id] = updated
+        return .just(updated)
+    }
+
+    func deleteSchedule(tripId: Int, id: Int) -> Single<Void> {
+        Self.removedScheduleIds.insert(id)
+        return .just(())
+    }
+
+    private static func baseSchedules(_ repo: MockStaffRepository) -> [StaffScheduleDTO] {
+        [
+            repo.schedule(id: 1, day: 1, "09:00", "10:30", "공항 집결", "미팅 및 이동"),
+            repo.schedule(id: 2, day: 1, "12:00", "13:30", "흑돼지 명가", "점심 식사"),
+            repo.schedule(id: 3, day: 2, "08:00", "09:00", "호텔 식당", "조식"),
+            repo.schedule(id: 4, day: 2, "15:00", "16:00", "숙소로 이동", "버스 이동"),
+            repo.schedule(id: 5, day: 2, "16:00", "23:00", "자유시간", nil),
+            repo.schedule(id: 6, day: 3, "10:00", "12:00", "성산일출봉", "트래킹"),
+        ]
     }
 
     private func schedule(

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -291,6 +291,11 @@ final class MockStaffRepository: StaffRepositoryProtocol {
         return .just(Self.notices.first { $0.id == id } ?? Self.notices[0])
     }
 
+    func deleteNotice(id: Int) -> Single<Void> {
+        Self.notices.removeAll { $0.id == id }
+        return .just(())
+    }
+
     func archiveNotice(id: Int) -> Single<StaffNoticeDTO> {
         Self.notices = Self.notices.map { $0.id == id ? Self.setActive($0, false) : $0 }
         return .just(Self.notices.first { $0.id == id } ?? Self.notices[0])

--- a/HiTrip/Data/Repositories/MockStaffRepository.swift
+++ b/HiTrip/Data/Repositories/MockStaffRepository.swift
@@ -217,6 +217,22 @@ final class MockStaffRepository: StaffRepositoryProtocol {
         return .just(created)
     }
 
+    func updateNotice(id: Int, title: String, content: String) -> Single<StaffNoticeDTO> {
+        guard let idx = Self.notices.firstIndex(where: { $0.id == id }) else {
+            return .error(HiTripError.notFound(.empty(statusCode: 404)))
+        }
+        let old = Self.notices[idx]
+        let updated = StaffNoticeDTO(
+            id: old.id, scope: old.scope, trip: old.trip, tripTitle: old.tripTitle,
+            authorName: old.authorName, title: title, content: content, priority: old.priority,
+            publishedAt: old.publishedAt, isActive: old.isActive,
+            readCount: old.readCount, audienceCount: old.audienceCount,
+            unreadCount: old.unreadCount, createdAt: old.createdAt
+        )
+        Self.notices[idx] = updated
+        return .just(updated)
+    }
+
     /// 활성 공지는 항상 1건 — 다른 공지를 활성화하면 기존 것은 자동으로 내려갑니다
     func publishNotice(id: Int) -> Single<StaffNoticeDTO> {
         Self.notices = Self.notices.map { Self.setActive($0, $0.id == id) }

--- a/HiTrip/Data/Repositories/StaffRepository.swift
+++ b/HiTrip/Data/Repositories/StaffRepository.swift
@@ -49,6 +49,15 @@ protocol StaffRepositoryProtocol {
 
     // 안전 구역
     func fetchGeofences(tripId: Int) -> Single<[GeofenceDTO]>
+
+    /// 미설정 일차에 새로 만듭니다
+    func createGeofence(
+        tripId: Int, dayNumber: Int,
+        centerLat: String, centerLng: String, centerAddress: String, radiusKm: Int
+    ) -> Single<GeofenceDTO>
+
+    /// 전일 설정 복사 — 미설정 일차의 기본값 제안
+    func copyPreviousGeofence(tripId: Int, dayNumber: Int, expectedRevision: Int) -> Single<GeofenceDTO>
     func updateGeofence(
         tripId: Int, id: Int,
         centerLat: String, centerLng: String, radiusKm: Int,
@@ -212,6 +221,33 @@ final class StaffRepository: StaffRepositoryProtocol {
     }
 
     /// expected_revision을 함께 보내 낙관적 잠금 충돌을 서버가 감지하게 합니다.
+    func createGeofence(
+        tripId: Int, dayNumber: Int,
+        centerLat: String, centerLng: String, centerAddress: String, radiusKm: Int
+    ) -> Single<GeofenceDTO> {
+        let body: [String: Any] = [
+            "day_number": dayNumber,
+            "center_lat": centerLat,
+            "center_lng": centerLng,
+            "center_address": centerAddress,
+            "radius_km": radiusKm,
+        ]
+        return networkService.request(
+            .staffGeofenceCreate(tripId: tripId, body: body),
+            type: GeofenceDTO.self
+        )
+    }
+
+    func copyPreviousGeofence(tripId: Int, dayNumber: Int, expectedRevision: Int) -> Single<GeofenceDTO> {
+        networkService.request(
+            .staffGeofenceCopyPrevious(
+                tripId: tripId,
+                body: ["day_number": dayNumber, "expected_revision": expectedRevision]
+            ),
+            type: GeofenceDTO.self
+        )
+    }
+
     func updateGeofence(
         tripId: Int, id: Int,
         centerLat: String, centerLng: String, radiusKm: Int,

--- a/HiTrip/Data/Repositories/StaffRepository.swift
+++ b/HiTrip/Data/Repositories/StaffRepository.swift
@@ -14,6 +14,9 @@ protocol StaffRepositoryProtocol {
     func fetchTrips() -> Single<[StaffTripDTO]>
     func fetchTrip(id: Int) -> Single<StaffTripDTO>
 
+    /// 참가자 명부 — 연락처·국가·여권번호
+    func fetchParticipants(tripId: Int) -> Single<[TripParticipantDTO]>
+
     // 일정
     func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]>
 
@@ -89,6 +92,10 @@ final class StaffRepository: StaffRepositoryProtocol {
     }
 
     // MARK: - 일정
+
+    func fetchParticipants(tripId: Int) -> Single<[TripParticipantDTO]> {
+        networkService.request(.staffTripParticipants(tripId: tripId), type: [TripParticipantDTO].self)
+    }
 
     func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]> {
         networkService.request(.staffSchedules(tripId: tripId), type: [StaffScheduleDTO].self)

--- a/HiTrip/Data/Repositories/StaffRepository.swift
+++ b/HiTrip/Data/Repositories/StaffRepository.swift
@@ -29,6 +29,7 @@ protocol StaffRepositoryProtocol {
     // 공지
     func fetchNotices() -> Single<[StaffNoticeDTO]>
     func createNotice(title: String, content: String, tripId: Int?) -> Single<StaffNoticeDTO>
+    func updateNotice(id: Int, title: String, content: String) -> Single<StaffNoticeDTO>
     func publishNotice(id: Int) -> Single<StaffNoticeDTO>
     func archiveNotice(id: Int) -> Single<StaffNoticeDTO>
 
@@ -137,6 +138,13 @@ final class StaffRepository: StaffRepositoryProtocol {
             body["scope"] = "global"
         }
         return networkService.request(.staffNoticeCreate(body: body), type: StaffNoticeDTO.self)
+    }
+
+    func updateNotice(id: Int, title: String, content: String) -> Single<StaffNoticeDTO> {
+        networkService.request(
+            .staffNoticeUpdate(id: id, body: ["title": title, "content": content]),
+            type: StaffNoticeDTO.self
+        )
     }
 
     func publishNotice(id: Int) -> Single<StaffNoticeDTO> {

--- a/HiTrip/Data/Repositories/StaffRepository.swift
+++ b/HiTrip/Data/Repositories/StaffRepository.swift
@@ -20,6 +20,20 @@ protocol StaffRepositoryProtocol {
     // 일정
     func fetchSchedules(tripId: Int) -> Single<[StaffScheduleDTO]>
 
+    /// 일정 추가 — 장소는 place_id로만 지정할 수 있어 제목은 main_content에 넣습니다
+    func createSchedule(
+        tripId: Int, dayNumber: Int,
+        startTime: String, endTime: String, content: String
+    ) -> Single<StaffScheduleDTO>
+
+    /// 시간 변경·메모 수정 — 바뀐 값만 보냅니다
+    func updateSchedule(
+        tripId: Int, id: Int,
+        startTime: String?, endTime: String?, content: String?
+    ) -> Single<StaffScheduleDTO>
+
+    func deleteSchedule(tripId: Int, id: Int) -> Single<Void>
+
     // 안전 관리
     func fetchSafetySummary(tripId: Int) -> Single<MonitoringSummaryDTO>
     func fetchParticipantsLatest(tripId: Int) -> Single<[ParticipantLatestDTO]>
@@ -103,6 +117,42 @@ final class StaffRepository: StaffRepositoryProtocol {
     }
 
     // MARK: - 안전 관리
+
+    func createSchedule(
+        tripId: Int, dayNumber: Int,
+        startTime: String, endTime: String, content: String
+    ) -> Single<StaffScheduleDTO> {
+        let body: [String: Any] = [
+            "day_number": dayNumber,
+            "start_time": startTime,
+            "end_time": endTime,
+            "main_content": content,
+        ]
+        return networkService.request(
+            .staffScheduleCreate(tripId: tripId, body: body),
+            type: StaffScheduleDTO.self
+        )
+    }
+
+    func updateSchedule(
+        tripId: Int, id: Int,
+        startTime: String?, endTime: String?, content: String?
+    ) -> Single<StaffScheduleDTO> {
+        var body: [String: Any] = [:]
+        if let startTime { body["start_time"] = startTime }
+        if let endTime   { body["end_time"] = endTime }
+        if let content   { body["main_content"] = content }
+
+        return networkService.request(
+            .staffScheduleUpdate(tripId: tripId, id: id, body: body),
+            type: StaffScheduleDTO.self
+        )
+    }
+
+    func deleteSchedule(tripId: Int, id: Int) -> Single<Void> {
+        networkService.request(.staffScheduleDelete(tripId: tripId, id: id), type: EmptyResponse.self)
+            .map { _ in () }
+    }
 
     func fetchSafetySummary(tripId: Int) -> Single<MonitoringSummaryDTO> {
         networkService.request(.monitoringSummary(tripId: tripId), type: MonitoringSummaryDTO.self)

--- a/HiTrip/Data/Repositories/StaffRepository.swift
+++ b/HiTrip/Data/Repositories/StaffRepository.swift
@@ -46,6 +46,7 @@ protocol StaffRepositoryProtocol {
     func updateNotice(id: Int, title: String, content: String) -> Single<StaffNoticeDTO>
     func publishNotice(id: Int) -> Single<StaffNoticeDTO>
     func archiveNotice(id: Int) -> Single<StaffNoticeDTO>
+    func deleteNotice(id: Int) -> Single<Void>
 
     // 안전 구역
     func fetchGeofences(tripId: Int) -> Single<[GeofenceDTO]>
@@ -204,6 +205,11 @@ final class StaffRepository: StaffRepositoryProtocol {
             .staffNoticeUpdate(id: id, body: ["title": title, "content": content]),
             type: StaffNoticeDTO.self
         )
+    }
+
+    func deleteNotice(id: Int) -> Single<Void> {
+        networkService.request(.staffNoticeDelete(id: id), type: EmptyResponse.self)
+            .map { _ in () }
     }
 
     func publishNotice(id: Int) -> Single<StaffNoticeDTO> {

--- a/HiTrip/Features/Notification/ViewModels/AlertCenterViewModel.swift
+++ b/HiTrip/Features/Notification/ViewModels/AlertCenterViewModel.swift
@@ -1,0 +1,194 @@
+import Foundation
+import RxSwift
+
+// MARK: - AlertCenterViewModel
+/// 알림 센터 — Figma 12381:4544 (신규 화면)
+///
+/// - GET  /api/monitoring/trips/{id}/alerts/                        경고·위험·이탈 알림
+/// - POST /api/monitoring/trips/{id}/incidents/{iid}/acknowledge/   위험 알림 [확인]
+///
+/// 읽음 상태는 서버에 필드가 없어 앱에서만 관리합니다.
+
+@MainActor
+final class AlertCenterViewModel: ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    /// 필터 칩 — 기획의 5종
+    enum Kind: String, CaseIterable, Identifiable {
+        case all, danger, warning, escaped, normal
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .all:     return "전체"
+            case .danger:  return "위험"
+            case .warning: return "경고"
+            case .escaped: return "이탈"
+            case .normal:  return "일반"
+            }
+        }
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var alerts: [MonitoringAlertDTO] = []
+    @Published var kind: Kind = .all
+
+    /// 읽은 알림 id — 카드 배경을 회색으로 바꾸는 기준
+    @Published private(set) var readIds: Set<Int> = []
+    /// 확인 처리한 위험 알림 id — 재알림이 멈춥니다
+    @Published private(set) var acknowledgedIds: Set<Int> = []
+
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private var tripId: Int?
+
+    init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
+        self.repository = repository
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] trips in
+                    guard let self else { return }
+                    guard let trip = trips.first else {
+                        self.state = .loaded
+                        return
+                    }
+                    self.tripId = trip.id
+                    self.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func refresh() {
+        guard let tripId else { return }
+        repository.fetchAlerts(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] list in
+                    self?.alerts = list.sorted { $0.createdAt > $1.createdAt }
+                    self?.state = .loaded
+                },
+                onFailure: { [weak self] error in
+                    if self?.alerts.isEmpty ?? true {
+                        self?.state = .failed(Self.message(for: error))
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 목록
+
+    var filtered: [MonitoringAlertDTO] { alerts.filter { matches($0) } }
+
+    private func matches(_ alert: MonitoringAlertDTO) -> Bool {
+        switch kind {
+        case .all:     return true
+        case .danger:  return alert.alertType != "location" && alert.severity == "danger"
+        case .warning: return alert.alertType != "location" && alert.severity == "warning"
+        case .escaped: return alert.alertType == "location"
+        case .normal:  return alert.alertType != "location" && alert.alertType != "health"
+        }
+    }
+
+    var isEmpty: Bool { filtered.isEmpty && state == .loaded }
+
+    // MARK: - 카드 표시
+
+    /// 뱃지 문구 — 이탈은 유형으로, 나머지는 심각도로 정합니다
+    func badgeText(_ alert: MonitoringAlertDTO) -> String {
+        if alert.alertType == "location" { return "이탈" }
+        if alert.alertType != "health"   { return "일반" }
+        return alert.severity == "danger" ? "위험" : "경고"
+    }
+
+    func isDangerous(_ alert: MonitoringAlertDTO) -> Bool {
+        alert.alertType == "location" || alert.severity == "danger"
+    }
+
+    func isGeneral(_ alert: MonitoringAlertDTO) -> Bool {
+        alert.alertType != "location" && alert.alertType != "health"
+    }
+
+    /// 카드 본문 — 서버 메시지에 이름이 없으면 앞에 붙입니다
+    func messageText(_ alert: MonitoringAlertDTO) -> String {
+        let name = alert.travelerName
+        guard !name.isEmpty, !alert.message.contains(name) else { return alert.message }
+        return "\(name)님 · \(alert.message)"
+    }
+
+    /// "10:24 · 탭하여 위치 확인"
+    func metaText(_ alert: MonitoringAlertDTO) -> String {
+        var parts = [Self.hhmm(alert.snapshotTime)]
+        if alert.alertType == "location" { parts.append("탭하여 위치 확인") }
+        return parts.joined(separator: " · ")
+    }
+
+    func isRead(_ alert: MonitoringAlertDTO) -> Bool { readIds.contains(alert.id) }
+
+    /// 확인이 필요한 위험 알림인지 — [확인] 전까지 5분 주기로 다시 알립니다
+    func needsAcknowledge(_ alert: MonitoringAlertDTO) -> Bool {
+        alert.severity == "danger"
+            && alert.incident != nil
+            && !acknowledgedIds.contains(alert.id)
+    }
+
+    func markRead(_ alert: MonitoringAlertDTO) { readIds.insert(alert.id) }
+
+    /// [확인] — 서버에 인지 처리를 남깁니다 (대응 이력)
+    func acknowledge(_ alert: MonitoringAlertDTO) {
+        guard let tripId, let incidentId = alert.incident else { return }
+        acknowledgedIds.insert(alert.id)
+        readIds.insert(alert.id)
+
+        repository.acknowledgeIncident(tripId: tripId, incidentId: incidentId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in self?.refresh() },
+                       onFailure: { [weak self] _ in
+                           self?.acknowledgedIds.remove(alert.id)
+                       })
+            .disposed(by: disposeBag)
+    }
+
+    private static func hhmm(_ iso: String) -> String {
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = parser.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+        guard let date else { return "" }
+
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            default:                        break
+            }
+        }
+        return "알림을 불러오지 못했어요"
+    }
+}

--- a/HiTrip/Features/Notification/ViewModels/AlertCenterViewModel.swift
+++ b/HiTrip/Features/Notification/ViewModels/AlertCenterViewModel.swift
@@ -48,6 +48,8 @@ final class AlertCenterViewModel: ObservableObject {
     private let repository: StaffRepositoryProtocol
     private let disposeBag = DisposeBag()
     private var tripId: Int?
+    /// 이름 → participant id — 알림에 participant_id가 없어 명단으로 맞춥니다
+    @Published private(set) var participantIdsByName: [String: Int] = [:]
 
     init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
         self.repository = repository
@@ -69,6 +71,7 @@ final class AlertCenterViewModel: ObservableObject {
                         return
                     }
                     self.tripId = trip.id
+                    self.loadParticipantIds(tripId: trip.id)
                     self.refresh()
                 },
                 onFailure: { [weak self] error in
@@ -76,6 +79,23 @@ final class AlertCenterViewModel: ObservableObject {
                 }
             )
             .disposed(by: disposeBag)
+    }
+
+    /// 이탈 알림에서 위치 확인으로 넘어가려면 participant id가 필요합니다
+    private func loadParticipantIds(tripId: Int) {
+        repository.fetchParticipantsLatest(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] list in
+                self?.participantIdsByName = Dictionary(
+                    list.map { ($0.travelerName, $0.participantId) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    func participantId(for alert: MonitoringAlertDTO) -> Int? {
+        participantIdsByName[alert.travelerName]
     }
 
     func refresh() {

--- a/HiTrip/Features/Notification/Views/NotificationCenterView.swift
+++ b/HiTrip/Features/Notification/Views/NotificationCenterView.swift
@@ -15,6 +15,7 @@ struct NotificationCenterView: View {
 
     @State private var showLocation = false
     @State private var locationTargetName: String?
+    @State private var locationTargetId: Int?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,7 +40,10 @@ struct NotificationCenterView: View {
         .navigationBarHidden(true)
         .task { viewModel.load() }
         .navigationDestination(isPresented: $showLocation) {
-            TouristLocationView(touristName: locationTargetName ?? "")
+            TouristLocationView(
+                participantId: locationTargetId ?? 0,
+                touristName: locationTargetName ?? ""
+            )
         }
     }
 
@@ -182,6 +186,7 @@ struct NotificationCenterView: View {
 
         if alert.alertType == "location" {
             locationTargetName = alert.travelerName
+            locationTargetId = viewModel.participantId(for: alert)
             showLocation = true
         } else {
             // 건강·일정 알림은 앞 화면(안전 관리·전체일정)으로 돌아가 확인합니다

--- a/HiTrip/Features/Notification/Views/NotificationCenterView.swift
+++ b/HiTrip/Features/Notification/Views/NotificationCenterView.swift
@@ -1,175 +1,229 @@
 import SwiftUI
 
+// MARK: - NotificationCenterView
+/// 알림 센터 (안내사 전용) — Figma 12381:4544
+///
+/// 안전 경고·위험·이탈 알림의 단일 수신 창구입니다.
+/// 위험 알림은 [확인]을 누를 때까지 서버가 5분 주기로 다시 알립니다.
+///
+/// 여행객에게는 노출하지 않습니다 (다른 관광객의 건강 정보가 보입니다).
+
 struct NotificationCenterView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @State private var selectedFilter = "전체"
+    @StateObject private var viewModel = AlertCenterViewModel()
 
-    private let filters = ["전체", "위험", "경고", "이탈", "일반"]
-
-    private let notifications: [NCItem] = [
-        NCItem(type: "위험", title: "에디님의 심박수가 위험 수치입니다! 바로 확인하세요!",
-               detail: "10:24 · 심박 187bpm", time: "10:24", requiresAction: true),
-        NCItem(type: "이탈", title: "둘리님이 안전 구역을 벗어났습니다 (1.2km)",
-               detail: "10:18 · 탭하여 위치 확인", time: "10:18", requiresAction: false),
-        NCItem(type: "경고", title: "펭수님의 심박수가 경고 수치입니다. 확인이 필요합니다.",
-               detail: "09:52 · 심박 135bpm", time: "09:52", requiresAction: false),
-        NCItem(type: "일반", title: "일정이 변경되었습니다 — 2일차 13:00 점심 장소 변경",
-               detail: "09:30", time: "09:30", requiresAction: false),
-    ]
-
-    private var filtered: [NCItem] {
-        selectedFilter == "전체" ? notifications : notifications.filter { $0.type == selectedFilter }
-    }
+    @State private var showLocation = false
+    @State private var locationTargetName: String?
 
     var body: some View {
         VStack(spacing: 0) {
             headerSection
+            filterChips
+                .padding(.top, 33)
 
-            filterRow
-                .padding(.top, 8)
-
-            ScrollView {
-                LazyVStack(spacing: 10) {
-                    ForEach(filtered) { item in
-                        notificationCard(item)
-                    }
+            switch viewModel.state {
+            case .idle, .loading:
+                loadingView
+            case .failed(let message):
+                errorView(message)
+            case .loaded:
+                if viewModel.isEmpty {
+                    emptyView
+                } else {
+                    alertList
                 }
-                .padding(.horizontal, 20)
-                .padding(.top, 12)
-                .padding(.bottom, 32)
             }
         }
         .background(Color.white)
         .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .navigationDestination(isPresented: $showLocation) {
+            TouristLocationView(touristName: locationTargetName ?? "")
+        }
     }
 
-    // MARK: - Header
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("알림")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
+
             HStack {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
             }
-            .padding(.horizontal, 12)
+            .padding(.leading, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
     // MARK: - 필터 칩
 
-    private var filterRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(filters, id: \.self) { f in
-                    Button { selectedFilter = f } label: {
-                        Text(f)
-                            .font(.system(size: 12, weight: selectedFilter == f ? .bold : .medium))
-                            .foregroundColor(selectedFilter == f ? .white : Color(hex: "#6B7280"))
-                            .padding(.horizontal, 16)
-                            .frame(height: 34)
-                            .background(selectedFilter == f ? Color(hex: "#2563EB") : Color(hex: "#F3F4F6"))
-                            .clipShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
+    private var filterChips: some View {
+        HStack(spacing: 8) {
+            ForEach(AlertCenterViewModel.Kind.allCases) { kind in
+                let isOn = viewModel.kind == kind
+                Button { viewModel.kind = kind } label: {
+                    Text(kind.label)
+                        .font(.system(size: 12, weight: isOn ? .bold : .medium))
+                        .foregroundColor(isOn ? .white : Color(hex: "#6B7280"))
+                        .frame(width: kind == .all ? 64 : 56, height: 32)
+                        .background(isOn ? Color(hex: "#2563EB") : Color(hex: "#F3F4F6"))
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
                 }
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 20)
+            Spacer(minLength: 0)
         }
-        .padding(.bottom, 4)
+        .padding(.horizontal, 24)
     }
 
-    // MARK: - 알림 카드
+    // MARK: - 목록
 
-    private func notificationCard(_ item: NCItem) -> some View {
-        let colors = badgeColors(item.type)
-        return VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 10) {
-                Text(item.type)
+    private var alertList: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(viewModel.filtered, id: \.id) { alert in
+                    alertCard(alert)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 28)
+            .padding(.bottom, 32)
+        }
+        .refreshable { viewModel.refresh() }
+    }
+
+    private func alertCard(_ alert: MonitoringAlertDTO) -> some View {
+        let needsAck = viewModel.needsAcknowledge(alert)
+
+        return VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                Text(viewModel.badgeText(alert))
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(colors.text)
-                    .padding(.horizontal, 10)
-                    .frame(height: 22)
-                    .background(colors.bg)
-                    .cornerRadius(6)
+                    .foregroundColor(badgeForeground(alert))
+                    .frame(width: 44, height: 22)
+                    .background(badgeBackground(alert))
+                    .cornerRadius(4)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(item.title)
-                        .font(.system(size: 13, weight: .medium))
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(viewModel.messageText(alert))
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(Color(hex: "#111827"))
                         .fixedSize(horizontal: false, vertical: true)
-                    if !item.detail.isEmpty {
-                        Text(item.detail)
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(hex: "#6B7280"))
+
+                    Text(viewModel.metaText(alert))
+                        .font(.system(size: 10))
+                        .foregroundColor(Color(hex: "#6B7280"))
+                        .padding(.top, 8)
+
+                    if needsAck {
+                        Text("[확인] 전까지 5분 주기 재알림")
+                            .font(.system(size: 9))
+                            .foregroundColor(Color(hex: "#EF4444"))
+                            .padding(.top, 6)
                     }
                 }
 
-                Spacer()
+                Spacer(minLength: 0)
             }
 
-            if item.requiresAction {
+            if needsAck {
                 HStack {
                     Spacer()
-                    Button { } label: {
+                    Button { viewModel.acknowledge(alert) } label: {
                         Text("확인")
                             .font(.system(size: 12, weight: .bold))
-                            .foregroundColor(Color(hex: "#EF4444"))
-                            .frame(width: 60, height: 32)
-                            .background(Color.white)
+                            .foregroundColor(.white)
+                            .frame(width: 80, height: 28)
+                            .background(Color(hex: "#EF4444"))
                             .cornerRadius(8)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color(hex: "#EF4444"), lineWidth: 1)
-                            )
                     }
                     .buttonStyle(.plain)
                 }
-
-                Text("[확인] 전까지 5분 주기 재알림")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(Color(hex: "#EF4444"))
+                .padding(.top, 8)
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 14)
-        .background(colors.cardBg)
-        .cornerRadius(12)
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // 읽은 알림은 배경을 회색으로
+        .background(viewModel.isRead(alert) ? Color(hex: "#F9FAFB") : Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(colors.border, lineWidth: 1)
+                .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
         )
+        .contentShape(Rectangle())
+        .onTapGesture { open(alert) }
     }
 
-    private func badgeColors(_ type: String) -> (bg: Color, text: Color, cardBg: Color, border: Color) {
-        switch type {
-        case "위험", "이탈":
-            return (Color(hex: "#FCE5E5"), Color(hex: "#EF4444"),
-                    Color(hex: "#FFF5F5"), Color(hex: "#FECACA"))
-        case "경고":
-            return (Color(hex: "#FFF2D9"), Color(hex: "#EB8C0D"),
-                    Color(hex: "#FFFBF0"), Color(hex: "#FDE68A"))
-        default:
-            return (Color(hex: "#E8F0FF"), Color(hex: "#2563EB"),
-                    Color(hex: "#F8FAFF"), Color(hex: "#BFDBFE"))
+    private func badgeBackground(_ alert: MonitoringAlertDTO) -> Color {
+        if viewModel.isGeneral(alert) { return Color(hex: "#E8F0FF") }
+        return viewModel.isDangerous(alert) ? Color(hex: "#FCE5E5") : Color(hex: "#FFF2D9")
+    }
+
+    private func badgeForeground(_ alert: MonitoringAlertDTO) -> Color {
+        if viewModel.isGeneral(alert) { return Color(hex: "#2563EB") }
+        return viewModel.isDangerous(alert) ? Color(hex: "#EF4444") : Color(hex: "#EB8C0D")
+    }
+
+    /// 유형별 딥링크 — 이탈은 위치 확인, 건강은 안전 관리로 돌아갑니다
+    private func open(_ alert: MonitoringAlertDTO) {
+        viewModel.markRead(alert)
+
+        if alert.alertType == "location" {
+            locationTargetName = alert.travelerName
+            showLocation = true
+        } else {
+            // 건강·일정 알림은 앞 화면(안전 관리·전체일정)으로 돌아가 확인합니다
+            dismiss()
         }
     }
-}
 
-private struct NCItem: Identifiable {
-    let id = UUID()
-    let type: String
-    let title: String
-    let detail: String
-    let time: String
-    let requiresAction: Bool
+    // MARK: - 상태 화면
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("알림을 불러오는 중이에요")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        Text("알림이 없어요")
+            .font(.system(size: 14))
+            .foregroundColor(Color(hex: "#6B7280"))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            Text(message)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+            Button { viewModel.load() } label: {
+                Text("재시도")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+                    .frame(height: 44)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 }

--- a/HiTrip/Features/Schedule/ViewModels/MapRangeSettingViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/MapRangeSettingViewModel.swift
@@ -1,0 +1,310 @@
+import Foundation
+import CoreLocation
+import RxSwift
+
+// MARK: - MapRangeSettingViewModel
+/// 지도 범위 설정 (지오펜스) — Figma 12380:1051
+///
+/// - GET  /api/trips/{id}/geofences/                 일차별 설정
+/// - POST /api/trips/{id}/geofences/                 미설정 일차 새로 만들기
+/// - POST /api/trips/{id}/geofences/copy-previous/   전일 설정 복사
+/// - PATCH /api/trips/{id}/geofences/{gid}/          수정 (expected_revision 낙관적 잠금)
+///
+/// 저장한 좌표는 고정입니다. 안내사가 이동해도 원이 따라오지 않습니다.
+
+@MainActor
+final class MapRangeSettingViewModel: NSObject, ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var trip: StaffTripDTO?
+    @Published private(set) var geofences: [GeofenceDTO] = []
+    @Published var selectedDay: Int = 1
+
+    /// 편집 중인 값 — 저장 전까지는 서버에 반영되지 않습니다
+    @Published var centerCoordinate: CLLocationCoordinate2D?
+    @Published var radiusKm: Int = 3
+    @Published private(set) var centerAddress: String = ""
+
+    @Published private(set) var isSaving = false
+    @Published var saveError: String?
+    @Published var toast: String?
+
+    /// 내 위치 — "내 위치로 중심 설정"에 씁니다
+    @Published private(set) var myLocation: CLLocationCoordinate2D?
+    @Published private(set) var locationDenied = false
+
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private let locationManager = CLLocationManager()
+    private let geocoder = CLGeocoder()
+
+    /// 저장된 값 — 미저장 변경이 있는지 비교합니다
+    private var savedCenter: CLLocationCoordinate2D?
+    private var savedRadius: Int = 3
+
+    init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
+        self.repository = repository
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] trips in
+                    guard let self else { return }
+                    guard let trip = trips.first else {
+                        self.state = .loaded
+                        return
+                    }
+                    self.trip = trip
+                    self.selectedDay = self.todayDayNumber ?? 1
+                    self.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+
+        requestLocation()
+    }
+
+    func refresh() {
+        guard let tripId = trip?.id else { return }
+
+        repository.fetchGeofences(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] list in
+                    self?.geofences = list
+                    self?.state = .loaded
+                    self?.applyDay(self?.selectedDay ?? 1)
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 일차
+
+    var totalDays: Int {
+        guard let trip,
+              let start = Self.date(from: trip.startDate),
+              let end = Self.date(from: trip.endDate),
+              let days = Calendar.current.dateComponents([.day], from: start, to: end).day
+        else { return 1 }
+        return max(days + 1, 1)
+    }
+
+    /// 스태프 API에 today_day_number가 없어 시작일로 계산합니다
+    var todayDayNumber: Int? {
+        guard let start = Self.date(from: trip?.startDate) else { return nil }
+        let today = Calendar.current.startOfDay(for: Date())
+        let days = Calendar.current.dateComponents([.day], from: start, to: today).day ?? 0
+        return days >= 0 ? days + 1 : nil
+    }
+
+    func geofence(for day: Int) -> GeofenceDTO? {
+        geofences.first { $0.dayNumber == day }
+    }
+
+    var currentGeofence: GeofenceDTO? { geofence(for: selectedDay) }
+
+    /// 이 일차가 아직 설정되지 않았는지 — 전일 복사를 제안합니다
+    var isUnset: Bool { currentGeofence == nil }
+
+    func select(day: Int) {
+        selectedDay = day
+        applyDay(day)
+    }
+
+    /// 선택한 일차의 저장값을 편집 상태로 옮깁니다.
+    /// 미설정 일차면 전일 값을 기본값으로 제안합니다.
+    private func applyDay(_ day: Int) {
+        if let fence = geofence(for: day) {
+            centerCoordinate = Self.coordinate(fence)
+            radiusKm = fence.radiusKm
+            centerAddress = fence.centerAddress ?? ""
+        } else if let previous = geofences.last(where: { $0.dayNumber < day }) {
+            centerCoordinate = Self.coordinate(previous)
+            radiusKm = previous.radiusKm
+            centerAddress = previous.centerAddress ?? ""
+        } else {
+            centerCoordinate = myLocation
+            radiusKm = 3
+            centerAddress = ""
+            reverseGeocode()
+        }
+        savedCenter = centerCoordinate
+        savedRadius = radiusKm
+    }
+
+    /// 저장하지 않은 변경이 있는지 — 나가기 확인에 씁니다
+    var hasUnsavedChanges: Bool {
+        if radiusKm != savedRadius { return true }
+        guard let current = centerCoordinate, let saved = savedCenter else {
+            return centerCoordinate != nil
+        }
+        return abs(current.latitude - saved.latitude) > 0.000001
+            || abs(current.longitude - saved.longitude) > 0.000001
+    }
+
+    // MARK: - 중심 지정
+
+    /// 지도 롱프레스·주소 검색 결과로 중심을 옮깁니다
+    func setCenter(_ coordinate: CLLocationCoordinate2D) {
+        centerCoordinate = coordinate
+        reverseGeocode()
+    }
+
+    func useMyLocation() {
+        guard let myLocation else {
+            if locationDenied { toast = "위치 권한을 허용해주세요" }
+            return
+        }
+        setCenter(myLocation)
+    }
+
+    private func reverseGeocode() {
+        guard let coordinate = centerCoordinate else { return }
+        geocoder.reverseGeocodeLocation(
+            CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        ) { [weak self] marks, _ in
+            guard let mark = marks?.first else { return }
+            let text = [mark.locality, mark.subLocality, mark.thoroughfare, mark.subThoroughfare]
+                .compactMap { $0 }
+                .joined(separator: " ")
+            Task { @MainActor in
+                self?.centerAddress = text.isEmpty ? "주소를 확인할 수 없어요" : text
+            }
+        }
+    }
+
+    // MARK: - 저장
+
+    func save() {
+        guard let tripId = trip?.id, let center = centerCoordinate else { return }
+        isSaving = true
+
+        let lat = String(format: "%.6f", center.latitude)
+        let lng = String(format: "%.6f", center.longitude)
+
+        let request: Single<GeofenceDTO>
+        if let fence = currentGeofence {
+            request = repository.updateGeofence(
+                tripId: tripId, id: fence.id,
+                centerLat: lat, centerLng: lng, radiusKm: radiusKm,
+                expectedRevision: fence.revision
+            )
+        } else {
+            request = repository.createGeofence(
+                tripId: tripId, dayNumber: selectedDay,
+                centerLat: lat, centerLng: lng,
+                centerAddress: centerAddress, radiusKm: radiusKm
+            )
+        }
+
+        request
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isSaving = false
+                    self?.toast = "저장되었습니다"
+                    self?.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.isSaving = false
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 위치 권한
+
+    private func requestLocation() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined: locationManager.requestWhenInUseAuthorization()
+        case .denied, .restricted: locationDenied = true
+        default: locationManager.startUpdatingLocation()
+        }
+    }
+
+    func stop() { locationManager.stopUpdatingLocation() }
+
+    // MARK: - 헬퍼
+
+    private static func coordinate(_ fence: GeofenceDTO) -> CLLocationCoordinate2D? {
+        guard let lat = Double(fence.centerLat), let lng = Double(fence.centerLng) else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    }
+
+    private static func date(from string: String?) -> Date? {
+        guard let string else { return nil }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: string)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            case .conflict:                 return "다른 기기에서 먼저 수정했어요. 새로고침 후 다시 시도해주세요"
+            default:                        break
+            }
+        }
+        return "저장하지 못했어요"
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension MapRangeSettingViewModel: CLLocationManagerDelegate {
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        Task { @MainActor in
+            let isFirst = self.myLocation == nil
+            self.myLocation = coordinate
+            // 아직 설정이 없는 일차면 현재 위치를 기본 중심으로 잡아 줍니다
+            if isFirst, self.centerCoordinate == nil {
+                self.setCenter(coordinate)
+            }
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            switch status {
+            case .authorizedWhenInUse, .authorizedAlways:
+                self.locationDenied = false
+                manager.startUpdatingLocation()
+            case .denied, .restricted:
+                self.locationDenied = true
+            default:
+                break
+            }
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/NoticeSettingViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/NoticeSettingViewModel.swift
@@ -146,6 +146,30 @@ final class NoticeSettingViewModel: ObservableObject {
             .disposed(by: disposeBag)
     }
 
+    /// 공지 삭제 — 활성 공지를 지우면 자동으로 "공지 없음" 상태가 됩니다
+    func delete(_ notice: StaffNoticeDTO) {
+        repository.deleteNotice(id: notice.id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] in
+                    self?.refresh()
+                    self?.toast = "공지를 삭제했어요"
+                },
+                onFailure: { [weak self] error in
+                    self?.saveError = Self.deleteMessage(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 서버가 아직 DELETE를 열어두지 않아 405가 오면 원인을 그대로 알려줍니다
+    private static func deleteMessage(for error: Error) -> String {
+        if let e = error as? HiTripError, case .httpError(let code, _) = e, code == 405 {
+            return "서버가 아직 공지 삭제를 지원하지 않아요"
+        }
+        return message(for: error)
+    }
+
     func activate(id: Int) {
         repository.publishNotice(id: id)
             .observe(on: MainScheduler.instance)

--- a/HiTrip/Features/Schedule/ViewModels/NoticeSettingViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/NoticeSettingViewModel.swift
@@ -1,0 +1,186 @@
+import Foundation
+import RxSwift
+
+// MARK: - NoticeSettingViewModel
+/// 공지 설정 — Figma 12381:5263
+///
+/// - GET   /api/v1/notices/                  공지 목록
+/// - POST  /api/v1/notices/                  새 공지
+/// - PATCH /api/v1/notices/{id}/             공지 수정
+/// - POST  /api/v1/notices/{id}/publish/     활성
+/// - POST  /api/v1/notices/{id}/archive/     비활성
+///
+/// 활성 공지는 항상 1건입니다. 다른 공지를 켜면 서버가 기존 것을 내립니다.
+
+@MainActor
+final class NoticeSettingViewModel: ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var notices: [StaffNoticeDTO] = []
+    @Published private(set) var isSaving = false
+    @Published var saveError: String?
+    @Published var toast: String?
+
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private var tripId: Int?
+
+    init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
+        self.repository = repository
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] trips in
+                self?.tripId = trips.first?.id
+                self?.refresh()
+            }, onFailure: { [weak self] error in
+                self?.state = .failed(Self.message(for: error))
+            })
+            .disposed(by: disposeBag)
+    }
+
+    func refresh() {
+        repository.fetchNotices()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] list in
+                    // 활성 최상단 → 최신 작성순
+                    self?.notices = list.sorted { a, b in
+                        if a.isActive != b.isActive { return a.isActive }
+                        return a.createdAt > b.createdAt
+                    }
+                    self?.state = .loaded
+                },
+                onFailure: { [weak self] error in
+                    if self?.notices.isEmpty ?? true {
+                        self?.state = .failed(Self.message(for: error))
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    var isEmpty: Bool { notices.isEmpty && state == .loaded }
+
+    // MARK: - 작성 / 수정
+
+    /// 새 공지 — 저장만 하고 활성화는 다음 단계에서 묻습니다
+    func create(content: String, onSuccess: @escaping (StaffNoticeDTO) -> Void) {
+        isSaving = true
+        repository.createNotice(title: Self.title(from: content), content: content, tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] created in
+                    self?.isSaving = false
+                    self?.refresh()
+                    onSuccess(created)
+                },
+                onFailure: { [weak self] error in
+                    self?.isSaving = false
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func update(id: Int, content: String, onSuccess: @escaping (StaffNoticeDTO) -> Void) {
+        isSaving = true
+        repository.updateNotice(id: id, title: Self.title(from: content), content: content)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] updated in
+                    self?.isSaving = false
+                    self?.refresh()
+                    onSuccess(updated)
+                },
+                onFailure: { [weak self] error in
+                    self?.isSaving = false
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 서버가 제목을 따로 받으므로 본문 첫 줄을 제목으로 씁니다 (작성 화면에는 제목 입력이 없습니다)
+    private static func title(from content: String) -> String {
+        let firstLine = content
+            .components(separatedBy: .newlines)
+            .first?
+            .trimmingCharacters(in: .whitespaces) ?? ""
+        return String(firstLine.prefix(40))
+    }
+
+    // MARK: - 활성 토글
+
+    /// 활성 공지를 다시 누르면 해제됩니다 (전체 비활성 = 관광객 홈 "등록된 공지가 없어요")
+    func toggleActive(_ notice: StaffNoticeDTO) {
+        let request = notice.isActive
+            ? repository.archiveNotice(id: notice.id)
+            : repository.publishNotice(id: notice.id)
+
+        request
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.refresh()
+                    self?.toast = notice.isActive ? "공지를 내렸어요" : "공지를 활성화했어요"
+                },
+                onFailure: { [weak self] error in
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func activate(id: Int) {
+        repository.publishNotice(id: id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] _ in
+                self?.refresh()
+                self?.toast = "공지를 활성화했어요"
+            }, onFailure: { [weak self] error in
+                self?.saveError = Self.message(for: error)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 표시
+
+    /// "04.24 10:20"
+    func dateText(_ notice: StaffNoticeDTO) -> String {
+        let raw = notice.publishedAt ?? notice.createdAt
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = parser.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) else { return "" }
+
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "MM.dd HH:mm"
+        return f.string(from: date)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            default:                        break
+            }
+        }
+        return "저장하지 못했어요"
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/SafetyManagementViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/SafetyManagementViewModel.swift
@@ -1,0 +1,263 @@
+import Foundation
+import RxSwift
+
+// MARK: - SafetyManagementViewModel
+/// 안전 관리 — Figma 12381:4446
+///
+/// - GET /api/monitoring/trips/{id}/summary/  상태별 집계
+/// - GET /api/monitoring/trips/{id}/latest/   관광객별 최신 심박·SpO₂·위치
+///
+/// 30초마다 갱신합니다. 상태 판정(normal/warning/danger)은 서버 값을 그대로 씁니다.
+/// 셀 단위 색(심박만 경고, SpO₂만 위험 등)은 서버가 지표별로 주지 않아
+/// 여행 임계값(heart_rate_min/max)과 기획서의 SpO₂ 기준으로 계산합니다.
+
+@MainActor
+final class SafetyManagementViewModel: ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    /// 칩 필터 — 재탭하면 해제됩니다
+    enum Filter: Equatable {
+        case warning, danger, escaped
+    }
+
+    /// 셀 색 단계
+    enum Level {
+        case normal, warning, danger
+        /// 데이터 미수신 — 워치 미연동·배터리 방전·통신 두절
+        case unknown
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var summary: MonitoringSummaryDTO?
+    @Published private(set) var participants: [ParticipantLatestDTO] = []
+    /// 참가자 명부 — 연락처·국가·여권번호 (모니터링 응답에 없어 따로 받습니다)
+    @Published private(set) var profiles: [Int: TravelerDetailDTO] = [:]
+    @Published private(set) var updatedAt: Date?
+    @Published var filter: Filter?
+
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private var pollingTask: Task<Void, Never>?
+
+    private(set) var trip: StaffTripDTO?
+
+    init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
+        self.repository = repository
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] trips in
+                    guard let self else { return }
+                    guard let trip = trips.first else {
+                        self.state = .loaded
+                        return
+                    }
+                    self.trip = trip
+                    self.loadProfiles(tripId: trip.id)
+                    self.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 참가자 명부는 자주 바뀌지 않아 진입 시 한 번만 받습니다
+    private func loadProfiles(tripId: Int) {
+        repository.fetchParticipants(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] list in
+                self?.profiles = Dictionary(
+                    uniqueKeysWithValues: list.compactMap { p in
+                        p.traveler.map { (p.id, $0) }
+                    }
+                )
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    func profile(for p: ParticipantLatestDTO) -> TravelerDetailDTO? {
+        profiles[p.participantId]
+    }
+
+    /// 팝업의 "위치보기" 활성 조건 — 이탈이거나 건강 경고·위험일 때만
+    func canViewLocation(_ p: ParticipantLatestDTO) -> Bool {
+        p.geofenceIncident != nil
+            || p.healthStatus == .warning
+            || p.healthStatus == .danger
+    }
+
+    /// "경계 밖 1.2km · 심박 110 · SpO₂ 95%"
+    func statusLine(_ p: ParticipantLatestDTO) -> String {
+        var parts: [String] = []
+        if let distance = escapeDistanceText(p) { parts.append("경계 밖 \(distance)") }
+        if let hr = p.health?.heartRate { parts.append("심박 \(hr)") }
+        let spo2 = spo2Text(p)
+        if spo2 != "—" { parts.append("SpO₂ \(spo2)%") }
+        return parts.isEmpty ? "수신된 데이터가 없어요" : parts.joined(separator: " · ")
+    }
+
+    /// 집계와 명단을 다시 불러옵니다 — 폴링·당겨서 새로고침 공용
+    func refresh() {
+        guard let tripId = trip?.id else { return }
+
+        repository.fetchSafetySummary(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.summary = $0 }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+
+        repository.fetchParticipantsLatest(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] list in
+                    self?.participants = list
+                    self?.updatedAt = Date()
+                    self?.state = .loaded
+                },
+                onFailure: { [weak self] error in
+                    if self?.participants.isEmpty ?? true {
+                        self?.state = .failed(Self.message(for: error))
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func startPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                await self?.refresh()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - 목록
+
+    /// 정렬: 위험 → 경고 → 정상, 동순위는 가나다
+    var sortedParticipants: [ParticipantLatestDTO] {
+        let filtered = participants.filter { matchesFilter($0) }
+        return filtered.sorted { a, b in
+            let ra = Self.rank(a.overallStatus), rb = Self.rank(b.overallStatus)
+            if ra != rb { return ra < rb }
+            return a.travelerName.localizedCompare(b.travelerName) == .orderedAscending
+        }
+    }
+
+    private func matchesFilter(_ p: ParticipantLatestDTO) -> Bool {
+        switch filter {
+        case nil:        return true
+        case .warning?:  return p.overallStatus == .warning
+        case .danger?:   return p.overallStatus == .danger
+        case .escaped?:  return p.geofenceIncident != nil
+        }
+    }
+
+    private static func rank(_ status: MonitoringStatus) -> Int {
+        switch status {
+        case .danger:  return 0
+        case .warning: return 1
+        case .normal:  return 2
+        default:       return 3
+        }
+    }
+
+    /// 칩을 다시 누르면 해제합니다
+    func toggle(_ target: Filter) {
+        filter = (filter == target) ? nil : target
+    }
+
+    // MARK: - 집계
+
+    var totalCount: Int { summary?.total ?? participants.count }
+    var warningCount: Int { summary?.warning ?? participants.filter { $0.overallStatus == .warning }.count }
+    var dangerCount: Int { summary?.danger ?? participants.filter { $0.overallStatus == .danger }.count }
+
+    /// 이탈 인원 — 요약에 항목이 없어 열린 지오펜스 사고로 셉니다
+    var escapedCount: Int { participants.filter { $0.geofenceIncident != nil }.count }
+
+    var isEmpty: Bool { participants.isEmpty && state == .loaded }
+
+    /// "10:24 기준 · 30초마다 갱신"
+    var updatedText: String {
+        guard let updatedAt else { return "갱신 대기 중 · 30초마다 갱신" }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "HH:mm"
+        return "\(f.string(from: updatedAt)) 기준 · 30초마다 갱신"
+    }
+
+    // MARK: - 셀 값
+
+    /// 이탈 거리 — 사고 메시지에서 "1.2km"를 뽑습니다.
+    /// 서버가 거리 필드를 따로 주지 않아 메시지를 파싱합니다.
+    func escapeDistanceText(_ p: ParticipantLatestDTO) -> String? {
+        guard let incident = p.geofenceIncident else { return nil }
+        let pattern = #"([0-9]+(?:\.[0-9]+)?)\s*(km|m)"#
+        guard let match = incident.message.range(of: pattern, options: .regularExpression) else {
+            return "이탈"
+        }
+        return String(incident.message[match]).replacingOccurrences(of: " ", with: "")
+    }
+
+    func heartRateText(_ p: ParticipantLatestDTO) -> String {
+        p.health?.heartRate.map(String.init) ?? "—"
+    }
+
+    func spo2Text(_ p: ParticipantLatestDTO) -> String {
+        guard let raw = p.health?.spo2, let value = Double(raw) else { return "—" }
+        return String(Int(value.rounded()))
+    }
+
+    /// 심박 단계 — 여행 임계값(heart_rate_min/max) 밖이면 경고, 20bpm 이상 벗어나면 위험
+    func heartRateLevel(_ p: ParticipantLatestDTO) -> Level {
+        guard let hr = p.health?.heartRate else { return .unknown }
+        let min = trip?.heartRateMin ?? 50
+        let max = trip?.heartRateMax ?? 110
+
+        if hr >= min && hr <= max { return .normal }
+        let over = hr > max ? hr - max : min - hr
+        return over > 20 ? .danger : .warning
+    }
+
+    /// SpO₂ — 기획서 기준: 정상 ≥95 · 경고 90~94 · 위험 <90
+    func spo2Level(_ p: ParticipantLatestDTO) -> Level {
+        guard let raw = p.health?.spo2, let value = Double(raw) else { return .unknown }
+        if value < 90 { return .danger }
+        if value < 95 { return .warning }
+        return .normal
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            default:                        break
+            }
+        }
+        return "안전 정보를 불러오지 못했어요"
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/StaffHomeViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/StaffHomeViewModel.swift
@@ -1,0 +1,238 @@
+import Foundation
+import RxSwift
+
+// MARK: - StaffHomeViewModel
+/// 안내사 홈 — Figma 12381:5370
+///
+/// - GET /api/v1/staff/trips/                     담당 여행
+/// - GET /api/v1/trips/{id}/schedules/            오늘의 일정
+/// - GET /api/monitoring/trips/{id}/summary/      안전 현황 (30초 갱신)
+/// - GET /api/monitoring/trips/{id}/alerts/       알림 뱃지·안전 빨간 점
+///
+/// 여행이 배정되지 않았으면 화면 전체를 안내 문구로 대체합니다.
+
+@MainActor
+final class StaffHomeViewModel: ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        /// 배정된 여행이 없음
+        case noTrip
+        case failed(String)
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var trip: StaffTripDTO?
+    @Published private(set) var schedules: [StaffScheduleDTO] = []
+    @Published private(set) var summary: MonitoringSummaryDTO?
+    @Published private(set) var alerts: [MonitoringAlertDTO] = []
+    @Published private(set) var unreadMessageCount: Int = 0
+
+    private let repository: StaffRepositoryProtocol
+    private let chatRepository: ChatRepositoryProtocol
+    private let disposeBag = DisposeBag()
+
+    /// 안전 현황 30초 폴링
+    private var pollingTask: Task<Void, Never>?
+
+    init(
+        repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide,
+        chatRepository: ChatRepositoryProtocol = AppDIContainer.shared.chatRepositoryForHome
+    ) {
+        self.repository = repository
+        self.chatRepository = chatRepository
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] trips in
+                    guard let self else { return }
+                    guard let trip = trips.first else {
+                        self.state = .noTrip
+                        return
+                    }
+                    self.trip = trip
+                    self.state = .loaded
+                    self.loadSecondary(tripId: trip.id)
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// 일정·안전·메시지 — 하나가 실패해도 나머지는 그립니다
+    private func loadSecondary(tripId: Int) {
+        repository.fetchSchedules(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.schedules = $0 }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+
+        refreshSafety()
+
+        chatRepository.fetchAllRooms()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] rooms in
+                self?.unreadMessageCount = rooms.reduce(0) { $0 + $1.unreadCount }
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    /// 안전 현황만 다시 — 30초 폴링과 당겨서 새로고침이 함께 씁니다
+    func refreshSafety() {
+        guard let tripId = trip?.id else { return }
+
+        repository.fetchSafetySummary(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.summary = $0 }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+
+        repository.fetchAlerts(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in self?.alerts = $0 }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    /// 화면이 보이는 동안만 30초마다 안전 현황을 갱신합니다
+    func startPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                await self?.refreshSafety()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - 표시값
+
+    var tripTitle: String { trip?.title ?? "" }
+
+    /// "안내사 김안내"
+    var managerText: String {
+        guard let name = trip?.managerName, !name.isEmpty else { return "" }
+        return "안내사 \(name)"
+    }
+
+    /// 오늘이 며칠째인지 — 시작일로부터 계산합니다 (스태프 API에 today_day_number가 없습니다)
+    var todayDayNumber: Int? {
+        guard let start = Self.date(from: trip?.startDate) else { return nil }
+        let today = Calendar.current.startOfDay(for: Date())
+        let days = Calendar.current.dateComponents([.day], from: start, to: today).day ?? 0
+        return days >= 0 ? days + 1 : nil
+    }
+
+    var todaySchedules: [StaffScheduleDTO] {
+        guard let day = todayDayNumber else { return [] }
+        return schedules.filter { $0.dayNumber == day }.sorted { $0.startTime < $1.startTime }
+    }
+
+    /// 진행률 — 당일 첫 일정 시작 ~ 마지막 일정 종료 대비 현재 시각 (여행객 홈과 같은 규칙)
+    var todayProgress: Double {
+        let starts = todaySchedules.compactMap { Self.minutes($0.startTime) }
+        let ends   = todaySchedules.compactMap { Self.minutes($0.endTime) }
+        guard let first = starts.min(), let last = ends.max(), last > first else { return 0 }
+        return min(max(Double(Self.minutesNow() - first) / Double(last - first), 0), 1)
+    }
+
+    /// 지금 진행 중이거나 다음에 올 일정
+    var currentSchedule: StaffScheduleDTO? {
+        let now = Self.minutesNow()
+        if let ongoing = todaySchedules.first(where: {
+            guard let s = Self.minutes($0.startTime), let e = Self.minutes($0.endTime) else { return false }
+            return s <= now && now < e
+        }) { return ongoing }
+        return todaySchedules.first { (Self.minutes($0.startTime) ?? 0) > now }
+    }
+
+    /// 그다음 일정 — 현재와 같으면 숨깁니다
+    var nextSchedule: StaffScheduleDTO? {
+        guard let current = currentSchedule,
+              let idx = todaySchedules.firstIndex(where: { $0.id == current.id }),
+              idx + 1 < todaySchedules.count else { return nil }
+        return todaySchedules[idx + 1]
+    }
+
+    // MARK: - 안전 현황
+
+    /// "전체 12명 · 경고 2 · 위험 1 · 이탈 1"
+    var safetySummaryText: String {
+        guard let s = summary else { return "집계를 불러오는 중이에요" }
+        return "전체 \(s.total)명 · 경고 \(s.warning) · 위험 \(s.danger) · 이탈 \(escapedCount)"
+    }
+
+    /// 이탈 인원 — alerts의 location 유형으로 셉니다 (summary에 이탈 항목이 없습니다)
+    var escapedCount: Int {
+        alerts.filter { $0.alertType == "location" }.count
+    }
+
+    /// 안전 관리 메뉴의 빨간 점 — 경고·위험 인원이 있으면 표시
+    var hasSafetyIssue: Bool {
+        guard let s = summary else { return false }
+        return s.warning > 0 || s.danger > 0 || escapedCount > 0
+    }
+
+    /// 알림 종 뱃지 — 미확인 알림 수
+    var unreadAlertCount: Int { alerts.count }
+
+    var unreadMessageBadgeText: String {
+        unreadMessageCount > 99 ? "99+" : "\(unreadMessageCount)"
+    }
+
+    // MARK: - 헬퍼
+
+    static func timeRange(_ start: String, _ end: String) -> String {
+        "\(hhmm(start)) - \(hhmm(end))"
+    }
+
+    static func hhmm(_ time: String) -> String {
+        String(time.prefix(5))
+    }
+
+    private static func minutes(_ time: String) -> Int? {
+        let parts = time.split(separator: ":")
+        guard parts.count >= 2, let h = Int(parts[0]), let m = Int(parts[1]) else { return nil }
+        return h * 60 + m
+    }
+
+    private static func minutesNow() -> Int {
+        let now = Calendar.current.dateComponents([.hour, .minute], from: Date())
+        return (now.hour ?? 0) * 60 + (now.minute ?? 0)
+    }
+
+    private static func date(from string: String?) -> Date? {
+        guard let string else { return nil }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: string)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            case .timeout:                  return "서버 응답이 없습니다"
+            default:                        break
+            }
+        }
+        return "정보를 불러오지 못했어요"
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/StaffTripDetailViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/StaffTripDetailViewModel.swift
@@ -1,0 +1,275 @@
+import Foundation
+import RxSwift
+
+// MARK: - StaffTripDetailViewModel
+/// 전체일정 확인·수정 — Figma 12381:5209
+///
+/// - GET    /api/trips/{id}/schedules/       일정 목록
+/// - POST   /api/trips/{id}/schedules/       일정 추가
+/// - PATCH  /api/trips/{id}/schedules/{sid}/ 시간 변경·메모 수정
+/// - DELETE /api/trips/{id}/schedules/{sid}/ 삭제
+///
+/// 수정은 즉시 서버에 저장합니다. 실패하면 목록을 되돌리고 재시도를 안내합니다.
+
+@MainActor
+final class StaffTripDetailViewModel: ObservableObject {
+
+    enum LoadState: Equatable {
+        case idle, loading, loaded
+        case failed(String)
+    }
+
+    struct DaySection: Identifiable {
+        let dayNumber: Int
+        let date: String
+        let items: [StaffScheduleDTO]
+        var id: Int { dayNumber }
+    }
+
+    // MARK: - State
+
+    @Published private(set) var state: LoadState = .idle
+    @Published private(set) var trip: StaffTripDTO?
+    @Published private(set) var schedules: [StaffScheduleDTO] = []
+    @Published var expandedDay: Int?
+    @Published private(set) var isSaving = false
+    @Published var saveError: String?
+    @Published var toast: String?
+
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+
+    init(repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide) {
+        self.repository = repository
+    }
+
+    // MARK: - Load
+
+    func load() {
+        guard state != .loading else { return }
+        state = .loading
+
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] trips in
+                    guard let self else { return }
+                    guard let trip = trips.first else {
+                        self.state = .loaded
+                        return
+                    }
+                    self.trip = trip
+                    self.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.state = .failed(Self.message(for: error))
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    /// SaaS·안내사 수정분을 반영하려면 화면에 들어올 때마다 다시 받습니다
+    func refresh() {
+        guard let tripId = trip?.id else { return }
+
+        repository.fetchSchedules(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] list in
+                    guard let self else { return }
+                    self.schedules = list
+                    self.state = .loaded
+                    if self.expandedDay == nil { self.expandedDay = self.todayDayNumber ?? self.days.first?.dayNumber }
+                },
+                onFailure: { [weak self] error in
+                    if self?.schedules.isEmpty ?? true {
+                        self?.state = .failed(Self.message(for: error))
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 목록
+
+    var days: [DaySection] {
+        let grouped = Dictionary(grouping: schedules, by: \.dayNumber)
+        return grouped.keys.sorted().map { day in
+            DaySection(
+                dayNumber: day,
+                date: dateText(for: day),
+                items: (grouped[day] ?? []).sorted { $0.startTime < $1.startTime }
+            )
+        }
+    }
+
+    /// 오늘이 며칠째인지 — 스태프 API에 today_day_number가 없어 시작일로 계산합니다
+    var todayDayNumber: Int? {
+        guard let start = Self.date(from: trip?.startDate) else { return nil }
+        let today = Calendar.current.startOfDay(for: Date())
+        let days = Calendar.current.dateComponents([.day], from: start, to: today).day ?? 0
+        return days >= 0 ? days + 1 : nil
+    }
+
+    var tripTitle: String { trip?.title ?? "" }
+
+    /// "2025.04.24 - 04.26 · 참여 인원 10명"
+    var tripSubtitle: String {
+        guard let trip else { return "" }
+        let start = trip.startDate.replacingOccurrences(of: "-", with: ".")
+        let endParts = trip.endDate.split(separator: "-")
+        let end = endParts.count >= 3 ? "\(endParts[1]).\(endParts[2])" : trip.endDate
+        return "\(start) - \(end) · 참여 인원 \(trip.participantCount)명"
+    }
+
+    /// 일차 헤더의 날짜 — 시작일 + (일차 - 1)
+    private func dateText(for dayNumber: Int) -> String {
+        guard let start = Self.date(from: trip?.startDate),
+              let date = Calendar.current.date(byAdding: .day, value: dayNumber - 1, to: start)
+        else { return "" }
+
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.dateFormat = "yyyy.MM.dd"
+        return f.string(from: date)
+    }
+
+    func toggle(day: Int) {
+        expandedDay = (expandedDay == day) ? nil : day
+    }
+
+    // MARK: - 수정
+
+    /// 기존 일정과 시간이 겹치는지 — 추가·시간 변경 전에 경고합니다
+    func overlaps(dayNumber: Int, start: String, end: String, excluding id: Int? = nil) -> Bool {
+        guard let s = Self.minutes(start), let e = Self.minutes(end), s < e else { return false }
+        return schedules
+            .filter { $0.dayNumber == dayNumber && $0.id != id }
+            .contains { item in
+                guard let ss = Self.minutes(item.startTime), let ee = Self.minutes(item.endTime) else { return false }
+                return s < ee && ss < e
+            }
+    }
+
+    func addSchedule(
+        dayNumber: Int, title: String, start: String, end: String,
+        onSuccess: @escaping () -> Void
+    ) {
+        guard let tripId = trip?.id else { return }
+        isSaving = true
+
+        repository.createSchedule(
+            tripId: tripId, dayNumber: dayNumber,
+            startTime: Self.withSeconds(start), endTime: Self.withSeconds(end),
+            content: title
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(
+            onSuccess: { [weak self] _ in
+                self?.isSaving = false
+                self?.expandedDay = dayNumber
+                self?.toast = "일정을 추가했어요"
+                self?.refresh()
+                onSuccess()
+            },
+            onFailure: { [weak self] error in
+                self?.isSaving = false
+                self?.saveError = Self.message(for: error)
+            }
+        )
+        .disposed(by: disposeBag)
+    }
+
+    func updateTime(_ item: StaffScheduleDTO, start: String, end: String, onSuccess: @escaping () -> Void) {
+        update(item, start: Self.withSeconds(start), end: Self.withSeconds(end), content: nil, onSuccess: onSuccess)
+    }
+
+    func updateMemo(_ item: StaffScheduleDTO, content: String, onSuccess: @escaping () -> Void) {
+        update(item, start: nil, end: nil, content: content, onSuccess: onSuccess)
+    }
+
+    private func update(
+        _ item: StaffScheduleDTO,
+        start: String?, end: String?, content: String?,
+        onSuccess: @escaping () -> Void
+    ) {
+        guard let tripId = trip?.id else { return }
+        isSaving = true
+
+        repository.updateSchedule(tripId: tripId, id: item.id, startTime: start, endTime: end, content: content)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] _ in
+                    self?.isSaving = false
+                    self?.toast = "저장했어요"
+                    self?.refresh()
+                    onSuccess()
+                },
+                onFailure: { [weak self] error in
+                    self?.isSaving = false
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func delete(_ item: StaffScheduleDTO) {
+        guard let tripId = trip?.id else { return }
+
+        repository.deleteSchedule(tripId: tripId, id: item.id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onSuccess: { [weak self] in
+                    self?.toast = "일정을 삭제했어요"
+                    self?.refresh()
+                },
+                onFailure: { [weak self] error in
+                    self?.saveError = Self.message(for: error)
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 헬퍼
+
+    /// 카드 제목 — 장소가 있으면 장소, 없으면 메모를 씁니다
+    static func title(of item: StaffScheduleDTO) -> String {
+        if !item.placeName.isEmpty { return item.placeName }
+        return item.mainContent ?? "일정"
+    }
+
+    static func timeRange(_ start: String, _ end: String) -> String {
+        "\(hhmm(start)) - \(hhmm(end))"
+    }
+
+    static func hhmm(_ time: String) -> String { String(time.prefix(5)) }
+
+    private static func withSeconds(_ hhmm: String) -> String {
+        hhmm.count == 5 ? "\(hhmm):00" : hhmm
+    }
+
+    private static func minutes(_ time: String) -> Int? {
+        let parts = time.split(separator: ":")
+        guard parts.count >= 2, let h = Int(parts[0]), let m = Int(parts[1]) else { return nil }
+        return h * 60 + m
+    }
+
+    private static func date(from string: String?) -> Date? {
+        guard let string else { return nil }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: string)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let e = error as? HiTripError {
+            switch e {
+            case .unauthorized, .forbidden: return "로그인이 필요합니다"
+            case .noConnection:             return "연결을 확인해주세요"
+            default:                        break
+            }
+        }
+        return "저장하지 못했어요"
+    }
+}

--- a/HiTrip/Features/Schedule/ViewModels/TouristLocationViewModel.swift
+++ b/HiTrip/Features/Schedule/ViewModels/TouristLocationViewModel.swift
@@ -1,0 +1,229 @@
+import Foundation
+import CoreLocation
+import RxSwift
+
+// MARK: - TouristLocationViewModel
+/// 관광객 위치 확인 — Figma 12381:4267
+///
+/// - GET /api/monitoring/trips/{id}/latest/   관광객 좌표 (10초 갱신)
+/// - GET /api/v1/trips/{id}/geofences/        허용 범위 경계
+///
+/// 안내사 본인 위치는 기기 GPS를 씁니다. 주소는 좌표를 역지오코딩합니다.
+
+@MainActor
+final class TouristLocationViewModel: NSObject, ObservableObject {
+
+    // MARK: - State
+
+    @Published private(set) var participant: ParticipantLatestDTO?
+    @Published private(set) var profile: TravelerDetailDTO?
+    @Published private(set) var geofence: GeofenceDTO?
+    @Published private(set) var address: String = ""
+    @Published private(set) var measuredAt: Date?
+    @Published private(set) var guideLocation: CLLocationCoordinate2D?
+
+    /// 범위 밖에 있었다가 돌아오면 한 번 알립니다
+    @Published var returnedNotice = false
+
+    private let participantId: Int
+    private let repository: StaffRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    private let locationManager = CLLocationManager()
+    private let geocoder = CLGeocoder()
+
+    private var tripId: Int?
+    private var pollingTask: Task<Void, Never>?
+    private var wasOutside = false
+    /// 역지오코딩을 좌표가 크게 바뀔 때만 다시 합니다
+    private var lastGeocodedCoordinate: CLLocationCoordinate2D?
+
+    init(
+        participantId: Int,
+        repository: StaffRepositoryProtocol = AppDIContainer.shared.staffRepositoryForGuide
+    ) {
+        self.participantId = participantId
+        self.repository = repository
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    // MARK: - 표시값
+
+    var touristName: String { participant?.travelerName ?? "" }
+
+    var touristCoordinate: CLLocationCoordinate2D? {
+        guard let lat = participant?.location?.latitude.flatMap(Double.init),
+              let lng = participant?.location?.longitude.flatMap(Double.init) else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    }
+
+    var geofenceCenter: CLLocationCoordinate2D? {
+        guard let g = geofence,
+              let lat = Double(g.centerLat), let lng = Double(g.centerLng) else { return nil }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    }
+
+    var geofenceRadiusM: Double? {
+        geofence.map { Double($0.radiusKm) * 1000 }
+    }
+
+    /// GPS가 끊겼는지 — 마지막 수신이 2분을 넘으면 옛 위치로 봅니다
+    var isStale: Bool {
+        guard let measuredAt else { return true }
+        return Date().timeIntervalSince(measuredAt) > 120
+    }
+
+    /// "10초 전 갱신" 또는 "마지막 수신 위치 · 5분 전"
+    var updatedText: String {
+        guard let measuredAt else { return "위치 수신 대기 중" }
+        let seconds = Int(Date().timeIntervalSince(measuredAt))
+
+        if isStale {
+            let minutes = max(seconds / 60, 1)
+            return "마지막 수신 위치 · \(minutes)분 전"
+        }
+        return seconds < 10 ? "방금 갱신" : "\(seconds)초 전 갱신"
+    }
+
+    var phoneNumber: String? { profile?.phone }
+
+    // MARK: - Load
+
+    func load() {
+        repository.fetchTrips()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] trips in
+                guard let self, let trip = trips.first else { return }
+                self.tripId = trip.id
+                self.loadGeofence(tripId: trip.id)
+                self.loadProfile(tripId: trip.id)
+                self.refresh()
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+
+        requestGuideLocation()
+    }
+
+    private func loadGeofence(tripId: Int) {
+        repository.fetchGeofences(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] list in
+                // 오늘 일차 것이 있으면 그것을, 없으면 가장 최근 것을 씁니다
+                self?.geofence = list.last(where: { $0.isActive }) ?? list.last
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    private func loadProfile(tripId: Int) {
+        repository.fetchParticipants(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] list in
+                guard let self else { return }
+                self.profile = list.first { $0.id == self.participantId }?.traveler
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    /// 관광객 좌표 — 10초마다 다시 받습니다
+    func refresh() {
+        guard let tripId else { return }
+
+        repository.fetchParticipantsLatest(tripId: tripId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] list in
+                guard let self,
+                      let target = list.first(where: { $0.participantId == self.participantId })
+                else { return }
+
+                self.participant = target
+                self.measuredAt = Self.date(from: target.location?.measuredAt)
+                self.updateGeocodeIfNeeded()
+                self.checkReturned(target)
+            }, onFailure: { _ in })
+            .disposed(by: disposeBag)
+    }
+
+    func startPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                await self?.refresh()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+        locationManager.stopUpdatingLocation()
+    }
+
+    /// 범위 밖 → 안으로 돌아오면 토스트를 띄웁니다
+    private func checkReturned(_ target: ParticipantLatestDTO) {
+        let isOutside = target.geofenceIncident != nil
+        if wasOutside && !isOutside { returnedNotice = true }
+        wasOutside = isOutside
+    }
+
+    // MARK: - 주소
+
+    private func updateGeocodeIfNeeded() {
+        guard let coordinate = touristCoordinate else { return }
+
+        if let last = lastGeocodedCoordinate {
+            let moved = CLLocation(latitude: last.latitude, longitude: last.longitude)
+                .distance(from: CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude))
+            // 30m 이내면 주소가 그대로일 가능성이 커서 다시 묻지 않습니다
+            guard moved > 30 else { return }
+        }
+        lastGeocodedCoordinate = coordinate
+
+        geocoder.reverseGeocodeLocation(
+            CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        ) { [weak self] marks, _ in
+            guard let mark = marks?.first else { return }
+            let parts = [mark.locality, mark.subLocality, mark.thoroughfare, mark.subThoroughfare]
+            let text = parts.compactMap { $0 }.joined(separator: " ")
+            Task { @MainActor in
+                self?.address = text.isEmpty ? "주소를 확인할 수 없어요" : "\(text) 인근"
+            }
+        }
+    }
+
+    // MARK: - 안내사 위치
+
+    private func requestGuideLocation() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined: locationManager.requestWhenInUseAuthorization()
+        case .denied, .restricted: break
+        default: locationManager.startUpdatingLocation()
+        }
+    }
+
+    private static func date(from iso: String?) -> Date? {
+        guard let iso else { return nil }
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return parser.date(from: iso) ?? ISO8601DateFormatter().date(from: iso)
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension TouristLocationViewModel: CLLocationManagerDelegate {
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        Task { @MainActor in self.guideLocation = coordinate }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+}

--- a/HiTrip/Features/Schedule/Views/MapRangeSettingView.swift
+++ b/HiTrip/Features/Schedule/Views/MapRangeSettingView.swift
@@ -1,96 +1,287 @@
 import SwiftUI
 import MapKit
 
+// MARK: - MapRangeSettingView
+/// 지도 범위 설정 (지오펜스) — Figma 12380:1051
+///
+/// 일차별로 중심과 반경을 따로 저장합니다.
+/// 저장된 좌표는 고정이라 안내사가 이동해도 원이 따라오지 않습니다.
+
 struct MapRangeSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @State private var radius: Double = 500
-    @State private var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 35.1588, longitude: 129.1603),
-        span: MKCoordinateSpan(latitudeDelta: 0.018, longitudeDelta: 0.018)
-    )
+    @StateObject private var viewModel = MapRangeSettingViewModel()
+
+    @State private var camera: MapCameraPosition = .automatic
+    @State private var showLeaveConfirm = false
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            mapView
+        ZStack(alignment: .top) {
+            mapLayer
+                .ignoresSafeArea()
 
-            controlPanel
-                .padding(.horizontal, 16)
-                .padding(.bottom, 40)
-        }
-        .navigationTitle("지도 범위 설정")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button { dismiss() } label: {
-                    Image(systemName: "chevron.left")
-                        .foregroundColor(.black)
-                }
+            VStack(spacing: 0) {
+                headerSection
+                dayTabs
+                    .padding(.top, 29)
+                Spacer()
             }
+
+            VStack(spacing: 0) {
+                Spacer()
+                bottomSheet
+            }
+            .ignoresSafeArea(edges: .bottom)
         }
-        .navigationBarBackButtonHidden(true)
+        .overlay(alignment: .top) { toastView }
+        .background(Color(hex: "#E0EAE0"))
+        .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .onDisappear { viewModel.stop() }
+        .onChange(of: viewModel.centerCoordinate?.latitude) { _, _ in focusCenter() }
+        .confirmationDialog(
+            "변경사항을 저장하지 않고 나가시겠습니까?",
+            isPresented: $showLeaveConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("나가기", role: .destructive) { dismiss() }
+            Button("계속", role: .cancel) { }
+        }
+        .alert("저장하지 못했어요", isPresented: Binding(
+            get: { viewModel.saveError != nil },
+            set: { if !$0 { viewModel.saveError = nil } }
+        )) {
+            Button("재시도") { viewModel.saveError = nil; viewModel.save() }
+            Button("닫기", role: .cancel) { viewModel.saveError = nil }
+        } message: {
+            Text(viewModel.saveError ?? "")
+        }
     }
 
     // MARK: - 지도
 
-    private var mapView: some View {
-        Map(coordinateRegion: $region)
-            .ignoresSafeArea()
-            .overlay(
-                Circle()
-                    .stroke(Color(hex: "#2563EB").opacity(0.6),
-                            style: StrokeStyle(lineWidth: 2, dash: [8]))
-                    .padding(mapCirclePadding)
-                    .allowsHitTesting(false)
+    private var mapLayer: some View {
+        MapReader { proxy in
+            Map(position: $camera) {
+                if let center = viewModel.centerCoordinate {
+                    MapCircle(center: center, radius: Double(viewModel.radiusKm) * 1000)
+                        .foregroundStyle(Color(hex: "#2563EB").opacity(0.10))
+                        .stroke(Color(hex: "#2563EB"), lineWidth: 2)
+
+                    Annotation("", coordinate: center) {
+                        ZStack {
+                            Circle()
+                                .fill(Color(hex: "#0C46C0"))
+                                .frame(width: 26, height: 26)
+                            Image(systemName: "mappin")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundColor(.white)
+                        }
+                    }
+                }
+            }
+            // 지도 롱프레스로도 중심을 지정할 수 있습니다
+            .onLongPressGesture(minimumDuration: 0.4) { } onPressingChanged: { _ in }
+            .gesture(
+                LongPressGesture(minimumDuration: 0.4)
+                    .sequenced(before: DragGesture(minimumDistance: 0))
+                    .onEnded { value in
+                        if case .second(_, let drag?) = value,
+                           let coordinate = proxy.convert(drag.location, from: .local) {
+                            viewModel.setCenter(coordinate)
+                        }
+                    }
             )
-            .overlay(
-                Circle()
-                    .fill(Color(hex: "#2563EB").opacity(0.08))
-                    .padding(mapCirclePadding)
-                    .allowsHitTesting(false)
-            )
+        }
     }
 
-    private var mapCirclePadding: CGFloat {
-        let base: CGFloat = 500
-        let ratio = CGFloat(radius) / base
-        let minPad: CGFloat = 20
-        let maxPad: CGFloat = 100
-        return max(minPad, maxPad - (ratio - 0.2) * 80)
+    private func focusCenter() {
+        guard let center = viewModel.centerCoordinate else { return }
+        // 반경이 화면에 들어오도록 여유를 둡니다
+        let span = Double(viewModel.radiusKm) / 111.0 * 2.6
+        withAnimation {
+            camera = .region(MKCoordinateRegion(
+                center: center,
+                span: MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span)
+            ))
+        }
     }
 
-    // MARK: - 컨트롤 패널
+    // MARK: - 헤더 / 일차 탭
 
-    private var controlPanel: some View {
-        VStack(alignment: .leading, spacing: 16) {
+    private var headerSection: some View {
+        ZStack {
+            Text("지도 범위 설정")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundColor(Color(hex: "#111827"))
+
             HStack {
-                Text("안전 범위")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(Color(hex: "#6B7280"))
+                Button { requestLeave() } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
+                }
                 Spacer()
-                Text("\(Int(radius))m")
+            }
+            .padding(.leading, 12)
+        }
+        .frame(height: 24)
+        .padding(.top, 8)
+    }
+
+    private var dayTabs: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(1...max(viewModel.totalDays, 1), id: \.self) { day in
+                    let isOn = viewModel.selectedDay == day
+                    Button { viewModel.select(day: day) } label: {
+                        Text("\(day)일차")
+                            .font(.system(size: 13, weight: isOn ? .bold : .medium))
+                            .foregroundColor(isOn ? .white : Color(hex: "#6B7280"))
+                            .frame(width: 78, height: 36)
+                            .background(isOn ? Color(hex: "#2563EB") : Color.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 18))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+
+    // MARK: - 하단 시트
+
+    private var bottomSheet: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 4) {
+                Text("중심 주소")
                     .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(Color(hex: "#2563EB"))
+                    .foregroundColor(.black)
+                Text("|  탭하여 검색, 지도 롱프레스로도 지정")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.black)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(.top, 32)
+
+            HStack(spacing: 10) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 16))
+                    .foregroundColor(Color(hex: "#EF4444"))
+                Text(viewModel.centerAddress.isEmpty ? "중심을 지정해주세요" : viewModel.centerAddress)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.black)
+                    .lineLimit(1)
+            }
+            .padding(.top, 14)
+
+            if viewModel.isUnset {
+                // 미설정 일차는 전일 값을 기본으로 제안합니다
+                Text("아직 설정되지 않은 일차예요. 전일 설정을 기본값으로 불러왔습니다.")
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(hex: "#EB8C0D"))
+                    .padding(.top, 8)
             }
 
-            Slider(value: $radius, in: 100...2000, step: 50)
-                .tint(Color(hex: "#2563EB"))
+            HStack {
+                Text("허용 반경")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.black)
+                Spacer()
+                Text("\(viewModel.radiusKm)km")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(.black)
+            }
+            .padding(.top, 26)
 
-            Button { dismiss() } label: {
-                Text("범위 저장")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 48)
-                    .background(Color(hex: "#2563EB"))
-                    .cornerRadius(12)
+            // 1~10km 정수 단계
+            Slider(
+                value: Binding(
+                    get: { Double(viewModel.radiusKm) },
+                    set: { viewModel.radiusKm = Int($0.rounded()) }
+                ),
+                in: 1...10,
+                step: 1
+            )
+            .tint(Color(hex: "#2563EB"))
+            .padding(.top, 6)
+
+            HStack {
+                Text("1km")
+                Spacer()
+                Text("10km • 정수 단계")
+            }
+            .font(.system(size: 12))
+            .foregroundColor(.black)
+
+            Button { viewModel.useMyLocation() } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "location.fill")
+                        .font(.system(size: 14))
+                    Text("내 위치로 중심 설정")
+                        .font(.system(size: 16, weight: .bold))
+                }
+                .foregroundColor(Color(hex: "#0C46C0"))
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .background(Color(hex: "#E8F0FF"))
+                .clipShape(RoundedRectangle(cornerRadius: 9))
             }
             .buttonStyle(.plain)
+            .padding(.top, 26)
+
+            Button { viewModel.save() } label: {
+                Group {
+                    if viewModel.isSaving {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("저장하기")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .background(viewModel.centerCoordinate == nil
+                            ? Color(hex: "#C3CDDA") : Color(hex: "#2563EB"))
+                .clipShape(RoundedRectangle(cornerRadius: 9))
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.centerCoordinate == nil || viewModel.isSaving)
+            .padding(.top, 10)
+            .padding(.bottom, 34)
         }
         .padding(.horizontal, 20)
-        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.10), radius: 12, x: 0, y: 2)
+        .clipShape(RoundedRectangle(cornerRadius: 25, style: .continuous))
+    }
+
+    private func requestLeave() {
+        if viewModel.hasUnsavedChanges {
+            showLeaveConfirm = true
+        } else {
+            dismiss()
+        }
+    }
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.top, 100)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
+        }
     }
 }

--- a/HiTrip/Features/Schedule/Views/NoticeSettingView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticeSettingView.swift
@@ -1,129 +1,483 @@
 import SwiftUI
 
+// MARK: - NoticeSettingView
+/// 공지 설정 (안내사) — Figma 12381:5263
+///
+/// 활성 공지는 항상 최대 1건입니다. 다른 공지를 켜면 서버가 기존 것을 내립니다.
+/// 활성 공지를 다시 누르면 해제되고, 그때 관광객 홈은 "등록된 공지가 없어요"가 됩니다.
+
 struct NoticeSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = NoticeSettingViewModel()
 
-    private let notices: [NoticeItem] = [
-        NoticeItem(isActive: true, date: "04.24 10:20",
-                   content: "오늘 자유 일정은 우천이 예상됩니다. 우산을 꼭 챙겨주세요. 집합 시간은 18:00 호텔 로비…"),
-        NoticeItem(isActive: false, date: "04.24 08:00",
-                   content: "조식은 2층 레스토랑에서 07:00부터 이용 가능합니다."),
-        NoticeItem(isActive: false, date: "04.23 21:00",
-                   content: "여행에 참여하신 여러분 모두 환영합니다! 이번 여행은 안전을 최우선으로 하는 웰니스 여행…"),
-    ]
+    @State private var showEditor = false
+    /// 수정 중인 공지 — nil이면 새 공지
+    @State private var editingNotice: StaffNoticeDTO?
+    @State private var draft = ""
+
+    /// 작성 후 "지금 활성화할까요?"
+    @State private var pendingActivationId: Int?
+    /// ⋮ 메뉴 대상
+    @State private var menuTarget: StaffNoticeDTO?
+    /// 전문 보기
+    @State private var detailTarget: StaffNoticeDTO?
+
+    private let contentLimit = 500
 
     var body: some View {
-        VStack(spacing: 0) {
-            headerSection
+        ZStack {
+            VStack(spacing: 0) {
+                headerSection
 
-            // 새 공지 버튼
-            Button { } label: {
-                Text("새 공지 작성하기")
-                    .font(.system(size: 15, weight: .bold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 52)
-                    .background(Color(hex: "#2563EB"))
-                    .cornerRadius(12)
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-            .padding(.bottom, 16)
+                Button {
+                    editingNotice = nil
+                    draft = ""
+                    showEditor = true
+                } label: {
+                    Text("새 공지 작성하기")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(Color(hex: "#2563EB"))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 24)
+                .padding(.top, 33)
 
-            ScrollView {
-                VStack(spacing: 12) {
-                    ForEach(notices) { notice in
-                        noticeCard(notice)
-                            .padding(.horizontal, 24)
+                switch viewModel.state {
+                case .idle, .loading:
+                    loadingView
+                case .failed(let message):
+                    errorView(message)
+                case .loaded:
+                    if viewModel.isEmpty {
+                        emptyView
+                    } else {
+                        noticeList
                     }
                 }
-                .padding(.bottom, 32)
+            }
+            .background(Color.white)
+
+            if showEditor {
+                NoticeEditorPopup(
+                    text: $draft,
+                    limit: contentLimit,
+                    isEditing: editingNotice != nil,
+                    isSaving: viewModel.isSaving,
+                    onCancel: { showEditor = false },
+                    onSubmit: save
+                )
+            }
+
+            if let notice = detailTarget {
+                noticeDetailPopup(notice)
             }
         }
-        .background(Color.white)
+        .overlay(alignment: .bottom) { toastView }
+        .animation(.easeInOut(duration: 0.2), value: showEditor)
         .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .confirmationDialog(
+            "이 공지를 지금 활성화할까요?",
+            isPresented: Binding(
+                get: { pendingActivationId != nil },
+                set: { if !$0 { pendingActivationId = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("예") {
+                if let id = pendingActivationId { viewModel.activate(id: id) }
+                pendingActivationId = nil
+            }
+            Button("아니오", role: .cancel) { pendingActivationId = nil }
+        } message: {
+            Text("기존 활성 공지는 자동으로 내려갑니다")
+        }
+        .confirmationDialog(
+            "공지",
+            isPresented: Binding(
+                get: { menuTarget != nil },
+                set: { if !$0 { menuTarget = nil } }
+            ),
+            titleVisibility: .hidden
+        ) {
+            Button("수정") {
+                if let target = menuTarget {
+                    editingNotice = target
+                    draft = target.content
+                    showEditor = true
+                }
+                menuTarget = nil
+            }
+            Button("취소", role: .cancel) { menuTarget = nil }
+        }
+        .alert("저장하지 못했어요", isPresented: Binding(
+            get: { viewModel.saveError != nil },
+            set: { if !$0 { viewModel.saveError = nil } }
+        )) {
+            Button("재시도") { viewModel.saveError = nil; save() }
+            Button("닫기", role: .cancel) { viewModel.saveError = nil }
+        } message: {
+            Text(viewModel.saveError ?? "")
+        }
     }
 
-    // MARK: - Header
+    // MARK: - 저장
+
+    private func save() {
+        let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, content.count <= contentLimit else { return }
+
+        if let editing = editingNotice {
+            viewModel.update(id: editing.id, content: content) { _ in
+                showEditor = false
+                draft = ""
+                editingNotice = nil
+            }
+        } else {
+            viewModel.create(content: content) { created in
+                showEditor = false
+                draft = ""
+                // 저장 직후 활성화 여부를 묻습니다
+                pendingActivationId = created.id
+            }
+        }
+    }
+
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("공지 설정")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(.black)
+
             HStack {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
             }
-            .padding(.horizontal, 12)
+            .padding(.leading, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
-    // MARK: - 공지 카드
+    // MARK: - 목록
 
-    private func noticeCard(_ notice: NoticeItem) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                // 토글 영역
-                ZStack {
-                    Capsule()
-                        .fill(notice.isActive ? Color(hex: "#2563EB") : Color(hex: "#E5E7EB"))
-                        .frame(width: 44, height: 24)
-                    Circle()
-                        .fill(.white)
-                        .frame(width: 18, height: 18)
-                        .offset(x: notice.isActive ? 10 : -10)
+    private var noticeList: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(viewModel.notices, id: \.id) { notice in
+                    noticeCard(notice)
                 }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            .padding(.bottom, 32)
+        }
+        .refreshable { viewModel.refresh() }
+    }
+
+    private func noticeCard(_ notice: StaffNoticeDTO) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                activeToggle(notice)
 
                 if notice.isActive {
                     Text("활성")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundColor(Color(hex: "#2563EB"))
-                        .padding(.horizontal, 8)
-                        .frame(height: 20)
+                        .frame(width: 44, height: 20)
                         .background(Color(hex: "#E8F0FF"))
                         .cornerRadius(4)
                 }
 
-                Text(notice.date)
+                Text(viewModel.dateText(notice))
                     .font(.system(size: 11))
                     .foregroundColor(Color(hex: "#6B7280"))
 
                 Spacer()
 
-                Text("⋮")
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(Color(hex: "#6B7280"))
+                Button { menuTarget = notice } label: {
+                    Text("⋮")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(Color(hex: "#6B7280"))
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
             }
 
+            // 한글 기준 2줄 말줄임 — 넘치면 행을 눌러 전문을 봅니다
             Text(notice.content)
                 .font(.system(size: 12))
                 .foregroundColor(Color(hex: "#333840"))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 20)
+
+            Spacer(minLength: 0)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .padding(16)
+        .frame(height: 104, alignment: .top)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white)
-        .cornerRadius(12)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
                 .stroke(notice.isActive ? Color(hex: "#2563EB") : Color(hex: "#E5E7EB"),
                         lineWidth: notice.isActive ? 1.5 : 1)
         )
+        .contentShape(Rectangle())
+        .onTapGesture { detailTarget = notice }
+    }
+
+    /// 활성 토글 — w44 h24, 노브 18
+    private func activeToggle(_ notice: StaffNoticeDTO) -> some View {
+        Button { viewModel.toggleActive(notice) } label: {
+            ZStack(alignment: notice.isActive ? .trailing : .leading) {
+                Capsule()
+                    .fill(notice.isActive ? Color(hex: "#2563EB") : Color(hex: "#E5E7EB"))
+                    .frame(width: 44, height: 24)
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 18, height: 18)
+                    .padding(.horizontal, 3)
+            }
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.15), value: notice.isActive)
+    }
+
+    // MARK: - 전문 팝업
+
+    private func noticeDetailPopup(_ notice: StaffNoticeDTO) -> some View {
+        ZStack {
+            Color.black.opacity(0.45)
+                .ignoresSafeArea()
+                .onTapGesture { detailTarget = nil }
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text(viewModel.dateText(notice))
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(hex: "#6B7280"))
+                    Spacer()
+                    Button { detailTarget = nil } label: {
+                        Text("✕")
+                            .font(.system(size: 16))
+                            .foregroundColor(Color(hex: "#6B7280"))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                ScrollView {
+                    Text(notice.content)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#333840"))
+                        .lineSpacing(4)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 240)
+                .padding(.top, 16)
+            }
+            .padding(20)
+            .frame(width: 330)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+    }
+
+    // MARK: - 상태 화면
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("공지를 불러오는 중이에요")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        Text("작성된 공지가 없어요")
+            .font(.system(size: 14))
+            .foregroundColor(Color(hex: "#6B7280"))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            Text(message)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+            Button { viewModel.load() } label: {
+                Text("재시도")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+                    .frame(height: 44)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 40)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
+        }
     }
 }
 
-private struct NoticeItem: Identifiable {
-    let id = UUID()
-    let isActive: Bool
-    let date: String
-    let content: String
+// MARK: - 공지 작성 팝업
+/// Figma 12381:5429 — 330×320 카드
+
+struct NoticeEditorPopup: View {
+
+    @Binding var text: String
+    let limit: Int
+    let isEditing: Bool
+    let isSaving: Bool
+    var onCancel: () -> Void
+    var onSubmit: () -> Void
+
+    @State private var showDiscardConfirm = false
+
+    /// 공백·개행만 있으면 작성완료를 막습니다
+    private var canSubmit: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && text.count <= limit
+            && !isSaving
+    }
+
+    private var isOverLimit: Bool { text.count > limit }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.45)
+                .ignoresSafeArea()
+                .onTapGesture { requestCancel() }
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(isEditing ? "공지 수정" : "새 공지 작성")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color(hex: "#111827"))
+                    .padding(.top, 22)
+
+                ZStack(alignment: .topLeading) {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(hex: "#F3F4F6"))
+
+                    if text.isEmpty {
+                        Text("새 공지를 작성하세요")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(hex: "#6B7280"))
+                            .padding(.horizontal, 20)
+                            .padding(.top, 16)
+                    }
+
+                    // 입력 중에 자르지 않습니다 (조합형 문자 입력이 깨집니다)
+                    TextEditor(text: $text)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#111827"))
+                        .scrollContentBackground(.hidden)
+                        .background(Color.clear)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                }
+                .frame(height: 160)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(isOverLimit ? Color(hex: "#EF4444") : .clear, lineWidth: 1)
+                )
+                .padding(.top, 14)
+
+                HStack {
+                    Spacer()
+                    Text("\(text.count)/\(limit)")
+                        .font(.system(size: 11, weight: isOverLimit ? .bold : .regular))
+                        .foregroundColor(isOverLimit ? Color(hex: "#EF4444") : Color(hex: "#6B7280"))
+                }
+                .padding(.top, 8)
+
+                HStack(spacing: 12) {
+                    Button { requestCancel() } label: {
+                        Text("취소하기")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(Color(hex: "#333840"))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(Color(hex: "#F3F4F6"))
+                            .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button { onSubmit() } label: {
+                        Group {
+                            if isSaving {
+                                ProgressView().tint(.white)
+                            } else {
+                                Text("작성완료")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundColor(.white)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 48)
+                        .background(canSubmit ? Color(hex: "#2563EB") : Color(hex: "#C3CDDA"))
+                        .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!canSubmit)
+                }
+                .padding(.top, 26)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 20)
+            .frame(width: 330, height: 320, alignment: .top)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+        .confirmationDialog("작성을 취소할까요?", isPresented: $showDiscardConfirm, titleVisibility: .visible) {
+            Button("작성 취소", role: .destructive) { onCancel() }
+            Button("계속 작성", role: .cancel) { }
+        } message: {
+            Text("내용은 저장되지 않습니다")
+        }
+    }
+
+    private func requestCancel() {
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            onCancel()
+        } else {
+            showDiscardConfirm = true
+        }
+    }
 }

--- a/HiTrip/Features/Schedule/Views/NoticeSettingView.swift
+++ b/HiTrip/Features/Schedule/Views/NoticeSettingView.swift
@@ -20,6 +20,8 @@ struct NoticeSettingView: View {
     @State private var pendingActivationId: Int?
     /// ⋮ 메뉴 대상
     @State private var menuTarget: StaffNoticeDTO?
+    /// 삭제 확인 대상
+    @State private var deleteTarget: StaffNoticeDTO?
     /// 전문 보기
     @State private var detailTarget: StaffNoticeDTO?
 
@@ -113,9 +115,31 @@ struct NoticeSettingView: View {
                 }
                 menuTarget = nil
             }
+            Button("삭제", role: .destructive) {
+                deleteTarget = menuTarget
+                menuTarget = nil
+            }
             Button("취소", role: .cancel) { menuTarget = nil }
         }
-        .alert("저장하지 못했어요", isPresented: Binding(
+        .confirmationDialog(
+            "이 공지를 삭제할까요?",
+            isPresented: Binding(
+                get: { deleteTarget != nil },
+                set: { if !$0 { deleteTarget = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("삭제", role: .destructive) {
+                if let target = deleteTarget { viewModel.delete(target) }
+                deleteTarget = nil
+            }
+            Button("취소", role: .cancel) { deleteTarget = nil }
+        } message: {
+            Text(deleteTarget?.isActive == true
+                 ? "활성 공지입니다. 삭제하면 관광객 홈에 공지가 표시되지 않습니다"
+                 : "삭제한 공지는 되돌릴 수 없습니다")
+        }
+        .alert("처리하지 못했어요", isPresented: Binding(
             get: { viewModel.saveError != nil },
             set: { if !$0 { viewModel.saveError = nil } }
         )) {

--- a/HiTrip/Features/Schedule/Views/SafetyManagementView.swift
+++ b/HiTrip/Features/Schedule/Views/SafetyManagementView.swift
@@ -64,8 +64,10 @@ struct SafetyManagementView: View {
         .onAppear { viewModel.startPolling() }
         .onDisappear { viewModel.stopPolling() }
         .navigationDestination(isPresented: $showLocation) {
-            // 관광객 위치 확인 화면은 다음 단계에서 서버에 연결합니다
-            TouristLocationView(touristName: locationTarget?.travelerName ?? "")
+            TouristLocationView(
+                participantId: locationTarget?.participantId ?? 0,
+                touristName: locationTarget?.travelerName ?? ""
+            )
         }
     }
 

--- a/HiTrip/Features/Schedule/Views/SafetyManagementView.swift
+++ b/HiTrip/Features/Schedule/Views/SafetyManagementView.swift
@@ -1,430 +1,497 @@
 import SwiftUI
+import UIKit
 
-struct SafetyTourist: Identifiable {
-    let id = UUID()
-    let name: String
-    let phone: String
-    let country: String
-    let passportNumber: String
-    var isDeparted: Bool
-    var departureDistance: Double?
-    var heartRate: Int
-    var spo2: Int
-
-    var isDepartureAlert: Bool { isDeparted || (departureDistance ?? 0) > 0 }
-
-    // 심박: >=150 위험, >100 경고
-    var heartRateLevel: AlertLevel {
-        if heartRate >= 150 || heartRate < 50 { return .danger }
-        if heartRate > 100 { return .warning }
-        return .normal
-    }
-
-    // SpO₂: <90 위험, <95 경고
-    var spo2Level: AlertLevel {
-        if spo2 < 90 { return .danger }
-        if spo2 < 95 { return .warning }
-        return .normal
-    }
-
-    var overallLevel: AlertLevel {
-        if isDepartureAlert || heartRateLevel == .danger || spo2Level == .danger { return .danger }
-        if heartRateLevel == .warning || spo2Level == .warning { return .warning }
-        return .normal
-    }
-
-    var statusText: String {
-        var parts: [String] = []
-        if let dist = departureDistance, dist > 0 {
-            parts.append("경계 밖 \(String(format: "%.1f", dist))km")
-        }
-        parts.append("심박 \(heartRate)")
-        parts.append("SpO₂ \(spo2)%")
-        return parts.joined(separator: " · ")
-    }
-}
-
-enum AlertLevel { case normal, warning, danger }
+// MARK: - SafetyManagementView
+/// 안전 관리 — Figma 12381:4446
+///
+/// 상태 요약 칩(탭 시 필터·재탭 해제) / 30초 갱신 / 관광객 표
+/// 행을 누르면 관광객 정보 팝업이 뜹니다.
 
 struct SafetyManagementView: View {
 
+    var onDismiss: (() -> Void)?
+
     @Environment(\.dismiss) private var dismiss
-    var onDismiss: (() -> Void)? = nil
-    @State private var selectedTourist: SafetyTourist?
-    @State private var showDetail = false
-    @State private var navigateToLocation = false
-    @State private var showPassport = false
+    @StateObject private var viewModel = SafetyManagementViewModel()
 
-    private let tourists: [SafetyTourist] = [
-        SafetyTourist(name: "이연세", phone: "010-1234-5678", country: "대한민국",
-                      passportNumber: "DND***000", isDeparted: false,
-                      departureDistance: nil, heartRate: 72, spo2: 97),
-        SafetyTourist(name: "둘리", phone: "010-2345-6789", country: "대한민국",
-                      passportNumber: "KIM***123", isDeparted: true,
-                      departureDistance: 1.2, heartRate: 110, spo2: 95),
-        SafetyTourist(name: "펭수", phone: "010-3456-7890", country: "대한민국",
-                      passportNumber: "PAK***456", isDeparted: false,
-                      departureDistance: nil, heartRate: 135, spo2: 94),
-        SafetyTourist(name: "뽀로로", phone: "010-4567-8901", country: "대한민국",
-                      passportNumber: "JEO***789", isDeparted: false,
-                      departureDistance: nil, heartRate: 88, spo2: 98),
-        SafetyTourist(name: "에디", phone: "010-5678-9012", country: "대한민국",
-                      passportNumber: "CHO***012", isDeparted: false,
-                      departureDistance: nil, heartRate: 187, spo2: 91),
-    ]
-
-    private var sorted: [SafetyTourist] {
-        tourists.sorted { a, b in levelPriority(a) > levelPriority(b) }
-    }
-
-    private func levelPriority(_ t: SafetyTourist) -> Int {
-        switch t.overallLevel {
-        case .danger: return 2
-        case .warning: return 1
-        case .normal: return 0
-        }
-    }
+    @State private var selected: ParticipantLatestDTO?
+    @State private var showLocation = false
+    @State private var locationTarget: ParticipantLatestDTO?
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 headerSection
-                pillsRow
-                    .padding(.horizontal, 24)
-                    .padding(.top, 12)
-                timestampRow
-                    .padding(.horizontal, 24)
-                    .padding(.top, 6)
-                    .padding(.bottom, 12)
-                tableSection
-                    .padding(.horizontal, 24)
-                legendSection
-                    .padding(.horizontal, 24)
-                    .padding(.top, 12)
-                Spacer()
+                filterChips
+                    .padding(.top, 21)
+                updatedRow
+                    .padding(.top, 14)
+
+                switch viewModel.state {
+                case .idle, .loading:
+                    loadingView
+                case .failed(let message):
+                    errorView(message)
+                case .loaded:
+                    if viewModel.isEmpty {
+                        emptyView
+                    } else {
+                        participantTable
+                    }
+                }
             }
             .background(Color.white)
-            .navigationBarHidden(true)
 
-            if showDetail, let tourist = selectedTourist {
-                Color.black.opacity(0.35)
-                    .ignoresSafeArea()
-                    .onTapGesture { showDetail = false }
-                touristDetailPopup(tourist)
-                    .padding(.horizontal, 24)
-                    .transition(.scale(scale: 0.95).combined(with: .opacity))
+            if let selected {
+                TouristInfoPopup(
+                    participant: selected,
+                    profile: viewModel.profile(for: selected),
+                    statusLine: viewModel.statusLine(selected),
+                    canViewLocation: viewModel.canViewLocation(selected),
+                    isEscaped: selected.geofenceIncident != nil,
+                    onClose: { self.selected = nil },
+                    onViewLocation: {
+                        locationTarget = selected
+                        self.selected = nil
+                        showLocation = true
+                    }
+                )
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: showDetail)
-        .navigationDestination(isPresented: $navigateToLocation) {
-            TouristLocationView(touristName: selectedTourist?.name ?? "")
+        .animation(.easeInOut(duration: 0.2), value: selected?.participantId)
+        .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .onAppear { viewModel.startPolling() }
+        .onDisappear { viewModel.stopPolling() }
+        .navigationDestination(isPresented: $showLocation) {
+            // 관광객 위치 확인 화면은 다음 단계에서 서버에 연결합니다
+            TouristLocationView(touristName: locationTarget?.travelerName ?? "")
         }
     }
 
-    // MARK: - Header
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("안전 관리")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
+
             HStack {
                 Button {
-                    if let onDismiss { onDismiss() }
-                    else { dismiss() }
+                    onDismiss?()
+                    dismiss()
                 } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
             }
-            .padding(.horizontal, 12)
+            .padding(.leading, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
-    // MARK: - Pills
+    // MARK: - 상태 요약 칩
 
-    private var pillsRow: some View {
+    private var filterChips: some View {
         HStack(spacing: 8) {
-            pill(label: "전체 \(tourists.count)", bg: Color(hex: "#F3F4F6"), fg: Color(hex: "#333840"))
-            pill(label: "경고 \(tourists.filter { $0.overallLevel == .warning }.count)",
-                 bg: Color(hex: "#FFF2D9"), fg: Color(hex: "#EB8C0D"))
-            pill(label: "위험 \(tourists.filter { $0.overallLevel == .danger && !$0.isDepartureAlert }.count)",
-                 bg: Color(hex: "#FCE5E5"), fg: Color(hex: "#EF4444"))
-            pill(label: "이탈 \(tourists.filter { $0.isDepartureAlert }.count)",
-                 bg: Color(hex: "#FCE5E5"), fg: Color(hex: "#EF4444"))
-            Spacer()
+            chip("전체 \(viewModel.totalCount)",
+                 background: Color(hex: "#F3F4F6"), foreground: Color(hex: "#333840"),
+                 isOn: viewModel.filter == nil) { viewModel.filter = nil }
+
+            chip("경고 \(viewModel.warningCount)",
+                 background: Color(hex: "#FFF2D9"), foreground: Color(hex: "#EB8C0D"),
+                 isOn: viewModel.filter == .warning) { viewModel.toggle(.warning) }
+
+            chip("위험 \(viewModel.dangerCount)",
+                 background: Color(hex: "#FCE5E5"), foreground: Color(hex: "#EF4444"),
+                 isOn: viewModel.filter == .danger) { viewModel.toggle(.danger) }
+
+            chip("이탈 \(viewModel.escapedCount)",
+                 background: Color(hex: "#FCE5E5"), foreground: Color(hex: "#EF4444"),
+                 isOn: viewModel.filter == .escaped) { viewModel.toggle(.escaped) }
+
+            Spacer(minLength: 0)
         }
+        .padding(.horizontal, 24)
     }
 
-    private func pill(label: String, bg: Color, fg: Color) -> some View {
-        Text(label)
-            .font(.system(size: 12, weight: .bold))
-            .foregroundColor(fg)
-            .padding(.horizontal, 12)
-            .frame(height: 32)
-            .background(bg)
-            .cornerRadius(16)
-    }
-
-    // MARK: - Timestamp
-
-    private var timestampRow: some View {
-        HStack {
-            Spacer()
-            Text("\(Date().formatted(.dateTime.hour(.twoDigits(amPM: .omitted)).minute())) 기준 · 30초마다 갱신")
-                .font(.system(size: 11))
-                .foregroundColor(Color(hex: "#6B7280"))
-        }
-    }
-
-    // MARK: - 테이블
-
-    private var tableSection: some View {
-        VStack(spacing: 0) {
-            tableHeader
-            Divider()
-            ForEach(sorted) { t in
-                tableRow(t)
-                Divider()
-            }
-        }
-        .cornerRadius(8)
-        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(hex: "#E5E7EB"), lineWidth: 1))
-    }
-
-    private var tableHeader: some View {
-        HStack(spacing: 0) {
-            Text("이름").frame(width: 52)
-            Divider().frame(height: 36)
-            Text("연락처").frame(maxWidth: .infinity)
-            Divider().frame(height: 36)
-            Text("이탈여부").frame(width: 52)
-            Divider().frame(height: 36)
-            Text("심박수").frame(width: 44)
-            Divider().frame(height: 36)
-            Text("SpO₂").frame(width: 44)
-        }
-        .font(.system(size: 11, weight: .bold))
-        .foregroundColor(Color(hex: "#6B7280"))
-        .frame(height: 36)
-        .background(Color(hex: "#F9FAFB"))
-    }
-
-    private func tableRow(_ t: SafetyTourist) -> some View {
-        Button {
-            selectedTourist = t
-            showPassport = false
-            showDetail = true
-        } label: {
-            HStack(spacing: 0) {
-                // 이름 (파랑)
-                Text(t.name)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(Color(hex: "#2563EB"))
-                    .frame(width: 52)
-
-                Divider().frame(height: 44)
-
-                // 연락처
-                Text(t.phone)
-                    .font(.system(size: 10))
-                    .foregroundColor(Color(hex: "#6B7280"))
-                    .frame(maxWidth: .infinity)
-
-                Divider().frame(height: 44)
-
-                // 이탈여부
-                if let dist = t.departureDistance, dist > 0 {
-                    Text("\(String(format: "%.1f", dist))km")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(Color(hex: "#EF4444"))
-                        .padding(.horizontal, 4)
-                        .frame(height: 20)
-                        .background(Color(hex: "#FCE5E5"))
-                        .cornerRadius(6)
-                        .frame(width: 52)
-                } else {
-                    Text("정상")
-                        .font(.system(size: 12))
-                        .foregroundColor(Color(hex: "#333840"))
-                        .frame(width: 52)
-                }
-
-                Divider().frame(height: 44)
-
-                // 심박수
-                alertCell(value: "\(t.heartRate)", level: t.heartRateLevel, width: 44)
-
-                Divider().frame(height: 44)
-
-                // SpO₂
-                alertCell(value: "\(t.spo2)", level: t.spo2Level, width: 44)
-            }
-            .frame(height: 44)
+    private func chip(
+        _ text: String, background: Color, foreground: Color,
+        isOn: Bool, action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(text)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(foreground)
+                .frame(width: 64, height: 32)
+                .background(background)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(isOn ? foreground : .clear, lineWidth: 1)
+                )
         }
         .buttonStyle(.plain)
     }
 
-    private func alertCell(value: String, level: AlertLevel, width: CGFloat) -> some View {
-        Group {
-            switch level {
-            case .danger:
-                Text(value)
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(Color(hex: "#EF4444"))
-                    .padding(.horizontal, 4)
-                    .frame(height: 20)
-                    .background(Color(hex: "#FCE5E5"))
-                    .cornerRadius(6)
-            case .warning:
-                Text(value)
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(Color(hex: "#EB8C0D"))
-                    .padding(.horizontal, 4)
-                    .frame(height: 20)
-                    .background(Color(hex: "#FFF2D9"))
-                    .cornerRadius(6)
-            case .normal:
-                Text(value)
-                    .font(.system(size: 11))
-                    .foregroundColor(Color(hex: "#333840"))
-            }
+    private var updatedRow: some View {
+        HStack {
+            Spacer()
+            Text(viewModel.updatedText)
+                .font(.system(size: 11))
+                .foregroundColor(Color(hex: "#6B7280"))
         }
-        .frame(width: width)
+        .padding(.horizontal, 24)
     }
 
-    // MARK: - 범례
+    // MARK: - 표
 
-    private var legendSection: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("경고(주황) · 위험(빨강) · — 데이터 수신 안 됨(워치 미연동·통신 두절)")
-                .font(.system(size: 10))
-                .foregroundColor(Color(hex: "#6B7280"))
-            Text("정렬: 위험 → 경고 → 정상 · 행 탭 시 관광객 정보 팝업")
-                .font(.system(size: 10))
-                .foregroundColor(Color(hex: "#6B7280"))
+    private var participantTable: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                tableHeader
+                    .padding(.horizontal, 24)
+                    .padding(.top, 24)
+
+                ForEach(viewModel.sortedParticipants, id: \.participantId) { p in
+                    participantRow(p)
+                        .padding(.horizontal, 24)
+
+                    Rectangle()
+                        .fill(Color(hex: "#E5E7EB"))
+                        .frame(height: 1)
+                        .padding(.horizontal, 24)
+                }
+
+                legend
+                    .padding(.horizontal, 24)
+                    .padding(.top, 26)
+                    .padding(.bottom, 32)
+            }
         }
+        .refreshable { viewModel.refresh() }
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: 0) {
+            headerCell("이름", width: 56)
+            headerCell("연락처", width: 88)
+            headerCell("이탈여부", width: 74)
+            headerCell("심박수", width: 64)
+            headerCell("SpO₂", width: 44)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 36)
+        .background(Color(hex: "#F3F4F6"))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func headerCell(_ text: String, width: CGFloat) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .bold))
+            .foregroundColor(Color(hex: "#6B7280"))
+            .frame(width: width, alignment: .leading)
+    }
+
+    private func participantRow(_ p: ParticipantLatestDTO) -> some View {
+        HStack(spacing: 0) {
+            Text(p.travelerName)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(Color(hex: "#2563EB"))
+                .frame(width: 56, alignment: .leading)
+                .lineLimit(1)
+
+            Text(viewModel.profile(for: p)?.phone ?? "—")
+                .font(.system(size: 10))
+                .foregroundColor(Color(hex: "#6B7280"))
+                .frame(width: 88, alignment: .leading)
+                .lineLimit(1)
+
+            // 이탈 거리 — 빨간 셀을 누르면 위치 확인으로 이동합니다
+            Group {
+                if let distance = viewModel.escapeDistanceText(p) {
+                    Text(distance)
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(Color(hex: "#EF4444"))
+                        .padding(.horizontal, 8)
+                        .frame(height: 20)
+                        .background(Color(hex: "#FCE5E5"))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .onTapGesture {
+                            locationTarget = p
+                            showLocation = true
+                        }
+                } else {
+                    Text(p.locationStatus == .offline || p.locationStatus == .unknown ? "—" : "정상")
+                        .font(.system(size: 12))
+                        .foregroundColor(p.locationStatus == .offline || p.locationStatus == .unknown
+                                         ? Color(hex: "#6B7280") : Color(hex: "#333840"))
+                }
+            }
+            .frame(width: 74, alignment: .leading)
+
+            metricCell(viewModel.heartRateText(p), level: viewModel.heartRateLevel(p), width: 64)
+            metricCell(viewModel.spo2Text(p), level: viewModel.spo2Level(p), width: 44)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 56)
+        .contentShape(Rectangle())
+        .onTapGesture { selected = p }
+    }
+
+    /// 심박·SpO₂ 셀 — 경고는 주황, 위험은 빨강 뱃지
+    private func metricCell(
+        _ text: String,
+        level: SafetyManagementViewModel.Level,
+        width: CGFloat
+    ) -> some View {
+        Group {
+            switch level {
+            case .normal:
+                Text(text)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(hex: "#333840"))
+            case .unknown:
+                Text("—")
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(hex: "#6B7280"))
+            case .warning, .danger:
+                Text(text)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(level == .warning ? Color(hex: "#EB8C0D") : Color(hex: "#EF4444"))
+                    .padding(.horizontal, 8)
+                    .frame(height: 20)
+                    .background(level == .warning ? Color(hex: "#FFF2D9") : Color(hex: "#FCE5E5"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+        }
+        .frame(width: width, alignment: .leading)
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("경고(주황) · 위험(빨강) · — 데이터 수신 안 됨(워치 미연동·통신 두절)")
+            Text("정렬: 위험 → 경고 → 정상 · 행 탭 시 관광객 정보 팝업")
+        }
+        .font(.system(size: 10))
+        .foregroundColor(Color(hex: "#6B7280"))
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - 상세 팝업
+    // MARK: - 상태 화면
 
-    private func touristDetailPopup(_ t: SafetyTourist) -> some View {
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("안전 정보를 불러오는 중이에요")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        Text("등록된 관광객이 없습니다")
+            .font(.system(size: 14))
+            .foregroundColor(Color(hex: "#6B7280"))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            Text(message)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+            Button { viewModel.load() } label: {
+                Text("재시도")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+                    .frame(height: 44)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - 관광객 정보 팝업
+/// Figma 12381:4366 — 320×300 카드
+///
+/// 여권번호는 중간 3자리를 가리고, 👁을 누르면 3초만 보여줍니다.
+/// 위치보기는 이탈이거나 건강 경고·위험일 때만 누를 수 있습니다 (프라이버시).
+
+struct TouristInfoPopup: View {
+
+    let participant: ParticipantLatestDTO
+    let profile: TravelerDetailDTO?
+    let statusLine: String
+    let canViewLocation: Bool
+    let isEscaped: Bool
+    var onClose: () -> Void
+    var onViewLocation: () -> Void
+
+    @State private var showsFullPassport = false
+    @State private var blockedNotice = false
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.45)
+                .ignoresSafeArea()
+                .onTapGesture { onClose() }
+
+            card
+        }
+    }
+
+    private var card: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(t.name)
-                    .font(.system(size: 17, weight: .bold))
+            HStack(alignment: .top, spacing: 8) {
+                Text(participant.travelerName)
+                    .font(.system(size: 18, weight: .bold))
                     .foregroundColor(Color(hex: "#111827"))
-                if t.isDepartureAlert {
+
+                if isEscaped {
                     Text("이탈")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundColor(Color(hex: "#EF4444"))
-                        .padding(.horizontal, 8)
-                        .frame(height: 22)
+                        .padding(.horizontal, 10)
+                        .frame(height: 20)
                         .background(Color(hex: "#FCE5E5"))
-                        .cornerRadius(6)
+                        .cornerRadius(4)
+                        .padding(.top, 2)
                 }
+
                 Spacer()
-                Button { showDetail = false } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 13))
+
+                Button(action: onClose) {
+                    Text("✕")
+                        .font(.system(size: 16))
                         .foregroundColor(Color(hex: "#6B7280"))
                 }
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 20)
-            .padding(.bottom, 16)
+            .padding(.top, 24)
 
-            Divider()
+            infoRow("국가", profile?.country ?? "—")
+                .padding(.top, 22)
+            passportRow
+                .padding(.top, 12)
+            infoRow("전화번호", profile?.phone ?? "—")
+                .padding(.top, 12)
+            infoRow("상태", statusLine, valueColor: Color(hex: "#EF4444"))
+                .padding(.top, 12)
 
-            detailRow("국가", t.country)
-            passportRow(t.passportNumber)
-            detailRow("전화번호", t.phone)
-
-            HStack {
-                Text("상태")
-                    .font(.system(size: 13))
-                    .foregroundColor(Color(hex: "#6B7280"))
-                    .frame(width: 60, alignment: .leading)
-                Text(t.statusText)
-                    .font(.system(size: 13))
-                    .foregroundColor(Color(hex: "#EF4444"))
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 12)
-
-            Divider()
-
-            HStack(spacing: 0) {
-                Button { } label: {
+            HStack(spacing: 12) {
+                Button { call() } label: {
                     Text("전화걸기")
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(Color(hex: "#111827"))
+                        .foregroundColor(hasPhone ? Color(hex: "#333840") : Color(hex: "#9CA3AF"))
                         .frame(maxWidth: .infinity)
-                        .frame(height: 50)
+                        .frame(height: 52)
                         .background(Color(hex: "#F3F4F6"))
+                        .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
+                .disabled(!hasPhone)
 
                 Button {
-                    showDetail = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        navigateToLocation = true
-                    }
+                    if canViewLocation { onViewLocation() } else { blockedNotice = true }
                 } label: {
                     Text("위치보기")
                         .font(.system(size: 14, weight: .bold))
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color(hex: "#2563EB"))
+                        .frame(height: 52)
+                        .background(canViewLocation ? Color(hex: "#2563EB") : Color(hex: "#C3CDDA"))
+                        .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
             }
-            .cornerRadius(12, corners: [.bottomLeft, .bottomRight])
-        }
-        .background(Color.white)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: 4)
-    }
+            .padding(.top, 24)
 
-    /// 여권번호 — 기본 마스킹, 👁 탭 시 전체 표시
-    private func passportRow(_ masked: String) -> some View {
-        HStack {
-            Text("여권번호")
-                .font(.system(size: 13))
-                .foregroundColor(Color(hex: "#6B7280"))
-                .frame(width: 60, alignment: .leading)
-            Text(showPassport ? masked.replacingOccurrences(of: "***", with: "123") : masked)
-                .font(.system(size: 13))
-                .foregroundColor(Color(hex: "#111827"))
-            Button { showPassport.toggle() } label: {
-                Image(systemName: showPassport ? "eye.slash" : "eye")
-                    .font(.system(size: 12))
+            if !hasPhone {
+                Text("연락처가 등록되지 않았어요")
+                    .font(.system(size: 11))
                     .foregroundColor(Color(hex: "#6B7280"))
+                    .padding(.top, 8)
+            } else if blockedNotice {
+                Text("위험 상태의 관광객만 위치를 볼 수 있어요")
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(hex: "#6B7280"))
+                    .padding(.top, 8)
             }
-            .buttonStyle(.plain)
-            Spacer()
+
+            Spacer(minLength: 0)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 20)
+        // Figma 320x300 카드
+        .frame(width: 320, height: 300, alignment: .top)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
-    private func detailRow(_ label: String, _ value: String) -> some View {
-        HStack {
+    private func infoRow(_ label: String, _ value: String, valueColor: Color = Color(hex: "#111827")) -> some View {
+        HStack(alignment: .top, spacing: 0) {
             Text(label)
-                .font(.system(size: 13))
+                .font(.system(size: 12))
                 .foregroundColor(Color(hex: "#6B7280"))
-                .frame(width: 60, alignment: .leading)
+                .frame(width: 66, alignment: .leading)
             Text(value)
-                .font(.system(size: 13))
-                .foregroundColor(Color(hex: "#111827"))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(valueColor)
+                .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 12)
+    }
+
+    /// 여권번호 — 기본 마스킹, 👁 탭 시 3초만 공개
+    private var passportRow: some View {
+        HStack(alignment: .top, spacing: 0) {
+            Text("여권번호")
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "#6B7280"))
+                .frame(width: 66, alignment: .leading)
+
+            Text(showsFullPassport
+                 ? (profile?.passportNumber ?? "—")
+                 : (profile?.maskedPassport ?? "—"))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+
+            if profile?.passportNumber != nil {
+                Button { revealPassport() } label: {
+                    Text("👁")
+                        .font(.system(size: 13))
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 8)
+            }
+        }
+    }
+
+    private func revealPassport() {
+        showsFullPassport = true
+        // 3초 뒤 자동으로 다시 가립니다 (개인정보 열람 최소화)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { showsFullPassport = false }
+    }
+
+    private var hasPhone: Bool {
+        guard let phone = profile?.phone else { return false }
+        return !phone.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func call() {
+        guard let phone = profile?.phone else { return }
+        let digits = phone.filter { $0.isNumber || $0 == "+" }
+        guard let url = URL(string: "tel://\(digits)"), UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url)
     }
 }

--- a/HiTrip/Features/Schedule/Views/StaffChatListView.swift
+++ b/HiTrip/Features/Schedule/Views/StaffChatListView.swift
@@ -1,28 +1,50 @@
 import SwiftUI
 
+// MARK: - StaffChatListView
+/// 고객 관리 (메시지) — Figma 12381:4655
+///
+/// - GET /api/v1/chat/rooms/   여행객과 같은 엔드포인트 (세션 쿠키로도 인증됩니다)
+///
+/// 채팅방 화면은 여행객 것과 동일한 ChatRoomView를 그대로 씁니다.
+/// 단체톡방은 여행 등록 시 자동 생성되고 나가기가 없어 항상 최상단에 고정합니다.
+
 struct StaffChatListView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @State private var selectedFilter = "전체"
+    @StateObject private var viewModel = AppDIContainer.shared.makeChatViewModel()
 
-    private let filters = ["전체", "미확인", "단체"]
+    @State private var tab: Tab = .all
+    @State private var selectedRoom: ChatRoom?
+    @State private var showMarkAllConfirm = false
 
-    private let chats: [StaffChatItem] = [
-        StaffChatItem(name: "여행 단체톡방", lastMessage: "오늘 저녁 집합 시간 안내드립니다",
-                      time: "일 12:40", unread: 9, isGroup: true),
-        StaffChatItem(name: "둘리", lastMessage: "가이드님 위치 확인 부탁드려요",
-                      time: "일 11:50", unread: 1, isGroup: false),
-        StaffChatItem(name: "이연세", lastMessage: "감사합니다!",
-                      time: "화 10:56", unread: 0, isGroup: false),
-        StaffChatItem(name: "펭수", lastMessage: "내일 일정 관련 문의드립니다",
-                      time: "화 10:56", unread: 0, isGroup: false),
-    ]
+    /// 기획 재정의 — 기존 "최근·이전·확인됨"은 기준이 모호했습니다
+    private enum Tab: String, CaseIterable, Identifiable {
+        /// 단체 고정 + 최신순
+        case all = "전체"
+        /// 안읽음이 있는 방만
+        case unread = "미확인"
+        /// 단체톡방만
+        case group = "단체"
 
-    private var filtered: [StaffChatItem] {
-        switch selectedFilter {
-        case "미확인": return chats.filter { $0.unread > 0 }
-        case "단체": return chats.filter { $0.isGroup }
-        default: return chats
+        var id: String { rawValue }
+        var width: CGFloat { self == .unread ? 76 : 60 }
+    }
+
+    // MARK: - 목록
+
+    /// 단체톡방 최상단 고정, 이하 마지막 메시지 최신순
+    private var sortedRooms: [ChatRoom] {
+        viewModel.chatRooms.sorted { a, b in
+            if a.isGroupChat != b.isGroupChat { return a.isGroupChat }
+            return a.lastMessageDate > b.lastMessageDate
+        }
+    }
+
+    private var rooms: [ChatRoom] {
+        switch tab {
+        case .all:    return sortedRooms
+        case .unread: return sortedRooms.filter { $0.unreadCount > 0 }
+        case .group:  return sortedRooms.filter { $0.isGroupChat }
         }
     }
 
@@ -30,118 +52,181 @@ struct StaffChatListView: View {
         VStack(spacing: 0) {
             headerSection
 
-            // 필터 칩
-            HStack(spacing: 8) {
-                ForEach(filters, id: \.self) { f in
-                    Button { selectedFilter = f } label: {
-                        Text(f)
-                            .font(.system(size: 12, weight: selectedFilter == f ? .bold : .medium))
-                            .foregroundColor(selectedFilter == f ? .white : Color(hex: "#6B7280"))
-                            .frame(width: f == "미확인" ? 76 : 60, height: 34)
-                            .background(selectedFilter == f ? Color(hex: "#2563EB") : Color(hex: "#F3F4F6"))
-                            .clipShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
+            tabRow
+                .padding(.top, 36)
+                .padding(.bottom, 20)
 
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(filtered) { chat in
-                        chatRow(chat)
-                        Divider()
-                            .padding(.leading, 24)
-                    }
-                }
+            if rooms.isEmpty {
+                emptyView
+            } else {
+                roomList
             }
         }
         .background(Color.white)
         .navigationBarHidden(true)
+        .navigationDestination(item: $selectedRoom) { room in
+            ChatRoomView(viewModel: viewModel, chatRoom: room)
+        }
+        .onAppear { viewModel.fetchChatRooms() }
+        .confirmationDialog(
+            "모든 채팅을 읽음 처리할까요?",
+            isPresented: $showMarkAllConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("확인") { viewModel.markAllAsRead() }
+            Button("취소", role: .cancel) { }
+        }
     }
 
-    // MARK: - Header
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("메시지 및 문의")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
+
             HStack {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
-                Button { } label: {
+                // 즉시 실행하지 않고 한 번 확인합니다
+                Button { showMarkAllConfirm = true } label: {
                     Text("모두 확인")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(Color(hex: "#2563EB"))
                 }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
-    // MARK: - 채팅 행
+    // MARK: - 탭 필터
 
-    private func chatRow(_ chat: StaffChatItem) -> some View {
+    private var tabRow: some View {
+        HStack(spacing: 12) {
+            ForEach(Tab.allCases) { item in
+                let isOn = tab == item
+                Button { tab = item } label: {
+                    Text(item.rawValue)
+                        .font(.system(size: 12, weight: isOn ? .bold : .medium))
+                        .foregroundColor(isOn ? .white : Color(hex: "#6B7280"))
+                        .frame(width: item.width, height: 34)
+                        .background(isOn ? Color(hex: "#2563EB") : Color(hex: "#F3F4F6"))
+                        .clipShape(RoundedRectangle(cornerRadius: 17))
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - 방 목록
+
+    private var roomList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(rooms) { room in
+                    Button { selectedRoom = room } label: { roomRow(room) }
+                        .buttonStyle(.plain)
+
+                    Rectangle()
+                        .fill(Color(hex: "#E5E7EB"))
+                        .frame(height: 1)
+                        .padding(.horizontal, 24)
+                }
+            }
+        }
+        .refreshable { viewModel.fetchChatRooms() }
+    }
+
+    private func roomRow(_ room: ChatRoom) -> some View {
         HStack(spacing: 14) {
-            // 아바타
             Circle()
-                .fill(Color(hex: "#E5E7EB"))
+                .fill(Color(hex: "#F3F4F6"))
                 .frame(width: 48, height: 48)
                 .overlay(
-                    Text(chat.isGroup ? "👥" : String(chat.name.prefix(1)))
-                        .font(.system(size: chat.isGroup ? 20 : 18, weight: .medium))
-                        .foregroundColor(Color(hex: "#6B7280"))
+                    Image(systemName: room.isGroupChat ? "person.3.fill" : "person.fill")
+                        .font(.system(size: room.isGroupChat ? 17 : 19))
+                        .foregroundColor(Color(hex: "#9CA3AF"))
                 )
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(chat.name)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(room.isGroupChat ? "📌 \(room.participantName)" : room.participantName)
                     .font(.system(size: 14, weight: .bold))
                     .foregroundColor(Color(hex: "#111827"))
-                Text(chat.lastMessage)
+                    .lineLimit(1)
+
+                Text(room.lastMessage.isEmpty ? "새로운 채팅방" : room.lastMessage)
                     .font(.system(size: 12))
                     .foregroundColor(Color(hex: "#6B7280"))
                     .lineLimit(1)
             }
 
-            Spacer()
+            Spacer(minLength: 8)
 
             VStack(alignment: .trailing, spacing: 6) {
-                Text(chat.time)
+                Text(Self.timeText(room.lastMessageDate))
                     .font(.system(size: 11))
                     .foregroundColor(Color(hex: "#6B7280"))
 
-                if chat.unread > 0 {
-                    ZStack {
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: 22, height: 22)
-                        Text("\(chat.unread)")
-                            .font(.system(size: 12, weight: .bold))
-                            .foregroundColor(.white)
-                    }
+                if room.unreadCount > 0 {
+                    Text(room.unreadCount > 99 ? "99+" : "\(room.unreadCount)")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .frame(minWidth: 22, minHeight: 22)
+                        .background(Color(hex: "#EF4444"))
+                        .clipShape(Capsule())
+                } else {
+                    Color.clear.frame(width: 0, height: 22)
                 }
             }
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 16)
+        .contentShape(Rectangle())
     }
-}
 
-private struct StaffChatItem: Identifiable {
-    let id = UUID()
-    let name: String
-    let lastMessage: String
-    let time: String
-    let unread: Int
-    let isGroup: Bool
+    // MARK: - 빈 상태
+
+    private var emptyView: some View {
+        VStack(spacing: 10) {
+            Spacer()
+            Image(systemName: tab == .unread ? "checkmark.circle" : "bubble.left.and.bubble.right")
+                .font(.system(size: 40))
+                .foregroundColor(Color(hex: "#D1D5DB"))
+            Text(tab == .unread ? "미확인 메시지가 없어요" : "메시지가 없어요")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// 오늘=HH:mm, 어제="어제", 이번 주=요일+시각("일 12:40"), 그 이전=M.D
+    private static func timeText(_ date: Date) -> String {
+        let cal = Calendar.current
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+
+        if cal.isDateInToday(date) {
+            f.dateFormat = "HH:mm"
+        } else if cal.isDateInYesterday(date) {
+            return "어제"
+        } else if let days = cal.dateComponents([.day], from: date, to: Date()).day, days < 7 {
+            f.dateFormat = "E HH:mm"
+        } else {
+            f.dateFormat = "M.d"
+        }
+        return f.string(from: date)
+    }
 }

--- a/HiTrip/Features/Schedule/Views/StaffDashboardView.swift
+++ b/HiTrip/Features/Schedule/Views/StaffDashboardView.swift
@@ -1,14 +1,20 @@
 import SwiftUI
 
+// MARK: - StaffDashboardView
+/// 안내사 홈 — Figma 12381:5370
+///
+/// 여행명·안내사명 / 오늘의 일정(진행바 + 현재·다음 일정) /
+/// 퀵 메뉴 2×2 / 오늘의 안전 현황
+///
+/// 안전 현황은 30초마다 갱신합니다 (화면이 보이는 동안만).
+
 struct StaffDashboardView: View {
 
     @EnvironmentObject var router: AppRouter
-    @StateObject private var viewModel = TripListViewModel()
+    @StateObject private var viewModel = StaffHomeViewModel()
 
-    @State private var isInteractive = false
     @State private var showMapRange = false
     @State private var showSafety = false
-    @State private var showTouristLocation = false
     @State private var showChat = false
     @State private var showNotification = false
     @State private var showFullSchedule = false
@@ -16,138 +22,165 @@ struct StaffDashboardView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-
-                    // Header
-                    headerSection
-
-                    // 오늘의 일정
-                    todayScheduleSection
-
-                    // 전체일정 링크
-                    Button { showFullSchedule = true } label: {
-                        Text("전체일정 확인 및 일정 수정하기  >")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(Color(hex: "#2563EB"))
-                    }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 12)
-                    .padding(.bottom, 22)
-
-                    // 퀵 메뉴 그리드
-                    quickMenuGrid
-                        .padding(.horizontal, 24)
-                        .padding(.bottom, 18)
-                        .disabled(!isInteractive)
-
-                    // 안전 현황 카드
-                    safetyStatusCard
-                        .padding(.horizontal, 24)
-                        .padding(.bottom, 32)
-                        .disabled(!isInteractive)
+            Group {
+                switch viewModel.state {
+                case .idle, .loading:
+                    loadingView
+                case .noTrip:
+                    noTripView
+                case .failed(let message):
+                    errorView(message)
+                case .loaded:
+                    content
                 }
             }
             .background(Color.white)
             .navigationBarHidden(true)
-            .onAppear {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { isInteractive = true }
-            }
+            .task { viewModel.load() }
+            .onAppear { viewModel.startPolling() }
+            .onDisappear { viewModel.stopPolling() }
             .navigationDestination(isPresented: $showMapRange) { MapRangeSettingView() }
             .navigationDestination(isPresented: $showSafety) {
                 SafetyManagementView(onDismiss: { showSafety = false })
             }
-            .navigationDestination(isPresented: $showTouristLocation) { TouristLocationView() }
-            .navigationDestination(isPresented: $showChat) {
-                StaffChatListView()
-            }
+            .navigationDestination(isPresented: $showChat) { StaffChatListView() }
             .navigationDestination(isPresented: $showNotification) { NotificationCenterView() }
             .navigationDestination(isPresented: $showFullSchedule) { StaffTripDetailView() }
             .navigationDestination(isPresented: $showNotice) { NoticeSettingView() }
         }
     }
 
-    // MARK: - Header
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                headerSection
+                todayScheduleSection
+
+                Button { showFullSchedule = true } label: {
+                    Text("전체일정 확인 및 일정 수정하기  >")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(Color(hex: "#2563EB"))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+                .padding(.bottom, 18)
+
+                quickMenuGrid
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 28)
+
+                safetyStatusCard
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 32)
+            }
+        }
+        .refreshable { viewModel.refreshSafety() }
+    }
+
+    // MARK: - 헤더
 
     private var headerSection: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("뉴진스 바다여행")
+                Text(viewModel.tripTitle)
                     .font(.system(size: 17, weight: .bold))
                     .foregroundColor(.black)
-                Text("안내사 김안내")
+                Text(viewModel.managerText)
                     .font(.system(size: 12))
                     .foregroundColor(Color(hex: "#6B7280"))
             }
+
             Spacer()
-            ZStack(alignment: .topTrailing) {
-                Text("🔔")
-                    .font(.system(size: 18))
-                ZStack {
-                    Circle()
-                        .fill(Color.red)
-                        .frame(width: 18, height: 18)
-                    Text("2")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(.white)
+
+            // 알림 센터 — 안전 경고·위험·이탈의 단일 수신 창구
+            Button { showNotification = true } label: {
+                ZStack(alignment: .topTrailing) {
+                    Text("🔔")
+                        .font(.system(size: 18))
+                        .padding(.top, 6)
+
+                    if viewModel.unreadAlertCount > 0 {
+                        Text("\(min(viewModel.unreadAlertCount, 99))")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundColor(.white)
+                            .frame(width: 18, height: 18)
+                            .background(Color(hex: "#EF4444"))
+                            .clipShape(Circle())
+                            .offset(x: 8, y: 0)
+                    }
                 }
-                .offset(x: 6, y: -4)
             }
-            .onTapGesture { showNotification = true }
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, 24)
-        .padding(.top, 16)
-        .padding(.bottom, 14)
+        .padding(.top, 10)
+        .padding(.bottom, 24)
     }
 
     // MARK: - 오늘의 일정
 
     private var todayScheduleSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 0) {
             Text("오늘의 일정")
                 .font(.system(size: 16, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
                 .padding(.horizontal, 24)
 
-            // 진행률 바
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Spacer().frame(width: 137)
+            // 진행바 + 버스 — 관광객 홈과 같은 규칙(당일 시각 비율)
+            GeometryReader { geo in
+                let filled = geo.size.width * viewModel.todayProgress
+                VStack(alignment: .leading, spacing: 2) {
                     Text("🚌")
                         .font(.system(size: 16))
-                    Spacer()
+                        .offset(x: max(filled - 8, 0))
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Color(hex: "#E5E7EB"))
+                            .frame(height: 4)
+                        Capsule()
+                            .fill(Color(hex: "#2563EB"))
+                            .frame(width: filled, height: 4)
+                    }
                 }
-                .padding(.horizontal, 24)
-                .padding(.bottom, 4)
-
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color(hex: "#E5E7EB"))
-                        .frame(height: 4)
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color(hex: "#2563EB"))
-                        .frame(width: 137, height: 4)
-                }
-                .padding(.horizontal, 24)
             }
-            .padding(.bottom, 10)
-
-            // 일정 아이템들
-            VStack(spacing: 8) {
-                scheduleItem(title: "숙소로 이동", time: "15:00 - 16:00", height: 56)
-                scheduleItem(title: "자유시간", time: "16:00 - 23:00", height: 48)
-            }
+            .frame(height: 40)
             .padding(.horizontal, 24)
+            .padding(.top, 4)
+
+            if let current = viewModel.currentSchedule {
+                scheduleRow(current, height: 56, titleSize: 14)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 4)
+            } else {
+                Text(viewModel.todaySchedules.isEmpty
+                     ? "오늘은 등록된 일정이 없어요"
+                     : "오늘 일정이 모두 끝났어요")
+                    .font(.system(size: 14))
+                    .foregroundColor(Color(hex: "#6B7280"))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .background(Color(hex: "#F3F4F6"))
+                    .cornerRadius(12)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 4)
+            }
+
+            if let next = viewModel.nextSchedule {
+                scheduleRow(next, height: 48, titleSize: 13)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 8)
+            }
         }
     }
 
-    private func scheduleItem(title: String, time: String, height: CGFloat) -> some View {
+    private func scheduleRow(_ item: StaffScheduleDTO, height: CGFloat, titleSize: CGFloat) -> some View {
         HStack {
-            Text(title)
-                .font(.system(size: 14, weight: .medium))
+            Text(item.placeName)
+                .font(.system(size: titleSize, weight: .medium))
                 .foregroundColor(Color(hex: "#111827"))
             Spacer()
-            Text(time)
+            Text(StaffHomeViewModel.timeRange(item.startTime, item.endTime))
                 .font(.system(size: 12))
                 .foregroundColor(Color(hex: "#6B7280"))
         }
@@ -155,64 +188,146 @@ struct StaffDashboardView: View {
         .frame(height: height)
         .background(Color(hex: "#F3F4F6"))
         .cornerRadius(12)
+        .contentShape(Rectangle())
+        .onTapGesture { showFullSchedule = true }
     }
 
-    // MARK: - 퀵 메뉴 그리드
+    // MARK: - 퀵 메뉴 2×2
 
     private var quickMenuGrid: some View {
-        HStack(spacing: 12) {
-            VStack(spacing: 12) {
-                quickMenuCard(emoji: "📢", title: "공지글 설정") { showNotice = true }
-                quickMenuCard(emoji: "📍", title: "지도 범위 설정") { showMapRange = true }
+        VStack(spacing: 16) {
+            HStack(spacing: 12) {
+                menuCard("📢", "공지글 설정") { showNotice = true }
+                menuCard("💬", "고객 관리", badge: viewModel.unreadMessageCount > 0
+                         ? viewModel.unreadMessageBadgeText : nil) { showChat = true }
             }
-            VStack(spacing: 12) {
-                quickMenuCard(emoji: "💬", title: "고객 관리") { showChat = true }
-                quickMenuCard(emoji: "🛡️", title: "안전 관리") { showSafety = true }
+            HStack(spacing: 12) {
+                menuCard("📍", "지도 범위 설정") { showMapRange = true }
+                menuCard("🛡", "안전 관리", showsDot: viewModel.hasSafetyIssue) { showSafety = true }
             }
         }
     }
 
-    private func quickMenuCard(emoji: String, title: String, action: @escaping () -> Void) -> some View {
+    private func menuCard(
+        _ emoji: String,
+        _ title: String,
+        badge: String? = nil,
+        showsDot: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(emoji)
-                    .font(.system(size: 24))
-                    .padding(.bottom, 18)
-                Text(title)
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(Color(hex: "#111827"))
+            ZStack(alignment: .topTrailing) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(emoji)
+                        .font(.system(size: 24))
+                    Spacer(minLength: 0)
+                    Text(title)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(Color(hex: "#111827"))
+                }
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 106)
+                .background(Color(hex: "#F3F4F6"))
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+
+                if let badge {
+                    Text(badge)
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .frame(minWidth: 20, minHeight: 20)
+                        .background(Color(hex: "#EF4444"))
+                        .clipShape(Capsule())
+                        .padding(10)
+                } else if showsDot {
+                    // 경고·위험 인원이 있으면 빨간 점
+                    Circle()
+                        .fill(Color(hex: "#EF4444"))
+                        .frame(width: 8, height: 8)
+                        .padding(14)
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 18)
-            .padding(.vertical, 18)
-            .frame(height: 106)
-            .background(Color(hex: "#F3F4F6"))
-            .cornerRadius(14)
         }
         .buttonStyle(.plain)
     }
 
-    // MARK: - 안전 현황 카드
+    // MARK: - 오늘의 안전 현황
 
     private var safetyStatusCard: some View {
         Button { showSafety = true } label: {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text("오늘의 안전 현황")
                     .font(.system(size: 13, weight: .bold))
                     .foregroundColor(Color(hex: "#2563EB"))
-                Text("전체 12명 · 경고 2 · 위험 1 · 이탈 1")
+                    .padding(.top, 14)
+
+                Text(viewModel.safetySummaryText)
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(Color(hex: "#111827"))
+                    .padding(.top, 14)
+
                 Text("안전 관리에서 자세히 보기  >")
                     .font(.system(size: 12))
                     .foregroundColor(Color(hex: "#6B7280"))
+                    .padding(.top, 10)
+
+                Spacer(minLength: 0)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
-            .padding(.vertical, 18)
+            .frame(height: 90, alignment: .top)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(hex: "#E8F0FF"))
-            .cornerRadius(12)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
         .buttonStyle(.plain)
+    }
+
+    // MARK: - 상태 화면
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("여행 정보를 불러오는 중이에요")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// 배정된 여행이 없을 때
+    private var noTripView: some View {
+        VStack(spacing: 10) {
+            Text("🧭").font(.system(size: 34))
+            Text("배정된 여행이 없습니다")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(Color(hex: "#111827"))
+            Text("SaaS에서 확인해주세요")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#6B7280"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            Text("🧭").font(.system(size: 34))
+            Text(message)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+                .multilineTextAlignment(.center)
+            Button { viewModel.load() } label: {
+                Text("다시 시도")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+                    .frame(height: 44)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/HiTrip/Features/Schedule/Views/StaffTripDetailView.swift
+++ b/HiTrip/Features/Schedule/Views/StaffTripDetailView.swift
@@ -1,239 +1,563 @@
 import SwiftUI
 
+// MARK: - StaffTripDetailView
+/// 전체일정 확인·수정 (안내사) — Figma 12381:5209
+///
+/// 일차 아코디언 + ⋮ 메뉴(시간 변경·메모 수정·삭제) + 일정 추가.
+/// 수정은 즉시 서버에 저장하고, 실패하면 [재시도]를 띄웁니다.
+///
+/// 앱에서는 당일 운영 조정(시간·메모)만 다룹니다.
+/// 장소 변경·일정 신규 구성은 SaaS 권장 — 서버가 장소를 place_id로만 받습니다.
+
 struct StaffTripDetailView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @State private var showContextMenu: Int? = nil
+    @StateObject private var viewModel = StaffTripDetailViewModel()
 
-    private let day1Items = [
-        ScheduleItem(title: "숙소로 이동", time: "09:00 - 10:00"),
-        ScheduleItem(title: "부산시민공원", time: "10:00 - 11:30"),
-        ScheduleItem(title: "포폴로피자 (중식)", time: "12:00 - 13:30"),
-    ]
+    /// ⋮ 메뉴 대상
+    @State private var menuTarget: StaffScheduleDTO?
+    /// 삭제 확인 대상
+    @State private var deleteTarget: StaffScheduleDTO?
+
+    /// 시트 상태
+    @State private var showSheet = false
+    @State private var sheetMode: SheetMode = .add(day: 1)
+    @State private var draftTitle = ""
+    @State private var draftStart = Date()
+    @State private var draftEnd = Date()
+    @State private var openPicker: TimeField?
+
+    private enum SheetMode: Equatable {
+        case add(day: Int)
+        case time(StaffScheduleDTO)
+        case memo(StaffScheduleDTO)
+
+        static func == (l: SheetMode, r: SheetMode) -> Bool {
+            switch (l, r) {
+            case let (.add(a), .add(b)):   return a == b
+            case let (.time(a), .time(b)): return a.id == b.id
+            case let (.memo(a), .memo(b)): return a.id == b.id
+            default: return false
+            }
+        }
+    }
+
+    private enum TimeField { case start, end }
 
     var body: some View {
         ZStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    // 헤더
-                    headerSection
+            VStack(spacing: 0) {
+                headerSection
 
-                    // 여행 정보 카드
-                    tripInfoCard
-                        .padding(.horizontal, 24)
-                        .padding(.top, 16)
-
-                    // 1일차 섹션
-                    daySection(
-                        day: "1일차",
-                        date: "2025.04.24 12:00 출발",
-                        isExpanded: true,
-                        items: day1Items,
-                        dayIndex: 0
-                    )
-                    .padding(.top, 12)
-                    .padding(.horizontal, 24)
-
-                    // + 일정 추가 버튼
-                    addScheduleButton
-                        .padding(.horizontal, 24)
-                        .padding(.top, 8)
-
-                    // 2일차 섹션 (접힘)
-                    collapsedDaySection(day: "2일차", date: "2025.04.25")
-                        .padding(.horizontal, 24)
-                        .padding(.top, 8)
-                        .padding(.bottom, 32)
+                switch viewModel.state {
+                case .idle, .loading:
+                    loadingView
+                case .failed(let message):
+                    errorView(message)
+                case .loaded:
+                    content
                 }
             }
             .background(Color.white)
 
-            // 컨텍스트 메뉴
-            if showContextMenu != nil {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .ignoresSafeArea()
-                    .onTapGesture { showContextMenu = nil }
+            if showSheet {
+                sheetOverlay
             }
         }
+        .overlay(alignment: .bottom) { toastView }
+        .animation(.easeInOut(duration: 0.2), value: showSheet)
         .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .confirmationDialog(
+            "일정",
+            isPresented: Binding(get: { menuTarget != nil }, set: { if !$0 { menuTarget = nil } }),
+            titleVisibility: .hidden
+        ) {
+            Button("시간 변경") { if let t = menuTarget { openTimeSheet(t) }; menuTarget = nil }
+            Button("메모 수정") { if let t = menuTarget { openMemoSheet(t) }; menuTarget = nil }
+            Button("삭제", role: .destructive) { deleteTarget = menuTarget; menuTarget = nil }
+            Button("취소", role: .cancel) { menuTarget = nil }
+        }
+        .confirmationDialog(
+            "이 일정을 삭제할까요?",
+            isPresented: Binding(get: { deleteTarget != nil }, set: { if !$0 { deleteTarget = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("삭제", role: .destructive) {
+                if let target = deleteTarget { viewModel.delete(target) }
+                deleteTarget = nil
+            }
+            Button("취소", role: .cancel) { deleteTarget = nil }
+        }
+        .alert("저장하지 못했어요", isPresented: Binding(
+            get: { viewModel.saveError != nil },
+            set: { if !$0 { viewModel.saveError = nil } }
+        )) {
+            Button("재시도") { viewModel.saveError = nil; submit() }
+            Button("닫기", role: .cancel) { viewModel.saveError = nil }
+        } message: {
+            Text(viewModel.saveError ?? "")
+        }
     }
 
-    // MARK: - Header
+    // MARK: - 헤더
 
     private var headerSection: some View {
         ZStack {
             Text("전체 일정")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundColor(.black)
+
             HStack {
                 Button { dismiss() } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundColor(.black)
+                        .frame(width: 24, height: 24)
                 }
                 Spacer()
             }
-            .padding(.horizontal, 12)
+            .padding(.leading, 12)
         }
-        .frame(height: 44)
+        .frame(height: 24)
         .padding(.top, 8)
     }
 
-    // MARK: - 여행 정보 카드
+    // MARK: - 본문
 
-    private var tripInfoCard: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("뉴진스 바다여행")
+    private var content: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                tripSummary
+                    .padding(.horizontal, 24)
+                    .padding(.top, 33)
+                    .padding(.bottom, 20)
+
+                ForEach(viewModel.days) { day in
+                    daySection(day)
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 16)
+                }
+
+                Spacer().frame(height: 32)
+            }
+        }
+        .refreshable { viewModel.refresh() }
+    }
+
+    /// 여행 요약 — SaaS 등록값, 읽기 전용
+    private var tripSummary: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(viewModel.tripTitle)
                 .font(.system(size: 15, weight: .bold))
                 .foregroundColor(Color(hex: "#111827"))
-            Text("2025.04.24 - 04.26 · 참여 인원 10명")
+            Text(viewModel.tripSubtitle)
                 .font(.system(size: 12))
                 .foregroundColor(Color(hex: "#6B7280"))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
-        .frame(height: 72)
+        .frame(height: 72, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(hex: "#F3F4F6"))
-        .cornerRadius(12)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    // MARK: - 일차 섹션 (펼침)
+    // MARK: - 일차
 
-    private func daySection(day: String, date: String, isExpanded: Bool, items: [ScheduleItem], dayIndex: Int) -> some View {
-        VStack(spacing: 8) {
-            // 일차 헤더
-            HStack {
-                Text(day)
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(.white)
-                    .frame(width: 48, height: 24)
-                    .background(Color(hex: "#2563EB"))
-                    .cornerRadius(6)
-                Text(date)
-                    .font(.system(size: 13, weight: .medium))
+    private func daySection(_ day: StaffTripDetailViewModel.DaySection) -> some View {
+        let isExpanded = viewModel.expandedDay == day.dayNumber
+
+        return VStack(spacing: 12) {
+            Button { withAnimation(.easeInOut(duration: 0.2)) { viewModel.toggle(day: day.dayNumber) } } label: {
+                HStack(spacing: 10) {
+                    Text("\(day.dayNumber)일차")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(isExpanded ? .white : Color(hex: "#6B7280"))
+                        .frame(width: 48, height: 24)
+                        .background(isExpanded ? Color(hex: "#2563EB") : Color(hex: "#E5E7EB"))
+                        .cornerRadius(6)
+
+                    Text(day.date)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(isExpanded ? Color(hex: "#111827") : Color(hex: "#6B7280"))
+
+                    Spacer()
+
+                    Text(isExpanded ? "∧" : "∨")
+                        .font(.system(size: 14))
+                        .foregroundColor(Color(hex: "#6B7280"))
+                }
+                .padding(.horizontal, 14)
+                .frame(height: 52)
+                .background(isExpanded ? Color(hex: "#E8F0FF") : Color(hex: "#F3F4F6"))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                if day.items.isEmpty {
+                    Text("등록된 일정이 없어요")
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#6B7280"))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 60)
+                        .background(Color(hex: "#F9FAFB"))
+                        .cornerRadius(12)
+                }
+
+                ForEach(day.items, id: \.id) { item in
+                    scheduleRow(item)
+                }
+
+                addButton(day: day.dayNumber)
+            }
+        }
+    }
+
+    private func scheduleRow(_ item: StaffScheduleDTO) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(StaffTripDetailViewModel.title(of: item))
+                    .font(.system(size: 14, weight: .medium))
                     .foregroundColor(Color(hex: "#111827"))
-                Spacer()
-                Text("∧")
-                    .font(.system(size: 14))
+                    .lineLimit(1)
+
+                Text(StaffTripDetailViewModel.timeRange(item.startTime, item.endTime))
+                    .font(.system(size: 12))
                     .foregroundColor(Color(hex: "#6B7280"))
             }
-            .padding(.horizontal, 14)
-            .frame(height: 52)
-            .background(Color(hex: "#E8F0FF"))
-            .cornerRadius(12)
 
-            // 스케줄 아이템들
-            ForEach(Array(items.enumerated()), id: \.offset) { idx, item in
-                ZStack(alignment: .topTrailing) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(item.title)
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(Color(hex: "#111827"))
-                            Text(item.time)
-                                .font(.system(size: 12))
-                                .foregroundColor(Color(hex: "#6B7280"))
-                        }
-                        Spacer()
-                        Button {
-                            showContextMenu = showContextMenu == idx ? nil : idx
-                        } label: {
-                            Text("⋮")
-                                .font(.system(size: 16, weight: .bold))
-                                .foregroundColor(Color(hex: "#6B7280"))
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                    .frame(height: 60)
-                    .background(Color.white)
-                    .cornerRadius(12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
-                    )
+            Spacer()
 
-                    // 컨텍스트 메뉴
-                    if showContextMenu == idx {
-                        contextMenu
-                            .offset(x: -8, y: 36)
-                    }
-                }
-                .zIndex(showContextMenu == idx ? 10 : 0)
+            Button { menuTarget = item } label: {
+                Text("⋮")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color(hex: "#6B7280"))
+                    .frame(width: 24, height: 24)
             }
+            .buttonStyle(.plain)
         }
-    }
-
-    // MARK: - 컨텍스트 메뉴
-
-    private var contextMenu: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            menuRow(title: "시간 변경", color: Color(hex: "#111827"))
-            Divider()
-            menuRow(title: "메모 수정", color: Color(hex: "#111827"))
-            Divider()
-            menuRow(title: "삭제", color: Color(hex: "#EF4444"))
-        }
-        .frame(width: 150)
+        .padding(.horizontal, 16)
+        .frame(height: 60)
         .background(Color.white)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(hex: "#E5E7EB"), lineWidth: 1)
+        )
     }
 
-    private func menuRow(title: String, color: Color) -> some View {
-        Text(title)
-            .font(.system(size: 13))
-            .foregroundColor(color)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 20)
-            .frame(height: 44)
-    }
-
-    // MARK: - + 일정 추가
-
-    private var addScheduleButton: some View {
-        Button { } label: {
+    private func addButton(day: Int) -> some View {
+        Button { openAddSheet(day: day) } label: {
             Text("+ 일정 추가")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(Color(hex: "#2563EB"))
                 .frame(maxWidth: .infinity)
                 .frame(height: 48)
                 .background(Color(hex: "#F3F4F6"))
-                .cornerRadius(12)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color(hex: "#6B7280").opacity(0.5), style: StrokeStyle(lineWidth: 1, dash: [6]))
+                        .strokeBorder(Color(hex: "#6B7280"), style: StrokeStyle(lineWidth: 1, dash: [4]))
                 )
         }
         .buttonStyle(.plain)
     }
 
-    // MARK: - 접힌 일차 섹션
+    // MARK: - 시트
 
-    private func collapsedDaySection(day: String, date: String) -> some View {
-        HStack {
-            Text(day)
-                .font(.system(size: 12, weight: .bold))
-                .foregroundColor(Color(hex: "#6B7280"))
-                .frame(width: 48, height: 24)
-                .background(Color(hex: "#E5E7EB"))
-                .cornerRadius(6)
-            Text(date)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(Color(hex: "#6B7280"))
-            Spacer()
-            Text("∨")
-                .font(.system(size: 14))
+    private var sheetOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.45)
+                .ignoresSafeArea()
+                .onTapGesture { closeSheet() }
+
+            VStack(spacing: 0) {
+                Spacer()
+                sheetCard
+                    .transition(.move(edge: .bottom))
+            }
+            .ignoresSafeArea(edges: .bottom)
+        }
+    }
+
+    private var sheetCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Spacer()
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color(hex: "#E5E7EB"))
+                    .frame(width: 52, height: 5)
+                Spacer()
+            }
+            .padding(.top, 10)
+
+            Text(sheetTitle)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Color(hex: "#111827"))
+                .padding(.top, 22)
+                .padding(.bottom, 16)
+
+            if needsTitleField {
+                Text(isMemoMode ? "메모" : "제목")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Color(hex: "#6B7280"))
+
+                TextField(isMemoMode ? "메모를 입력하세요" : "예: 자유시간", text: $draftTitle)
+                    .font(.system(size: 14))
+                    .foregroundColor(Color(hex: "#111827"))
+                    .padding(.horizontal, 16)
+                    .frame(height: 48)
+                    .background(Color(hex: "#F3F4F6"))
+                    .cornerRadius(12)
+                    .padding(.top, 6)
+                    .padding(.bottom, 12)
+            }
+
+            if needsTimeFields {
+                Text("시간")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Color(hex: "#6B7280"))
+
+                HStack(spacing: 12) {
+                    timeField("시작", value: hhmm(draftStart), field: .start)
+                    timeField("종료", value: hhmm(draftEnd), field: .end)
+                }
+                .padding(.top, 6)
+
+                if let field = openPicker {
+                    DatePicker(
+                        "",
+                        selection: field == .start ? $draftStart : $draftEnd,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .frame(height: 140)
+                }
+
+                if isEndBeforeStart {
+                    Text("종료 시간이 시작 시간보다 빠릅니다")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(hex: "#EF4444"))
+                        .padding(.top, 6)
+                } else if hasOverlap {
+                    Text("기존 일정과 시간이 겹칩니다")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(hex: "#EB8C0D"))
+                        .padding(.top, 6)
+                }
+            }
+
+            Button { submit() } label: {
+                Group {
+                    if viewModel.isSaving {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("저장")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(canSubmit ? Color(hex: "#2563EB") : Color(hex: "#C3CDDA"))
+                .cornerRadius(12)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSubmit)
+            .padding(.top, 20)
+            .padding(.bottom, 34)
+        }
+        .padding(.horizontal, 24)
+        .background(Color.white)
+        .cornerRadius(24, corners: [.topLeft, .topRight])
+    }
+
+    private func timeField(_ prefix: String, value: String, field: TimeField) -> some View {
+        Button { openPicker = (openPicker == field) ? nil : field } label: {
+            HStack(spacing: 8) {
+                Text(prefix)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color(hex: "#6B7280"))
+                Text(value)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(Color(hex: "#111827"))
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(Color(hex: "#F3F4F6"))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(openPicker == field ? Color(hex: "#2563EB") : .clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - 시트 상태
+
+    private var sheetTitle: String {
+        switch sheetMode {
+        case .add:  return "일정 추가"
+        case .time: return "시간 변경"
+        case .memo: return "메모 수정"
+        }
+    }
+
+    private var isMemoMode: Bool { if case .memo = sheetMode { return true }; return false }
+    private var needsTitleField: Bool { if case .time = sheetMode { return false }; return true }
+    private var needsTimeFields: Bool { if case .memo = sheetMode { return false }; return true }
+
+    private var isEndBeforeStart: Bool { hhmm(draftEnd) <= hhmm(draftStart) }
+
+    private var hasOverlap: Bool {
+        guard needsTimeFields, !isEndBeforeStart else { return false }
+        switch sheetMode {
+        case .add(let day):
+            return viewModel.overlaps(dayNumber: day, start: hhmm(draftStart), end: hhmm(draftEnd))
+        case .time(let item):
+            return viewModel.overlaps(
+                dayNumber: item.dayNumber,
+                start: hhmm(draftStart), end: hhmm(draftEnd),
+                excluding: item.id
+            )
+        case .memo:
+            return false
+        }
+    }
+
+    private var canSubmit: Bool {
+        if viewModel.isSaving { return false }
+        switch sheetMode {
+        case .add:
+            return !draftTitle.trimmingCharacters(in: .whitespaces).isEmpty && !isEndBeforeStart
+        case .time:
+            return !isEndBeforeStart
+        case .memo:
+            return true
+        }
+    }
+
+    // MARK: - 시트 동작
+
+    private func openAddSheet(day: Int) {
+        sheetMode = .add(day: day)
+        draftTitle = ""
+        draftStart = Self.time(hour: 9)
+        draftEnd = Self.time(hour: 10)
+        openPicker = nil
+        showSheet = true
+    }
+
+    private func openTimeSheet(_ item: StaffScheduleDTO) {
+        sheetMode = .time(item)
+        draftStart = Self.time(from: item.startTime)
+        draftEnd = Self.time(from: item.endTime)
+        openPicker = nil
+        showSheet = true
+    }
+
+    private func openMemoSheet(_ item: StaffScheduleDTO) {
+        sheetMode = .memo(item)
+        draftTitle = item.mainContent ?? ""
+        openPicker = nil
+        showSheet = true
+    }
+
+    private func submit() {
+        guard canSubmit else { return }
+        switch sheetMode {
+        case .add(let day):
+            viewModel.addSchedule(
+                dayNumber: day,
+                title: draftTitle.trimmingCharacters(in: .whitespaces),
+                start: hhmm(draftStart), end: hhmm(draftEnd)
+            ) { closeSheet() }
+
+        case .time(let item):
+            viewModel.updateTime(item, start: hhmm(draftStart), end: hhmm(draftEnd)) { closeSheet() }
+
+        case .memo(let item):
+            viewModel.updateMemo(item, content: draftTitle) { closeSheet() }
+        }
+    }
+
+    private func closeSheet() {
+        showSheet = false
+        openPicker = nil
+        draftTitle = ""
+    }
+
+    // MARK: - 시각 헬퍼
+
+    private func hhmm(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
+    }
+
+    private static func time(hour: Int) -> Date {
+        Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: Date()) ?? Date()
+    }
+
+    private static func time(from text: String) -> Date {
+        let parts = text.split(separator: ":")
+        let h = parts.count >= 2 ? Int(parts[0]) ?? 9 : 9
+        let m = parts.count >= 2 ? Int(parts[1]) ?? 0 : 0
+        return Calendar.current.date(bySettingHour: h, minute: m, second: 0, of: Date()) ?? Date()
+    }
+
+    // MARK: - 상태 화면
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("일정을 불러오는 중이에요")
+                .font(.system(size: 13))
                 .foregroundColor(Color(hex: "#6B7280"))
         }
-        .padding(.horizontal, 14)
-        .frame(height: 52)
-        .background(Color(hex: "#F3F4F6"))
-        .cornerRadius(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-}
 
-private struct ScheduleItem {
-    let title: String
-    let time: String
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 14) {
+            Text(message)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Color(hex: "#111827"))
+            Button { viewModel.load() } label: {
+                Text("재시도")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+                    .frame(height: 44)
+                    .background(Color(hex: "#2563EB"))
+                    .cornerRadius(10)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var toastView: some View {
+        if let toast = viewModel.toast {
+            Text(toast)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .frame(height: 44)
+                .background(Color(hex: "#111827").opacity(0.92))
+                .clipShape(Capsule())
+                .padding(.bottom, 40)
+                .task(id: toast) {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    viewModel.toast = nil
+                }
+        }
+    }
 }

--- a/HiTrip/Features/Schedule/Views/TouristLocationView.swift
+++ b/HiTrip/Features/Schedule/Views/TouristLocationView.swift
@@ -1,177 +1,267 @@
 import SwiftUI
 import MapKit
+import UIKit
+
+// MARK: - TouristLocationView
+/// 관광객 위치 확인 — Figma 12381:4267
+///
+/// 관광객 핀(보라)과 안내사 핀(파랑), 허용 범위 경계를 함께 보여줍니다.
+/// 관광객 좌표는 10초마다 갱신하고, GPS가 끊기면 마지막 위치를 반투명으로 표시합니다.
 
 struct TouristLocationView: View {
 
+    /// 어느 관광객인지 — 안전 관리·알림 센터에서 넘겨줍니다
+    let participantId: Int
+    /// 좌표를 받기 전에 헤더에 보여줄 이름
+    var touristName: String = ""
+
     @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: TouristLocationViewModel
 
-    var touristName: String = "둘리"
-    var address: String = "부산 해운대구 중동 1015 인근"
+    @State private var camera: MapCameraPosition = .automatic
 
-    private let guideCoordinate = CLLocationCoordinate2D(latitude: 35.158, longitude: 129.159)
-    private let touristCoordinate = CLLocationCoordinate2D(latitude: 35.1620, longitude: 129.164)
-
-    @State private var region = MKCoordinateRegion(
-        center: CLLocationCoordinate2D(latitude: 35.1600, longitude: 129.1615),
-        span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
-    )
+    init(participantId: Int, touristName: String = "") {
+        self.participantId = participantId
+        self.touristName = touristName
+        _viewModel = StateObject(wrappedValue: TouristLocationViewModel(participantId: participantId))
+    }
 
     var body: some View {
         ZStack(alignment: .top) {
-            mapView
-                .ignoresSafeArea()
+            mapLayer
+                .ignoresSafeArea(edges: .bottom)
 
             VStack(spacing: 0) {
                 headerSection
                 Spacer()
-                bottomPanel
+            }
+
+            VStack(spacing: 0) {
+                Spacer()
+                legend
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 38)
+
+                mapButtons
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 19)
+
+                callButton
+                    .padding(.horizontal, 21)
+                    .padding(.bottom, 24)
+            }
+
+            if viewModel.returnedNotice {
+                returnedToast
             }
         }
+        .background(Color(hex: "#E0EAE0"))
         .navigationBarHidden(true)
+        .task { viewModel.load() }
+        .onAppear { viewModel.startPolling() }
+        .onDisappear { viewModel.stopPolling() }
+        .onChange(of: viewModel.touristCoordinate?.latitude) { _, _ in
+            if case .automatic = camera { focusAll() }
+        }
     }
 
-    // MARK: - 헤더 (타이틀 + 주소/갱신)
+    // MARK: - 지도
+
+    private var mapLayer: some View {
+        Map(position: $camera) {
+            // 허용 범위 경계 — 빨간 실선
+            if let center = viewModel.geofenceCenter, let radius = viewModel.geofenceRadiusM {
+                MapCircle(center: center, radius: radius)
+                    .foregroundStyle(Color.red.opacity(0.05))
+                    .stroke(Color.red, lineWidth: 2)
+            }
+
+            if let coordinate = viewModel.touristCoordinate {
+                Annotation(viewModel.touristName.isEmpty ? touristName : viewModel.touristName,
+                           coordinate: coordinate) {
+                    pin(color: Color(hex: "#734CD9"))
+                        // GPS가 끊기면 반투명으로 — 옛 위치라는 표시
+                        .opacity(viewModel.isStale ? 0.45 : 1)
+                }
+            }
+
+            if let guide = viewModel.guideLocation {
+                Annotation("나 (안내사)", coordinate: guide) {
+                    pin(color: Color(hex: "#0C46C0"))
+                }
+            }
+        }
+    }
+
+    private func pin(color: Color) -> some View {
+        ZStack {
+            Circle()
+                .fill(color)
+                .frame(width: 26, height: 26)
+            Image(systemName: "mappin")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(.white)
+        }
+    }
+
+    // MARK: - 헤더
 
     private var headerSection: some View {
         VStack(spacing: 0) {
             ZStack {
-                Text("\(touristName) 님의 현재 위치")
+                Text("\(viewModel.touristName.isEmpty ? touristName : viewModel.touristName) 님의 현재 위치")
                     .font(.system(size: 17, weight: .bold))
                     .foregroundColor(Color(hex: "#111827"))
+
                 HStack {
                     Button { dismiss() } label: {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 18, weight: .medium))
                             .foregroundColor(.black)
+                            .frame(width: 24, height: 24)
                     }
                     Spacer()
                 }
-                .padding(.horizontal, 12)
+                .padding(.leading, 12)
             }
-            .frame(height: 44)
+            .frame(height: 24)
+            .padding(.top, 8)
 
-            HStack {
-                Text("주소: \(address)")
+            HStack(alignment: .firstTextBaseline) {
+                Text("주소: \(viewModel.address.isEmpty ? "확인 중" : viewModel.address)")
                     .font(.system(size: 13))
                     .foregroundColor(Color(hex: "#333840"))
-                Spacer()
-                Text("10초 전 갱신")
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Text(viewModel.updatedText)
                     .font(.system(size: 11))
                     .foregroundColor(Color(hex: "#6B7280"))
             }
             .padding(.horizontal, 24)
-            .frame(height: 40)
+            .padding(.top, 17)
+            .padding(.bottom, 12)
         }
         .background(Color.white)
     }
 
-    // MARK: - 지도
+    // MARK: - 범례
 
-    private var mapView: some View {
-        Map(coordinateRegion: $region, annotationItems: pins) { pin in
-            MapAnnotation(coordinate: pin.coordinate) {
-                VStack(spacing: 2) {
-                    Image(systemName: "mappin")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(pin.color)
-                    Text(pin.label)
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundColor(pin.color)
-                }
-            }
+    private var legend: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(Color.red)
+                .frame(width: 14, height: 3)
+                .cornerRadius(1)
+            Text("허용 범위 경계")
+                .font(.system(size: 12))
+                .foregroundColor(Color(hex: "#333840"))
         }
-        .overlay(boundaryOverlay)
+        .padding(.horizontal, 12)
+        .frame(height: 30)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 15))
     }
 
-    /// 허용 범위 경계 — 디자인의 -15° 회전 사각형
-    private var boundaryOverlay: some View {
-        Rectangle()
-            .fill(Color.red.opacity(0.05))
-            .overlay(Rectangle().stroke(Color.red, lineWidth: 2))
-            .frame(width: 340, height: 340)
-            .rotationEffect(.degrees(-15))
-            .allowsHitTesting(false)
-    }
+    // MARK: - 지도 이동 버튼
 
-    private var pins: [MapPinItem] {[
-        MapPinItem(coordinate: guideCoordinate, label: "나 (안내사)", color: Color(hex: "#0C46C0")),
-        MapPinItem(coordinate: touristCoordinate, label: touristName, color: Color(hex: "#734CD9")),
-    ]}
-
-    // MARK: - 하단 패널
-
-    private var bottomPanel: some View {
-        VStack(spacing: 0) {
-            // 범례 칩
-            HStack {
-                HStack(spacing: 8) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.red)
-                        .frame(width: 14, height: 3)
-                    Text("허용 범위 경계")
-                        .font(.system(size: 12))
-                        .foregroundColor(Color(hex: "#333840"))
-                }
-                .padding(.horizontal, 12)
-                .frame(height: 30)
-                .background(Color.white)
-                .cornerRadius(15)
-                Spacer()
+    private var mapButtons: some View {
+        HStack(spacing: 12) {
+            mapButton("내 위치", isPrimary: false) {
+                if let guide = viewModel.guideLocation { focus(on: guide) }
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 38)
-
-            // 뷰 전환 버튼 3개
-            HStack(spacing: 12) {
-                viewButton(title: "내 위치", isSelected: false) {
-                    region.center = guideCoordinate
-                }
-                viewButton(title: "관광객 위치", isSelected: false) {
-                    region.center = touristCoordinate
-                }
-                viewButton(title: "전체 보기", isSelected: true) {
-                    region = MKCoordinateRegion(
-                        center: CLLocationCoordinate2D(latitude: 35.1600, longitude: 129.1615),
-                        span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
-                    )
-                }
+            mapButton("관광객 위치", isPrimary: false) {
+                if let coordinate = viewModel.touristCoordinate { focus(on: coordinate) }
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 19)
-
-            // 전화걸기
-            Button { } label: {
-                Text("전화걸기")
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(Color(hex: "#EF4444"))
-                    .cornerRadius(9)
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 21)
-            .padding(.bottom, 32)
+            mapButton("전체 보기", isPrimary: true) { focusAll() }
         }
     }
 
-    private func viewButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+    private func mapButton(_ title: String, isPrimary: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 13, weight: isSelected ? .bold : .medium))
-                .foregroundColor(isSelected ? Color(hex: "#2563EB") : Color(hex: "#333840"))
+                .font(.system(size: 13, weight: isPrimary ? .bold : .medium))
+                .foregroundColor(isPrimary ? Color(hex: "#2563EB") : Color(hex: "#333840"))
                 .frame(maxWidth: .infinity)
                 .frame(height: 44)
-                .background(isSelected ? Color(hex: "#E8F0FF") : Color(hex: "#F3F4F6"))
-                .cornerRadius(10)
+                .background(isPrimary ? Color(hex: "#E8F0FF") : Color(hex: "#F3F4F6"))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
         }
         .buttonStyle(.plain)
     }
-}
 
-private struct MapPinItem: Identifiable {
-    let id = UUID()
-    let coordinate: CLLocationCoordinate2D
-    let label: String
-    let color: Color
+    private func focus(on coordinate: CLLocationCoordinate2D) {
+        withAnimation {
+            camera = .region(MKCoordinateRegion(
+                center: coordinate,
+                span: MKCoordinateSpan(latitudeDelta: 0.008, longitudeDelta: 0.008)
+            ))
+        }
+    }
+
+    /// 두 핀과 경계가 모두 보이도록 줌을 맞춥니다
+    private func focusAll() {
+        var points: [CLLocationCoordinate2D] = []
+        if let tourist = viewModel.touristCoordinate { points.append(tourist) }
+        if let guide = viewModel.guideLocation { points.append(guide) }
+        if let center = viewModel.geofenceCenter { points.append(center) }
+        guard !points.isEmpty else { return }
+
+        let lats = points.map(\.latitude), lngs = points.map(\.longitude)
+        let center = CLLocationCoordinate2D(
+            latitude: (lats.min()! + lats.max()!) / 2,
+            longitude: (lngs.min()! + lngs.max()!) / 2
+        )
+        // 경계 원까지 담기도록 반경만큼 여유를 둡니다
+        let radiusDegrees = (viewModel.geofenceRadiusM ?? 0) / 111_000 * 2.4
+        let span = MKCoordinateSpan(
+            latitudeDelta: max(lats.max()! - lats.min()!, radiusDegrees, 0.006) * 1.4,
+            longitudeDelta: max(lngs.max()! - lngs.min()!, radiusDegrees, 0.006) * 1.4
+        )
+
+        withAnimation { camera = .region(MKCoordinateRegion(center: center, span: span)) }
+    }
+
+    // MARK: - 전화걸기
+
+    private var callButton: some View {
+        Button { call() } label: {
+            Text("전화걸기")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .background(viewModel.phoneNumber == nil
+                            ? Color(hex: "#C3CDDA") : Color(hex: "#EF4444"))
+                .clipShape(RoundedRectangle(cornerRadius: 9))
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.phoneNumber == nil)
+    }
+
+    private func call() {
+        guard let phone = viewModel.phoneNumber else { return }
+        let digits = phone.filter { $0.isNumber || $0 == "+" }
+        guard let url = URL(string: "tel://\(digits)"), UIApplication.shared.canOpenURL(url) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    // MARK: - 복귀 토스트
+
+    private var returnedToast: some View {
+        Text("범위 내로 복귀했어요")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(.white)
+            .padding(.horizontal, 18)
+            .frame(height: 44)
+            .background(Color(hex: "#111827").opacity(0.92))
+            .clipShape(Capsule())
+            .padding(.top, 120)
+            .task(id: viewModel.returnedNotice) {
+                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                viewModel.returnedNotice = false
+            }
+    }
 }


### PR DESCRIPTION
## 개요

안내사(가이드) 화면 **8개 전부**를 기획서 동작 명세에 맞추고 스태프 API에 연결했습니다. 8개 커밋, 19개 파일.

기존 안내사 화면들은 목 배열을 나열하는 수준이었고, 일부는 API가 이미 있는데도 화면에 연결되지 않은 상태였습니다. 화면 하나씩 진행했습니다: 기획서 대조 → Figma 좌표·색상 추출 → API 확인 → 구현 → 시뮬레이터 검증 → 커밋.

---

## 화면별 변경

### 홈 (Figma 12381:5370)
- `staff/trips` · `schedules` · `monitoring/summary` · `monitoring/alerts` 연결
- 진행 인디케이터는 관광객 홈과 **같은 로직**(당일 첫 일정~마지막 일정 대비 현재 시각)
- 안전 현황 **30초 폴링** + 당겨서 새로고침, 화면을 벗어나면 폴링 정지
- 고객 관리에 미확인 채팅 합계 뱃지, 안전 관리에 경고·위험 시 빨간 점
- 여행 미배정 시 「배정된 여행이 없습니다 / SaaS에서 확인해주세요」

### 안전 관리 + 관광객 정보 팝업 (12381:4446 / 4366)
- `monitoring/latest`로 심박·SpO₂·위치·사고를 받고, `trips/{id}/participants`를 **추가 호출해 연락처·국가·여권번호를 이어 붙임** (모니터링 응답에 없어서)
- 상태 칩 4종 — 탭 시 필터, 재탭 해제 / 30초 갱신 + 「HH:mm 기준」 표기
- 이탈 셀은 사고 메시지의 거리를 뱃지로, 탭하면 위치 확인으로 이동
- **SpO₂는 기획서 기준 그대로**(정상 ≥95 / 경고 90~94 / 위험 <90)
- 미수신은 「—」로 통일(기존 x·- 혼용 정리), 정렬 위험 → 경고 → 정상 → 가나다
- 팝업: **여권번호 중간 3자리 마스킹 + 👁 3초 공개 후 자동 재마스킹**
- 위치보기는 **이탈이거나 건강 경고·위험일 때만** 활성 (정상 관광객은 프라이버시 보호)

### 알림 센터 — 신규 (12381:4544)
- 경고·위험·이탈 알림의 단일 수신 창구. 기존 화면은 목을 나열만 하고 확인 처리 경로가 없었습니다
- 필터 칩 5종, 위험 알림에만 **[확인]** → `incidents/{id}/acknowledge/`로 인지 처리 기록
- 「[확인] 전까지 5분 주기 재알림」 표기, 이탈 알림 탭 → 위치 확인 딥링크
- 읽은 카드 배경 회색, 0건 「알림이 없어요」

### 관광객 위치 확인 (12381:4267)
- 관광객 좌표 **10초 폴링**, 주소 역지오코딩(30m 이상 이동 시에만 재조회)
- GPS 유실 시 「마지막 수신 위치 · n분 전」 + 핀 반투명
- 관광객 핀 `#734CD9` / 안내사 핀 `#0C46C0`, 허용 범위 원 + **범례 신설**
- 지도 버튼 3종 — 내 위치 / 관광객 위치 / **전체 보기**(두 핀 + 경계 자동 줌)
- 범위 복귀 시 「범위 내로 복귀했어요」 토스트, 전화걸기 CTA

### 공지 설정 + 작성 팝업 (12381:5263 / 5429)
- **수정(PATCH) 신설** — API는 있었지만 화면 연결이 없었습니다
- 활성 공지 항상 1건, **재탭 시 해제** → 관광객 홈 「등록된 공지가 없어요」
- 작성 팝업: **500자 카운터**, 공백·개행만이면 작성완료 비활성, 취소 시 확인
- 저장 후 **「지금 활성화할까요?」** — 예를 누르면 기존 활성 공지 자동 해제
- 저장 실패 시 입력 유지 + [재시도]

### 전체일정 확인·수정 (12381:5209)
- 목록/추가/수정/삭제 전부 연결 (모두 화면 연결이 없던 API)
- 헤더 「전체 일정」 — 기존 「원정대 신청」 오표기·모집인원 표기 정정
- ⋮ 메뉴 = 시간 변경 / 메모 수정 / 삭제, 삭제 시 확인 팝업
- + 일정 추가(휠 피커), 기존 일정과 겹치면 주황 경고, 종료<시작이면 저장 차단
- 수정 즉시 서버 저장, 실패 시 [재시도]

### 고객관리(메시지) (12381:4655)
- 채팅 API가 **세션 쿠키와 여행객 토큰을 모두 받아**(`cookieAuth` + `TravelerTokenAuth`) 여행객과 같은 엔드포인트를 쓰고, **채팅방 화면도 그대로 재사용**
- 탭 재정의: 전체(단체 고정 + 최신순) / 미확인 / 단체 — 기존 「최근·이전·확인됨」의 모호한 기준 대체
- **「모두 확인」에 확인 팝업** 추가 (기존 즉시 실행)
- 시각 표기: 오늘 HH:mm / 어제 / 이번 주 「일 12:40」 / 그 이전 M.D

### 지도 범위 설정 (12380:1051)
- 일차별 조회/생성/**전일 복사**/수정(`expected_revision` 낙관적 잠금) 연결
- **일차 탭 복원** — 신규 프레임에서 누락됐던 부분
- 미설정 일차는 전일 설정을 기본값으로 제안
- 지도 롱프레스로 중심 지정, 반경 1~10km 정수 슬라이더, 원 실시간 반영
- **중심 좌표는 저장 시점 고정** (안내사 이동을 따라가지 않음 — 상충 정책 확정)
- 저장 성공 토스트 / 실패 [재시도] / 다른 기기 선수정 시 충돌 안내
- 미저장 변경 시 뒤로가기 확인

---

## 부수 작업

**`MockStaffRepository` 신설** — 안내사 저장소에 목이 없어 `.mock` 환경에서는 화면 확인 자체가 불가능했습니다. 위험/경고/이탈/미연동이 모두 보이도록 데이터를 구성했습니다.

**`StaffRepository` 확장** — 참가자 명부, 일정 CRUD, 공지 수정, 지오펜스 생성·복사를 추가했습니다.

---

## 확인 방법

`APIEnvironment.current`를 `.mock` / `.remote`로 전환합니다. `.remote`에서 안내사 화면은 **세션 쿠키 인증**이라 `demo_manager1` 계정으로 로그인해야 합니다.

시뮬레이터(iPhone 17)에서 화면별로 확인했습니다: 홈 → 안전 관리(칩 필터·팝업·여권 마스킹) → 알림 센터([확인] 버튼) → 위치 확인(두 핀·전체 보기) → 공지 설정(작성 팝업·활성 토글) → 전체일정(⋮ 메뉴·시간 변경 시트) → 고객관리(탭·모두 확인 팝업) → 지도 범위(일차 전환·슬라이더·저장).

---

## 백엔드 요청 (이번에 새로 나온 것)

1. **공지 DELETE 없음** — `/api/v1/notices/{id}/`는 GET·PATCH만. 기획의 「⋮ 삭제」를 넣지 못했습니다
2. **지표별 심각도 없음** — `health_status` 하나만 와서 심박·SpO₂ 셀 색을 앱이 계산 중입니다. `heart_rate_status` / `spo2_status`를 주시면 앱 계산이 사라집니다
3. **알림에 `participant_id` 없음** — 이탈 알림 → 위치 확인 이동을 위해 이름으로 명단과 대조 중(동명이인 시 오작동)
4. **알림 읽음 상태 없음** — 앱 메모리에서만 관리, 재시작 시 초기화
5. **이탈 거리 필드 없음** — `IncidentSummary.message`에서 정규식으로 파싱 중
6. **안전 요약에 이탈 카운트 없음** — `alerts`의 location 유형 개수로 대체
7. **`today_day_number`가 스태프 API에 없음** — 시작일로 앱이 계산 중 (여행객 API에는 있습니다)
8. **일정 장소 지정 불가** — `place_name`이 readOnly, `place_id`만 받아 장소 검색 API가 필요합니다
9. **주소 검색 API 미정** — 지도 범위 설정의 「탭하여 검색」

🤖 Generated with [Claude Code](https://claude.com/claude-code)
