### PR TITLE
feat: 로딩·오류·네트워크 UX 개선 (스켈레톤·공통 상태 화면·오프라인 배너·재시도)

### DIFF
--- a/HiTrip/App/RootView.swift
+++ b/HiTrip/App/RootView.swift
@@ -3,34 +3,35 @@ import SwiftUI
 // MARK: - RootView
 /// 앱 최상위 View — AppRouter 상태에 따라 화면 분기
 ///
-/// 역할:
 /// - router.currentScreen 값을 관찰하여 해당 화면 렌더링
-/// - 화면 전환 시 0.3초 easeInOut 애니메이션 적용
-///
-/// DI 흐름:
-/// - LoginView: AppDIContainer에서 LoginViewModel 생성하여 주입
-/// - HomeView, SplashView: 별도 주입 불필요 (EnvironmentObject로 router 사용)
+/// - 스플래시를 뺀 모든 화면 상단에 오프라인 배너(OfflineBanner)
+/// - 화면 전환 시 0.3초 easeInOut 애니메이션
 
 struct RootView: View {
 
     @EnvironmentObject var router: AppRouter
+    @ObservedObject private var network = NetworkMonitor.shared
 
     var body: some View {
-        Group {
-            switch router.currentScreen {
-            case .splash:
-                SplashView()
+        VStack(spacing: 0) {
+            if router.currentScreen != .splash {
+                OfflineBanner()
+            }
 
-            case .login:
-                LoginView()
-
-            case .agreement:
-                AgreementView(userType: router.userType)
-
-            case .home:
-                HomeView()
+            Group {
+                switch router.currentScreen {
+                case .splash:
+                    SplashView()
+                case .login:
+                    LoginView()
+                case .agreement:
+                    AgreementView(userType: router.userType)
+                case .home:
+                    HomeView()
+                }
             }
         }
         .animation(.easeInOut(duration: 0.3), value: router.currentScreen)
+        .animation(.easeInOut(duration: 0.25), value: network.isConnected)
     }
 }

--- a/HiTrip/Core/DesignSystem/Components/Skeleton.swift
+++ b/HiTrip/Core/DesignSystem/Components/Skeleton.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+// MARK: - Skeleton
+/// 첫 로딩 동안 실제 레이아웃 모양의 회색 틀을 보여줍니다.
+///
+/// 현업 규칙대로 **첫 로딩에만** 씁니다. 새로고침·폴링 중에는 기존 내용을 그대로 둡니다
+/// (ViewModel은 load()에서만 .loading이 되고, refresh()는 상태를 바꾸지 않습니다).
+
+struct SkeletonBlock: View {
+    var width: CGFloat? = nil
+    var height: CGFloat
+    var radius: CGFloat = AppRadius.sm
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: radius)
+            .fill(AppColor.surface)
+            .frame(width: width, height: height)
+            .frame(maxWidth: width == nil ? .infinity : nil, alignment: .leading)
+    }
+}
+
+// MARK: - Shimmer
+
+private struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = -1
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                GeometryReader { geo in
+                    LinearGradient(
+                        colors: [.clear, Color.white.opacity(0.6), .clear],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: geo.size.width * 0.6)
+                    .offset(x: phase * geo.size.width * 1.6)
+                }
+                .mask(content)
+            )
+            .onAppear {
+                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) { phase = 1 }
+            }
+            .accessibilityLabel("불러오는 중")
+    }
+}
+
+extension View {
+    /// 스켈레톤 위로 빛이 지나가는 효과
+    func shimmering() -> some View { modifier(ShimmerModifier()) }
+}
+
+// MARK: - SkeletonList
+/// 목록·카드 화면용 기본 스켈레톤
+
+struct SkeletonList: View {
+    var rows: Int = 5
+    var rowHeight: CGFloat = 60
+    var spacing: CGFloat = AppSpacing.sm
+    var topInset: CGFloat = AppSpacing.lg
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(0..<rows, id: \.self) { _ in
+                SkeletonBlock(height: rowHeight, radius: AppRadius.lg)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, AppSpacing.xl)
+        .padding(.top, topInset)
+        .shimmering()
+    }
+}

--- a/HiTrip/Core/DesignSystem/Components/StateViews.swift
+++ b/HiTrip/Core/DesignSystem/Components/StateViews.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+// MARK: - ErrorStateView
+/// 불러오기 실패 화면 — 원인 문구 + [다시 시도]
+///
+/// 인터넷이 다시 연결되면 자동으로 retry를 한 번 부릅니다(사용자가 누르지 않아도 됨).
+
+struct ErrorStateView: View {
+    let message: String
+    var retryTitle: String = "다시 시도"
+    let retry: () -> Void
+
+    /// 연결 문제로 보이는 문구면 와이파이 아이콘, 아니면 경고 아이콘
+    private var iconName: String {
+        message.contains("연결") || message.contains("네트워크") ? "wifi.slash" : "exclamationmark.triangle"
+    }
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: iconName)
+                .font(AppFont.icon(34))
+                .foregroundColor(AppColor.borderStrong)
+            Text(message)
+                .font(AppFont.bodyMMedium)
+                .foregroundColor(AppColor.textPrimary)
+                .multilineTextAlignment(.center)
+            Button(action: retry) {
+                Text(retryTitle)
+                    .font(AppFont.bodyBold)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, AppSpacing.xl)
+                    .frame(height: 44)
+                    .background(AppColor.accent)
+                    .cornerRadius(AppRadius.md)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onReceive(NotificationCenter.default.publisher(for: .hiTripNetworkReconnected)) { _ in retry() }
+    }
+}
+
+// MARK: - EmptyStateView
+/// 데이터가 없을 때 — 아이콘 + 제목 + (선택) 설명
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    var message: String? = nil
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(AppFont.logo)
+                .foregroundColor(AppColor.borderStrong)
+            Text(title)
+                .font(AppFont.bodyMMedium)
+                .foregroundColor(AppColor.textPrimary)
+            if let message {
+                Text(message)
+                    .font(AppFont.label)
+                    .foregroundColor(AppColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+            }
+        }
+        .padding(.horizontal, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/HiTrip/Core/Network/Service/NetworkService.swift
+++ b/HiTrip/Core/Network/Service/NetworkService.swift
@@ -35,7 +35,7 @@ final class NetworkService {
     /// - private으로 외부에서 직접 생성 방지
     private init() {
         self.baseURL = APIEnvironment.current.baseURL
-        self.session = .shared
+        self.session = URLSession(configuration: Self.defaultConfiguration)
     }
 
     /// 테스트용 초기화 — Mock URLSession 주입 가능
@@ -45,6 +45,39 @@ final class NetworkService {
     init(baseURL: String, session: URLSession = .shared) {
         self.baseURL = baseURL
         self.session = session
+    }
+
+    // MARK: - 연결 정책
+
+    /// 응답 대기 15초 — 기본 60초면 서버가 멈췄을 때 사용자가 1분 동안 로딩만 보게 됩니다
+    private static let defaultConfiguration: URLSessionConfiguration = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 60
+        config.waitsForConnectivity = false
+        return config
+    }()
+
+    /// 조회(GET)만 자동 재시도 — 저장·전송은 성공 여부가 불분명할 때 반복하면 안 됩니다
+    private static let maxRetryCount = 2
+
+    /// 금방 실패하는 연결 오류만 재시도합니다. 응답 대기 초과(timeout)는 이미 15초를 기다렸으므로 재시도하지 않습니다.
+    private static func isTransient(_ error: Error) -> Bool {
+        switch error as? HiTripError {
+        case .noConnection?, .networkFailure?: return true
+        default: return false
+        }
+    }
+
+    private func retryingIfSafe<T>(_ single: Single<T>, method: APIEndpoint.HTTPMethod) -> Single<T> {
+        guard method == .get else { return single }
+        return single.retry(when: { errors in
+            errors.enumerated().flatMap { attempt, error -> Observable<Int> in
+                guard attempt < Self.maxRetryCount, Self.isTransient(error) else { return .error(error) }
+                // 1초 → 2초 간격
+                return Observable<Int>.timer(.seconds(attempt + 1), scheduler: MainScheduler.instance)
+            }
+        })
     }
 
     // MARK: - RxSwift 요청 (메인 API)
@@ -66,7 +99,7 @@ final class NetworkService {
         _ endpoint: APIEndpoint,
         type: T.Type
     ) -> Single<T> {
-        return Single.create { [weak self] single in
+        let base = Single<T>.create { [weak self] single in
             guard let self,
                   let request = self.buildRequest(endpoint) else {
                 print("❌ [Network] URL 생성 실패 | path: \(endpoint.path)")
@@ -161,6 +194,7 @@ final class NetworkService {
             // Disposable: 구독 해제 시 네트워크 요청 취소
             return Disposables.create { task.cancel() }
         }
+        return retryingIfSafe(base, method: endpoint.method)
     }
 
     // MARK: - async/await 요청 (Swift Concurrency)

--- a/HiTrip/Core/System/NetworkMonitor.swift
+++ b/HiTrip/Core/System/NetworkMonitor.swift
@@ -2,7 +2,10 @@ import Foundation
 import Network
 
 // MARK: - NetworkMonitor
-/// 연결 상태 감시 — 오프라인 전송 대기 큐를 다시 굴리는 신호로 씁니다.
+/// 연결 상태 감시
+///
+/// - isConnected: 오프라인 배너 표시
+/// - 재연결 시 .hiTripNetworkReconnected 알림 — 실패 화면 자동 재시도, 채팅 전송 대기 큐 재전송
 
 final class NetworkMonitor: ObservableObject {
 
@@ -23,9 +26,17 @@ final class NetworkMonitor: ObservableObject {
             DispatchQueue.main.async {
                 let wasOffline = !self.isConnected
                 self.isConnected = connected
-                if connected && wasOffline { self.onReconnect?() }
+                if connected && wasOffline {
+                    self.onReconnect?()
+                    NotificationCenter.default.post(name: .hiTripNetworkReconnected, object: nil)
+                }
             }
         }
         monitor.start(queue: queue)
     }
+}
+
+extension Notification.Name {
+    /// 인터넷이 끊겼다가 다시 연결됨
+    static let hiTripNetworkReconnected = Notification.Name("hiTripNetworkReconnected")
 }

--- a/HiTrip/Features/Common/OfflineBanner.swift
+++ b/HiTrip/Features/Common/OfflineBanner.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+// MARK: - OfflineBanner
+/// 앱을 쓰는 중 인터넷이 끊기면 상단에 띄우는 배너.
+/// 다시 연결되면 사라지고, 실패 화면(ErrorStateView)은 자동으로 다시 불러옵니다.
+
+struct OfflineBanner: View {
+
+    @ObservedObject private var network = NetworkMonitor.shared
+
+    var body: some View {
+        if !network.isConnected {
+            HStack(spacing: AppSpacing.xs) {
+                Image(systemName: "wifi.slash")
+                    .font(AppFont.icon(13, weight: .semibold))
+                Text("인터넷 연결이 끊겼어요")
+                    .font(AppFont.labelMedium)
+                Text("연결되면 자동으로 새로고침해요")
+                    .font(AppFont.caption)
+                    .opacity(0.8)
+                Spacer(minLength: 0)
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, AppSpacing.lg)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            .background(AppColor.textDark)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+        }
+    }
+}

--- a/HiTrip/Features/Guide/AlertCenter/NotificationCenterView.swift
+++ b/HiTrip/Features/Guide/AlertCenter/NotificationCenterView.swift
@@ -180,38 +180,14 @@ struct NotificationCenterView: View {
     // MARK: - 상태 화면
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("알림을 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 4, rowHeight: 76)
     }
 
     private var emptyView: some View {
-        Text("알림이 없어요")
-            .font(AppFont.body)
-            .foregroundColor(AppColor.textSecondary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        EmptyStateView(icon: "bell.slash", title: "알림이 없어요")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Button { viewModel.load() } label: {
-                Text("재시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 }

--- a/HiTrip/Features/Guide/Home/GuideHomeSkeleton.swift
+++ b/HiTrip/Features/Guide/Home/GuideHomeSkeleton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+// MARK: - GuideHomeSkeleton
+/// 안내사 홈 첫 로딩 — 제목 · 오늘의 일정 · 메뉴 4칸 · 안전 현황 순서
+
+struct GuideHomeSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SkeletonBlock(width: 180, height: 22)
+                .padding(.top, AppSpacing.md)
+            SkeletonBlock(width: 90, height: 14)
+                .padding(.top, AppSpacing.xs)
+
+            SkeletonBlock(width: 90, height: 18)
+                .padding(.top, AppSpacing.xl)
+            SkeletonBlock(height: 4, radius: 2)
+                .padding(.top, AppSpacing.md)
+            SkeletonBlock(height: 56, radius: AppRadius.lg)
+                .padding(.top, AppSpacing.md)
+            SkeletonBlock(height: 48, radius: AppRadius.lg)
+                .padding(.top, AppSpacing.xs)
+
+            LazyVGrid(columns: [GridItem(.flexible(), spacing: AppSpacing.sm), GridItem(.flexible())], spacing: AppSpacing.md) {
+                ForEach(0..<4, id: \.self) { _ in SkeletonBlock(height: 106, radius: AppRadius.xl) }
+            }
+            .padding(.top, AppSpacing.xl)
+
+            SkeletonBlock(height: 90, radius: AppRadius.xl)
+                .padding(.top, AppSpacing.xl)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, AppSpacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .shimmering()
+    }
+}

--- a/HiTrip/Features/Guide/Home/StaffDashboardView.swift
+++ b/HiTrip/Features/Guide/Home/StaffDashboardView.swift
@@ -287,13 +287,7 @@ struct StaffDashboardView: View {
     // MARK: - 상태 화면
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("여행 정보를 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        GuideHomeSkeleton()
     }
 
     /// 배정된 여행이 없을 때
@@ -311,24 +305,6 @@ struct StaffDashboardView: View {
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text("🧭").font(AppFont.emojiXL)
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-                .multilineTextAlignment(.center)
-            Button { viewModel.load() } label: {
-                Text("다시 시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 40)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 }

--- a/HiTrip/Features/Guide/NoticeSetting/NoticeSettingView.swift
+++ b/HiTrip/Features/Guide/NoticeSetting/NoticeSettingView.swift
@@ -328,39 +328,15 @@ struct NoticeSettingView: View {
     // MARK: - 상태 화면
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("공지를 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 3, rowHeight: 104)
     }
 
     private var emptyView: some View {
-        Text("작성된 공지가 없어요")
-            .font(AppFont.body)
-            .foregroundColor(AppColor.textSecondary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        EmptyStateView(icon: "megaphone", title: "작성된 공지가 없어요")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Button { viewModel.load() } label: {
-                Text("재시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 
 }

--- a/HiTrip/Features/Guide/Safety/SafetyManagementView.swift
+++ b/HiTrip/Features/Guide/Safety/SafetyManagementView.swift
@@ -271,39 +271,15 @@ struct SafetyManagementView: View {
     // MARK: - 상태 화면
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("안전 정보를 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 6, rowHeight: 44, spacing: AppSpacing.xs)
     }
 
     private var emptyView: some View {
-        Text("등록된 관광객이 없습니다")
-            .font(AppFont.body)
-            .foregroundColor(AppColor.textSecondary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        EmptyStateView(icon: "person.2", title: "등록된 관광객이 없습니다")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Button { viewModel.load() } label: {
-                Text("재시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 }
 

--- a/HiTrip/Features/Guide/Schedule/StaffTripDetailView.swift
+++ b/HiTrip/Features/Guide/Schedule/StaffTripDetailView.swift
@@ -494,32 +494,11 @@ struct StaffTripDetailView: View {
     // MARK: - 상태 화면
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("일정을 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 5)
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Button { viewModel.load() } label: {
-                Text("재시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 
 }

--- a/HiTrip/Features/Tourist/Home/TouristHomeSkeleton.swift
+++ b/HiTrip/Features/Tourist/Home/TouristHomeSkeleton.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+// MARK: - TouristHomeSkeleton
+/// 관광객 홈 첫 로딩 — 제목 · 진행률 카드 · 오늘의 일정 · 주변 스팟 · 공지 순서
+
+struct TouristHomeSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SkeletonBlock(width: 180, height: 22)
+                .padding(.top, AppSpacing.md)
+            SkeletonBlock(width: 110, height: 14)
+                .padding(.top, AppSpacing.xs)
+
+            SkeletonBlock(height: 120, radius: AppRadius.xl)
+                .padding(.top, AppSpacing.xl)
+
+            SkeletonBlock(width: 90, height: 18)
+                .padding(.top, AppSpacing.xl)
+            SkeletonBlock(height: 64, radius: AppRadius.lg)
+                .padding(.top, AppSpacing.sm)
+            SkeletonBlock(height: 48, radius: AppRadius.lg)
+                .padding(.top, AppSpacing.xs)
+
+            SkeletonBlock(width: 110, height: 18)
+                .padding(.top, AppSpacing.xl)
+            HStack(spacing: AppSpacing.sm) {
+                ForEach(0..<3, id: \.self) { _ in SkeletonBlock(width: 150, height: 84, radius: AppRadius.lg) }
+            }
+            .padding(.top, AppSpacing.sm)
+
+            SkeletonBlock(height: 58, radius: AppRadius.lg)
+                .padding(.top, AppSpacing.xl)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, AppSpacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .clipped()
+        .shimmering()
+    }
+}

--- a/HiTrip/Features/Tourist/Home/TripListView.swift
+++ b/HiTrip/Features/Tourist/Home/TripListView.swift
@@ -90,36 +90,11 @@ struct TripListView: View {
     // MARK: - 로딩 / 에러
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("여행 정보를 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        TouristHomeSkeleton()
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Text("🧭")
-                .font(AppFont.emojiXL)
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-                .multilineTextAlignment(.center)
-            Button { viewModel.load() } label: {
-                Text("다시 시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 40)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 
     // MARK: - Header

--- a/HiTrip/Features/Tourist/LocalLanguage/LocalLanguageView.swift
+++ b/HiTrip/Features/Tourist/LocalLanguage/LocalLanguageView.swift
@@ -121,53 +121,14 @@ struct LocalLanguageView: View {
     // MARK: - 로딩 / 빈 상태 / 에러
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("현지 표현을 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 5, rowHeight: 70)
     }
 
     private var emptyView: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "text.bubble")
-                .font(AppFont.logo)
-                .foregroundColor(AppColor.borderStrong)
-            Text("등록된 문구가 없어요")
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Text("안내사가 현지 문구를 등록하면\n여기에 표시됩니다")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-                .multilineTextAlignment(.center)
-                .lineSpacing(3)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        EmptyStateView(icon: "text.bubble", title: "등록된 문구가 없어요", message: "안내사가 현지 문구를 등록하면\n여기에 표시됩니다")
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Image(systemName: "exclamationmark.bubble")
-                .font(AppFont.emojiXL)
-                .foregroundColor(AppColor.borderStrong)
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-                .multilineTextAlignment(.center)
-            Button { viewModel.load() } label: {
-                Text("다시 시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 40)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 }

--- a/HiTrip/Features/Tourist/Notification/TouristNotificationListView.swift
+++ b/HiTrip/Features/Tourist/Notification/TouristNotificationListView.swift
@@ -42,22 +42,7 @@ struct TouristNotificationListView: View {
     // MARK: - 빈 상태
 
     private var emptyState: some View {
-        VStack(spacing: 10) {
-            Spacer()
-            Image(systemName: "bell")
-                .font(AppFont.logo)
-                .foregroundColor(AppColor.borderStrong)
-            Text("받은 알림이 없습니다")
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-            Text("일정 변경이나 안전 확인 요청이 오면\n여기에 표시됩니다")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-                .multilineTextAlignment(.center)
-                .lineSpacing(3)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
+        EmptyStateView(icon: "bell", title: "받은 알림이 없습니다", message: "일정 변경이나 안전 확인 요청이 오면\n여기에 표시됩니다")
     }
 
     // MARK: - 알림 행

--- a/HiTrip/Features/Tourist/Schedule/TripDetailView.swift
+++ b/HiTrip/Features/Tourist/Schedule/TripDetailView.swift
@@ -139,37 +139,11 @@ struct TripDetailView: View {
     // MARK: - 로딩 / 에러
 
     private var loadingView: some View {
-        VStack(spacing: AppSpacing.sm) {
-            ProgressView()
-            Text("일정을 불러오는 중이에요")
-                .font(AppFont.label)
-                .foregroundColor(AppColor.textSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        SkeletonList(rows: 5)
     }
 
     private func errorView(_ message: String) -> some View {
-        VStack(spacing: 14) {
-            Image(systemName: "calendar.badge.exclamationmark")
-                .font(AppFont.emojiXL)
-                .foregroundColor(AppColor.borderStrong)
-            Text(message)
-                .font(AppFont.bodyMMedium)
-                .foregroundColor(AppColor.textPrimary)
-                .multilineTextAlignment(.center)
-            Button { viewModel.load() } label: {
-                Text("다시 시도")
-                    .font(AppFont.bodyBold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .frame(height: 44)
-                    .background(AppColor.accent)
-                    .cornerRadius(AppRadius.md)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 40)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ErrorStateView(message: message) { viewModel.load() }
     }
 
     // MARK: - 본문


### PR DESCRIPTION
## 목적

서버가 자주 멈추는 개발 환경에서 사용자가 겪는 문제를 줄이는 것이 목적입니다.

- 첫 로딩이 **가운데 스피너 하나**라 화면 구조를 예측할 수 없고 체감 대기가 김
- 서버가 멈추면 iOS 기본값 **60초** 동안 로딩만 보임
- 실패 화면이 **8개 화면에 복사**돼 있어 문구·동작이 제각각이고, 재시도는 사용자가 직접 눌러야 함
- 앱을 쓰는 중 인터넷이 끊겨도 **알려주지 않음** (연결 감지는 채팅에서만 사용)

## 완료한 것

| 항목 | 내용 | 적용 범위 |
|---|---|---|
| 스켈레톤 로딩 | 첫 로딩에 실제 레이아웃 모양의 회색 틀 + 반짝임 | 관광객·안내사 홈(전용 레이아웃), 목록 6개 화면 |
| 공통 실패 화면 `ErrorStateView` | 원인 아이콘(연결/일반) + 문구 + [다시 시도], **재연결 시 자동 재시도** | 8개 화면 |
| 공통 빈 화면 `EmptyStateView` | 아이콘 + 제목 + 설명 | 5개 화면 |
| 오프라인 배너 `OfflineBanner` | 「인터넷 연결이 끊겼어요 · 연결되면 자동으로 새로고침해요」 | 스플래시 외 전 화면 |
| 응답 대기 단축 | 60초 → 15초 | 전체 API |
| 조회 자동 재시도 | GET만, 연결 오류 시 1초·2초 간격 최대 2회 | 전체 GET |

## 사용한 기술·패턴

| 작업 | 사용한 것 | 설명 |
|---|---|---|
| 스켈레톤 | SwiftUI `ViewModifier` + `LinearGradient` + `mask` | `.shimmering()` 수정자로 어떤 뷰에도 반짝임을 붙일 수 있게 함. 외부 라이브러리 없이 구현 |
| 첫 로딩에만 스켈레톤 | 기존 `LoadState` 상태 머신 활용 | `load()`만 `.loading`으로 바꾸고 `refresh()`·폴링은 상태를 건드리지 않는 구조라, 새로고침 중에는 기존 내용이 유지됨 (stale-while-revalidate 방식) |
| 연결 감지 | Apple `Network` 프레임워크 `NWPathMonitor` | 기존 `NetworkMonitor`를 확장 |
| 재연결 알림 | `NotificationCenter` (옵저버 패턴) | 기존엔 콜백 하나(`onReconnect`)라 채팅만 받을 수 있었음 → 알림으로 바꿔 여러 화면이 동시에 구독 |
| 자동 재시도 | RxSwift `retry(when:)` + `Observable.timer` | 지수적으로 늘어나는 간격(1초→2초)의 재시도(backoff). GET에만 적용 |
| 응답 대기 | `URLSessionConfiguration.timeoutIntervalForRequest` | `URLSession.shared` 대신 설정을 가진 전용 세션 사용 |
| 공통 화면 | 재사용 컴포넌트 (`Core/DesignSystem/Components`) | 지난 정리(#27)의 디자인 토큰(`AppColor`·`AppFont`·`AppSpacing`)만 사용 |

## 의도적으로 정한 것

- **저장·전송(POST·PATCH·DELETE)은 재시도하지 않습니다.** 성공 여부가 불분명한 쓰기를 반복하면 중복 저장이 생길 수 있습니다(멱등성). 서버 API 문서의 요구와도 같습니다.
- **응답 대기 초과(timeout)는 재시도하지 않습니다.** 이미 15초를 기다린 상태라, 재시도하면 서버가 멈췄을 때 최대 약 48초가 걸립니다. 즉시 실패하는 연결 오류(연결 없음·끊김)만 재시도합니다.
- **스켈레톤은 첫 로딩에만 씁니다.** 30초 폴링·당겨서 새로고침 때마다 틀로 바뀌면 화면이 깜빡이기 때문입니다.
- **실패 화면 아이콘을 🧭 이모지에서 SF Symbol로 통일했습니다.** 이 화면들은 Figma 디자인이 없어서, 앱 전체 톤에 맞춰 연결 문제(`wifi.slash`)와 일반 오류(`exclamationmark.triangle`)로 구분했습니다.
- **오프라인 배너는 스플래시에 띄우지 않습니다.** 스플래시에는 이미 「네트워크 연결을 확인해주세요 + 재시도」가 있어서 중복됩니다.

## 확인하지 못한 것

- **스켈레톤 실제 모습**: Mock에 임시 3초 지연을 넣고 캡처했지만, 탭과 캡처 사이 지연으로 이미 로딩이 끝난 뒤였습니다. (임시 코드는 되돌렸고 커밋하지 않았습니다.)
- **실패 화면·자동 재시도**: 서버가 멈춘 상태라 로그인 후 화면에 들어갈 수 없었습니다.
- **오프라인 배너**: 시뮬레이터에서 네트워크를 끊는 테스트를 하지 않았습니다.
- 확인한 것: 빌드 성공, Mock 모드에서 안내사 홈이 정상 표시됨.

→ 서버가 복구되면 실패 화면·재시도를, 실기기에서 와이파이를 끄면 배너·자동 재시도를 확인할 수 있습니다.

## 추가로 고려할 점

1. **마지막 데이터 캐시** — 지금은 오프라인이면 실패 화면이 뜹니다. 일정·공지의 마지막 성공 응답을 저장해 두면 오프라인에서도 볼 수 있습니다(기획 보류 항목 「오프라인 캐시 범위」와 연결).
2. **중복 요청 정리** — 여행 목록을 화면마다 따로 불러 같은 요청이 여러 번 나갑니다. 공유 저장소로 합치면 로딩이 빨라지고 재시도 부담도 줄어듭니다.
3. **이미지 캐시** — 사진 데이터가 들어오면 `AsyncImage`는 캐시가 없어 매번 다시 받습니다. 캐시와 스켈레톤 자리 표시가 필요합니다.
4. **오류 로그 수집** — 서버 500 같은 문제를 사용자 신고 전에 알 수 있도록 Crashlytics 같은 도구 도입을 검토할 만합니다(외부 서비스라 결정 필요).
5. **Mock 응답 지연 옵션** — 스켈레톤 개발·QA를 위해 Mock 저장소에 응답 지연을 켜고 끄는 설정을 두면 편합니다.
6. **접근성** — 스켈레톤은 「불러오는 중」으로 읽히게 했습니다. 오류 화면의 VoiceOver 순서도 실기기에서 점검이 필요합니다.

## 변경 파일

- 새 컴포넌트: `Core/DesignSystem/Components/StateViews.swift`, `Skeleton.swift`
- 새 화면 요소: `Features/Common/OfflineBanner.swift`, `Features/Tourist/Home/TouristHomeSkeleton.swift`, `Features/Guide/Home/GuideHomeSkeleton.swift`
- 네트워크: `NetworkService.swift`(세션 설정·재시도), `NetworkMonitor.swift`(재연결 알림)
- 적용: 홈 2개, 일정 2개, 안전 관리, 알림 센터, 공지 설정, 현지 언어, 관광객 알림, `RootView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
